### PR TITLE
chore: update dependabot config to provide commit message preference to match commit lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
       schedule:
           interval: weekly
       versioning-strategy: increase
+      commit-message:
+          prefix: dependency
+          prefix-development: devDependency
+          include: scope


### PR DESCRIPTION
# What

Added commit-message preferences to dependabot config

# Why

Currently all dependabot PRs are failing because the commit message length does not adhere to commit lint's rules, changing to these preferences should resolve this