### PR TITLE
ci/add build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,16 @@ jobs:
             - name: Run linters
               run: |
                   npm run lint
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: "18"
+            - name: Install Dependencies
+              run: |
+                  npm ci
+            - name: Build Project
+              run: |
+                  npm run build


### PR DESCRIPTION
# What

Update ci.yml to run project build process as part of pipeline

# Why

To ensure any code that is integrated with master is able to be built without errors
- Prevents broken changes from being merged and impacted other development