### PR TITLE
chore: update commit lint configuration to ignore dependabot commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,3 @@ updates:
       schedule:
           interval: weekly
       versioning-strategy: increase
-      commit-message:
-          prefix: dependency
-          prefix-development: devDependency
-          include: scope

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -2,6 +2,9 @@ import type { UserConfig } from "@commitlint/types";
 
 const configuration: UserConfig = {
     extends: ["@commitlint/config-conventional"],
+    ignores: [
+        (message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message),
+    ],
 };
 
 module.exports = configuration;


### PR DESCRIPTION
# What

Reverted changes to dependabot configuration
Updated commit lint config to ignore dependabot commits

# Why

Configuration changes still did not meet commit lint requirements
Provided the header of the commit matches the standard, the release creation process will still correctly create tags etc. if required (shouldn't need to)