### PR TITLE
ci: update usages of aws cred configure action to v2

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: "18.12.1"
-            - uses: aws-actions/configure-aws-credentials@v1-node16
+            - uses: aws-actions/configure-aws-credentials@v2
               with:
                   aws-region: eu-west-2
                   role-to-assume: ${{ secrets.DEPLOY_ROLE_ARN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: "18.12.1"
-            - uses: aws-actions/configure-aws-credentials@v1-node16
+            - uses: aws-actions/configure-aws-credentials@v2
               with:
                   aws-region: eu-west-2
                   role-to-assume: ${{ secrets.DEPLOY_ROLE_ARN }}
@@ -203,7 +203,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: "18.12.1"
-            - uses: aws-actions/configure-aws-credentials@v1-node16
+            - uses: aws-actions/configure-aws-credentials@v2
               with:
                   aws-region: eu-west-2
                   role-to-assume: ${{ secrets.DEPLOY_ROLE_ARN }}


### PR DESCRIPTION
# What

Updated all usages of `configure-aws-credentials` to version 2

# Why

V1 tag is no longer receiving updates
- Avoids issues where changes were made to v1 but not the node16 variant