### PR TITLE
feat(api): update terraform config to output graphql api url

### DIFF
--- a/api/infra/main.tf
+++ b/api/infra/main.tf
@@ -571,3 +571,7 @@ resource "aws_cognito_identity_pool_roles_attachment" "main" {
 output "identity_pool_id" {
   value = aws_cognito_identity_pool.main.id
 }
+
+output "graphql_api_url" {
+  value = aws_appsync_graphql_api.main.uris["GRAPHQL"]
+}


### PR DESCRIPTION
# What

Updated API terraform config to output GraphQL API URL

# Why

To enable access the value from the terraform CLI
- Will be used by UI deployment to generate a .env file