### PR TITLE
fix/content clipping mobile

### DIFF
--- a/src/routes/components/SiteLayout/styles.ts
+++ b/src/routes/components/SiteLayout/styles.ts
@@ -36,8 +36,7 @@ export const SiteTheme = styled.div`
 `;
 
 export const ContentWrapper = styled.div`
-    height: 100vh;
-    max-height: 100%;
+    min-height: 100vh;
     overflow-y: hidden;
 
     ${(props) => css`


### PR DESCRIPTION
# What

Update content wrapper styling to allow content to overflow past viewport height

# Why

Previously, on mobile, the requirements table was being cut off if there was not enough height to show the content. This was caused by the height being fixed to 100vh. By changing the styling to use minimum, it will grow to take up required space while preventing inner scrolling