### PR TITLE
ci/configure husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+npm run lint
+npm run format:check

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
                 "eslint": "^8.32.0",
                 "eslint-config-prettier": "^8.6.0",
                 "eslint-plugin-react": "^7.32.1",
+                "husky": "^8.0.3",
                 "npm-package-json-lint": "^6.4.0",
                 "prettier": "^2.8.3",
                 "typescript": "^4.9.3",
@@ -2755,6 +2756,21 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
+        },
+        "node_modules/husky": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+            "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+            "dev": true,
+            "bin": {
+                "husky": "lib/bin.js"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/typicode"
+            }
         },
         "node_modules/ignore": {
             "version": "5.2.4",
@@ -6740,6 +6756,12 @@
                     "dev": true
                 }
             }
+        },
+        "husky": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+            "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+            "dev": true
         },
         "ignore": {
             "version": "5.2.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "format:write": "npx prettier --write .",
         "lint": "npm run lint:code && npm run lint:packages",
         "lint:code": "npx eslint .",
-        "lint:packages": "npmPkgJsonLint ."
+        "lint:packages": "npmPkgJsonLint .",
+        "prepare": "husky install"
     },
     "dependencies": {
         "react": "18.2.0",
@@ -27,6 +28,7 @@
         "eslint": "^8.32.0",
         "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-react": "^7.32.1",
+        "husky": "^8.0.3",
         "npm-package-json-lint": "^6.4.0",
         "prettier": "^2.8.3",
         "typescript": "^4.9.3",


### PR DESCRIPTION
# What

Add husky config to run linters and formatters on pre-commit

# Why

To ensure that all code committed meets code quality and format standards (prevents commit history pollution)