### PR TITLE
build(ui): add api as dev dependency to fix deployment order

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -41,6 +41,7 @@
         "styled-components": "5.3.6"
     },
     "devDependencies": {
+        "@colony-survival-calculator/api": "^0.0.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^14.4.3",


### PR DESCRIPTION
# What

Added api package as dev dependency to ui package using lerna

# Why

Lerna was running API and UI deployments in parrallel, which was causing pipeline to fail due to attempt to lock state on both jobs at the same time
- If the API is needing deployment at the same time as UI, then UI should wait
- Adding API as dev dependency should force lerna to wait in this scenario