### PR TITLE
ci: fix previous tag selection

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,7 +40,7 @@ jobs:
                   TF_VAR_mongodb_private_key: ${{ secrets.MONGODB_PRIVATE_KEY }}
                   TF_VAR_mongodb_public_key: ${{ secrets.MONGODB_PUBLIC_KEY }}
               run: |
-                  previous_tag=$(git tag | tail -n 2 | head -n 1)
+                  previous_tag=$(git tag | sort -V | tail -n 2 | head -n 1)
                   if [ -n "$previous_tag" ]; then
                     lerna run deploy --since="$previous_tag" -- -e prod
                   else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
                   if [ "${{ github.ref }}" != "refs/heads/master" ]; then
                     lerna run format:check --since=origin/master
                   else
-                    previous_tag=$(git tag | tail -n 1)
+                    previous_tag=$(git tag | sort -V | tail -n 1)
                     if [ -n "$previous_tag" ]; then
                       lerna run format:check --since="$previous_tag"
                     else
@@ -62,7 +62,7 @@ jobs:
                   if [ "${{ github.ref }}" != "refs/heads/master" ]; then
                     lerna run lint --since=origin/master
                   else
-                    previous_tag=$(git tag | tail -n 1)
+                    previous_tag=$(git tag | sort -V | tail -n 1)
                     if [ -n "$previous_tag" ]; then
                       lerna run lint --since="$previous_tag"
                     else
@@ -124,7 +124,7 @@ jobs:
                   if [ "${{ github.ref }}" != "refs/heads/master" ]; then
                     lerna run validate --since=origin/master
                   else
-                    previous_tag=$(git tag | tail -n 1)
+                    previous_tag=$(git tag | sort -V | tail -n 1)
                     if [ -n "$previous_tag" ]; then
                       lerna run validate --since="$previous_tag"
                     else
@@ -154,7 +154,7 @@ jobs:
                   if [ "${{ github.ref }}" != "refs/heads/master" ]; then
                     lerna run build --since=origin/master
                   else
-                    previous_tag=$(git tag | tail -n 1)
+                    previous_tag=$(git tag | sort -V | tail -n 1)
                     if [ -n "$previous_tag" ]; then
                       lerna run build --since="$previous_tag"
                     else
@@ -184,7 +184,7 @@ jobs:
                   if [ "${{ github.ref }}" != "refs/heads/master" ]; then
                     lerna run test --since=origin/master
                   else
-                    previous_tag=$(git tag | tail -n 1)
+                    previous_tag=$(git tag | sort -V | tail -n 1)
                     if [ -n "$previous_tag" ]; then
                       lerna run test --since="$previous_tag"
                     else
@@ -227,7 +227,7 @@ jobs:
                   if [ "${{ github.ref }}" != "refs/heads/master" ]; then
                     lerna run deploy:plan --since=origin/master -- -e prod
                   else
-                    previous_tag=$(git tag | tail -n 1)
+                    previous_tag=$(git tag | sort -V | tail -n 1)
                     if [ -n "$previous_tag" ]; then
                       lerna run deploy:plan --since="$previous_tag" -- -e prod
                     else


### PR DESCRIPTION
# What

Added version sorting to all previous tag commands in CI/CD pipeline

# Why

`git tag` was not returning tags in order of version, using `sort -V` forces this to be the case
- Was causing the CI/CD pipelines to run tasks against packages that had not changed