### PR TITLE
ci/fix duplicate dependabot pr

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,3 @@ updates:
       schedule:
           interval: weekly
       versioning-strategy: increase
-    - directory: /ui
-      package-ecosystem: npm
-      schedule:
-          interval: weekly
-      versioning-strategy: increase


### PR DESCRIPTION
# What

Remove sub directory definitions from dependabot config

# Why

Previously, Dependabot did not work with monorepos w/o having to specify each directory that includes a package.json manually. It seems that this is no longer the case
- Removing this prevents duplicate PRs