### PR TITLE
fix(api): update game day second mapping to reflect daytime hours rather than entire day

### DIFF
--- a/api/src/functions/query-output/domain/__tests__/output-calculator.test.ts
+++ b/api/src/functions/query-output/domain/__tests__/output-calculator.test.ts
@@ -98,9 +98,9 @@ test("throws an error if more than one details are returned from database", asyn
 });
 
 test.each([
-    [OutputUnit.GAME_DAYS, 2, 3, 5400],
+    [OutputUnit.GAME_DAYS, 2, 3, 3262.5],
     [OutputUnit.MINUTES, 2, 3, 450],
-    [OutputUnit.GAME_DAYS, 8.5, 1, 423.53],
+    [OutputUnit.GAME_DAYS, 8.5, 1, 255.88],
     [OutputUnit.MINUTES, 8.5, 1, 35.29],
 ])(
     "returns the expected output for an item in %s given item create time of: %s and amount created: %s with 5 workers",

--- a/api/src/functions/query-output/utils/OutputUnitSecondMapping.ts
+++ b/api/src/functions/query-output/utils/OutputUnitSecondMapping.ts
@@ -2,7 +2,7 @@ import { OutputUnit } from "../interfaces/query-output-primary-port";
 
 const OutputUnitSecondMappings: Readonly<Record<OutputUnit, number>> = {
     [OutputUnit.MINUTES]: 60,
-    [OutputUnit.GAME_DAYS]: 720,
+    [OutputUnit.GAME_DAYS]: 435,
 };
 
 export default OutputUnitSecondMappings;


### PR DESCRIPTION
# What

Updated game day unit mapping from 720 seconds per game day to 435

# Why

Colonists in the game only work in daytime hours, this is between 4:30am and 7pm. The previous mapping expected a colonist to be working around the clock.
- New mapping based on 30 actual seconds per in game hour