### PR TITLE
chore: force chore prefix on dependabot commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
       schedule:
           interval: weekly
       versioning-strategy: increase
+      commit-message:
+          prefix: chore
+          prefix-development: chore
+          include: scope


### PR DESCRIPTION
# What

Added chore as prefix for any dependabot commit message

# Why

To force dependabot to use correct prefix for commits