### PR TITLE
fix/inner content scrolling

### DIFF
--- a/src/routes/components/SiteLayout/styles.ts
+++ b/src/routes/components/SiteLayout/styles.ts
@@ -38,7 +38,7 @@ export const SiteTheme = styled.div`
 export const ContentWrapper = styled.div`
     height: 100vh;
     max-height: 100%;
-    overflow-y: auto;
+    overflow-y: hidden;
 
     ${(props) => css`
         background: ${props.theme.color.background};


### PR DESCRIPTION
# What

Updated content wrapper styling to prevent inner container scrolling

# Why

To prevent scrolling the inner content of the page when the content overflows available height
- Occurs on mobile when using virtual keyboard
- Gives the user a sticky banner which is not intended