### PR TITLE
fix/mobile background color

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,6 @@ import { RouterProvider } from "react-router-dom";
 import "normalize.css";
 
 import router from "./routes/router";
-import "./styles/global.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <React.StrictMode>

--- a/src/routes/components/SiteLayout/styles.ts
+++ b/src/routes/components/SiteLayout/styles.ts
@@ -21,8 +21,6 @@ export const SiteHeader = styled.h1`
 `;
 
 export const SiteTheme = styled.div`
-    height: 100%;
-
     ${(props) => css`
         color: ${props.theme.color.text};
         font-family ${props.theme.typography.family};
@@ -30,7 +28,9 @@ export const SiteTheme = styled.div`
 `;
 
 export const ContentWrapper = styled.div`
-    height: 100%;
+    height: 100vh;
+    max-height: 100%;
+    overflow-y: auto;
 
     ${(props) => css`
         background: ${props.theme.color.background};

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,0 @@
-html,
-body,
-#root {
-    height: 100%;
-}


### PR DESCRIPTION
# What

Updated content wrapper styling to handle overflow on Y axis.
Removes redundant global styling for ensuring 100% vertical height is used

# Why

Previously, on mobile browsers, when a user opens a virtual keyboard, the background would not handle the overflow that occurs. This results in the user being shown a white background to the page, rather than the theme's background color.