### PR TITLE
chore(ui): update eslint ignore to include graphql client generated code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,6 @@
 
 node_modules
 
-# Generated files
-
-src/types/generated/*
-
 # Built files
 
 dist

--- a/ui/.eslintignore
+++ b/ui/.eslintignore
@@ -4,7 +4,7 @@ node_modules
 
 # Generated files
 
-src/types/generated/*
+src/graphql/__generated__/*
 
 # Built files
 

--- a/ui/.prettierignore
+++ b/ui/.prettierignore
@@ -4,7 +4,6 @@ node_modules
 
 # Generated files
 
-src/types/generated/*
 src/graphql/__generated__/*
 
 # Built files


### PR DESCRIPTION
# What

Updated ignores to remove references to old generated types and add only refer to new GraphQL codegen files

# Why

Received eslint warnings on builds as these files were previously included: 
- [Example Job](https://github.com/ashley-evans/colony-survival-calculator/actions/runs/4588645962/jobs/8103015477)