### PR TITLE
fix: debounce requests

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -7,7 +7,6 @@
         "": {
             "name": "@colony-survival-calculator/ui",
             "version": "0.0.0",
-            "hasInstallScript": true,
             "dependencies": {
                 "@apollo/client": "3.7.10",
                 "@aws-amplify/auth": "5.2.1",
@@ -21,7 +20,8 @@
                 "react": "18.2.0",
                 "react-dom": "18.2.0",
                 "react-router-dom": "6.8.1",
-                "styled-components": "5.3.6"
+                "styled-components": "5.3.6",
+                "use-debounce": "9.0.3"
             },
             "devDependencies": {
                 "@graphql-codegen/cli": "^3.2.2",
@@ -15924,6 +15924,17 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/use-debounce": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-9.0.3.tgz",
+            "integrity": "sha512-FhtlbDtDXILJV7Lix5OZj5yX/fW1tzq+VrvK1fnT2bUrPOGruU9Rw8NCEn+UI9wopfERBEZAOQ8lfeCJPllgnw==",
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            }
+        },
         "node_modules/use-sync-external-store": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
@@ -28905,6 +28916,12 @@
             "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
             "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
             "peer": true
+        },
+        "use-debounce": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-9.0.3.tgz",
+            "integrity": "sha512-FhtlbDtDXILJV7Lix5OZj5yX/fW1tzq+VrvK1fnT2bUrPOGruU9Rw8NCEn+UI9wopfERBEZAOQ8lfeCJPllgnw==",
+            "requires": {}
         },
         "use-sync-external-store": {
             "version": "1.2.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -36,7 +36,8 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-router-dom": "6.8.1",
-        "styled-components": "5.3.6"
+        "styled-components": "5.3.6",
+        "use-debounce": "9.0.3"
     },
     "devDependencies": {
         "@colony-survival-calculator/api": "^0.0.0",

--- a/ui/src/pages/Calculator/__tests__/Calculator-item-selection.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-item-selection.test.tsx
@@ -64,9 +64,9 @@ test("queries all known item names", async () => {
     );
 
     render(<Calculator />, expectedGraphQLAPIURL);
-    const [, body] = await expectedRequest;
+    const { matchedRequestDetails } = await expectedRequest;
 
-    expect(body?.variables).toEqual({});
+    expect(matchedRequestDetails.variables).toEqual({});
 });
 
 test("renders desired output header", async () => {
@@ -237,9 +237,9 @@ test("requests item details on the first option in the item name list without se
 
     render(<Calculator />, expectedGraphQLAPIURL);
     await screen.findByRole("combobox", { name: expectedItemSelectLabel });
-    const [, body] = await expectedRequest;
+    const { matchedRequestDetails } = await expectedRequest;
 
-    expect(body?.variables).toEqual({ name: items[0].name });
+    expect(matchedRequestDetails.variables).toEqual({ name: items[0].name });
 });
 
 test("requests item details for newly selected item if selection is changed", async () => {
@@ -254,12 +254,12 @@ test("requests item details for newly selected item if selection is changed", as
 
     render(<Calculator />, expectedGraphQLAPIURL);
     await screen.findByRole("combobox", { name: expectedItemSelectLabel });
-
     await selectItemAndWorkers({ itemName: expectedItemName });
+    const { matchedRequestDetails } = await expectedRequest;
 
-    const [, body] = await expectedRequest;
-
-    expect(body?.variables).toEqual({ name: expectedItemName });
+    expect(matchedRequestDetails.variables).toEqual({
+        name: expectedItemName,
+    });
 });
 
 describe("item name request error handling", () => {

--- a/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
@@ -6,7 +6,7 @@ import { vi } from "vitest";
 
 import {
     renderWithTestProviders as render,
-    wrapWithApolloProvider,
+    wrapWithTestProviders,
 } from "../../../test/utils";
 import { waitForRequest } from "../../../helpers/utils";
 import {
@@ -282,7 +282,7 @@ describe("debounces optimal output requests", () => {
         );
 
         const { rerender } = rtlRender(
-            wrapWithApolloProvider(
+            wrapWithTestProviders(
                 <OptimalOutput
                     itemName={expectedItemName}
                     workers={1}
@@ -292,7 +292,7 @@ describe("debounces optimal output requests", () => {
             )
         );
         rerender(
-            wrapWithApolloProvider(
+            wrapWithTestProviders(
                 <OptimalOutput
                     itemName={expectedItemName}
                     workers={2}
@@ -302,7 +302,7 @@ describe("debounces optimal output requests", () => {
             )
         );
         rerender(
-            wrapWithApolloProvider(
+            wrapWithTestProviders(
                 <OptimalOutput
                     itemName={expectedItemName}
                     workers={3}

--- a/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
@@ -1,9 +1,13 @@
 import React from "react";
 import { graphql } from "msw";
 import { setupServer } from "msw/node";
-import { screen } from "@testing-library/react";
+import { act, screen, render as rtlRender } from "@testing-library/react";
+import { vi } from "vitest";
 
-import { renderWithTestProviders as render } from "../../../test/utils";
+import {
+    renderWithTestProviders as render,
+    wrapWithApolloProvider,
+} from "../../../test/utils";
 import { waitForRequest } from "../../../helpers/utils";
 import {
     ItemName,
@@ -15,8 +19,10 @@ import {
     selectItemAndWorkers,
     selectOutputUnit,
 } from "./utils";
-import Calculator from "../Calculator";
 import { OutputUnit } from "../../../graphql/__generated__/graphql";
+
+import Calculator from "../Calculator";
+import OptimalOutput from "../components/OptimalOutput";
 
 const expectedGraphQLAPIURL = "http://localhost:3000/graphql";
 const item: ItemName = { name: "Item 1" };
@@ -83,9 +89,9 @@ test("queries optimal output if item and workers inputted with default unit sele
         itemName: item.name,
         workers: expectedWorkers,
     });
-    const [, body] = await expectedRequest;
+    const { matchedRequestDetails } = await expectedRequest;
 
-    expect(body?.variables).toEqual({
+    expect(matchedRequestDetails.variables).toEqual({
         name: item.name,
         workers: expectedWorkers,
         unit: OutputUnit.Minutes,
@@ -107,9 +113,9 @@ test("queries optimal output if item annd workers inputted with non-default unit
         itemName: item.name,
         workers: expectedWorkers,
     });
-    const [, body] = await expectedRequest;
+    const { matchedRequestDetails } = await expectedRequest;
 
-    expect(body?.variables).toEqual({
+    expect(matchedRequestDetails.variables).toEqual({
         name: item.name,
         workers: expectedWorkers,
         unit: OutputUnit.GameDays,
@@ -256,6 +262,67 @@ describe("error handling", async () => {
         expect(
             screen.queryByText(expectedOutputPrefix, { exact: false })
         ).not.toBeInTheDocument();
+    });
+});
+
+describe("debounces optimal output requests", () => {
+    beforeAll(() => {
+        vi.useFakeTimers();
+    });
+
+    test("only requests optimal output every 500ms on worker change", async () => {
+        const expectedItemName = "test item";
+        const expectedOutputUnit = OutputUnit.GameDays;
+        const expectedLastRequest = waitForRequest(
+            server,
+            "POST",
+            expectedGraphQLAPIURL,
+            expectedOutputQueryName,
+            { name: expectedItemName, workers: 3, unit: expectedOutputUnit }
+        );
+
+        const { rerender } = rtlRender(
+            wrapWithApolloProvider(
+                <OptimalOutput
+                    itemName={expectedItemName}
+                    workers={1}
+                    outputUnit={expectedOutputUnit}
+                />,
+                expectedGraphQLAPIURL
+            )
+        );
+        rerender(
+            wrapWithApolloProvider(
+                <OptimalOutput
+                    itemName={expectedItemName}
+                    workers={2}
+                    outputUnit={expectedOutputUnit}
+                />,
+                expectedGraphQLAPIURL
+            )
+        );
+        rerender(
+            wrapWithApolloProvider(
+                <OptimalOutput
+                    itemName={expectedItemName}
+                    workers={3}
+                    outputUnit={expectedOutputUnit}
+                />,
+                expectedGraphQLAPIURL
+            )
+        );
+        act(() => {
+            vi.advanceTimersByTime(500);
+        });
+        const { detailsUpToMatch } = await expectedLastRequest;
+
+        expect(detailsUpToMatch).not.toContainEqual(
+            expect.objectContaining({ workers: 2 })
+        );
+    });
+
+    afterAll(() => {
+        vi.useRealTimers();
     });
 });
 

--- a/ui/src/pages/Calculator/__tests__/Calculator-requirements.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-requirements.test.tsx
@@ -82,9 +82,9 @@ test("queries requirements if item and workers inputted", async () => {
         itemName: itemWithSingleRequirement.name,
         workers: expectedWorkers,
     });
-    const [, body] = await expectedRequest;
+    const { matchedRequestDetails } = await expectedRequest;
 
-    expect(body?.variables).toEqual({
+    expect(matchedRequestDetails.variables).toEqual({
         name: itemWithSingleRequirement.name,
         workers: expectedWorkers,
     });

--- a/ui/src/pages/Calculator/__tests__/Calculator-requirements.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-requirements.test.tsx
@@ -1,9 +1,18 @@
 import React from "react";
 import { graphql } from "msw";
 import { setupServer } from "msw/node";
-import { screen, within } from "@testing-library/react";
+import {
+    screen,
+    within,
+    render as rtlRender,
+    act,
+} from "@testing-library/react";
+import { vi } from "vitest";
 
-import { renderWithTestProviders as render } from "../../../test/utils";
+import {
+    renderWithTestProviders as render,
+    wrapWithTestProviders,
+} from "../../../test/utils";
 import { Requirement } from "../../../graphql/__generated__/graphql";
 import { waitForRequest } from "../../../helpers/utils";
 import Calculator from "../Calculator";
@@ -15,6 +24,7 @@ import {
     expectedItemNameQueryName,
     expectedItemDetailsQueryName,
 } from "./utils";
+import Requirements from "../components/Requirements";
 
 const expectedGraphQLAPIURL = "http://localhost:3000/graphql";
 const expectedRequirementsHeading = "Requirements:";
@@ -309,6 +319,63 @@ describe("error handling", async () => {
         await screen.findByText(expectedOutputText);
 
         expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    });
+});
+
+describe("debounces requirement requests", () => {
+    beforeAll(() => {
+        vi.useFakeTimers();
+    });
+
+    test("only requests requirements every 500ms on worker change", async () => {
+        const expectedItemName = "test item";
+        const expectedLastRequest = waitForRequest(
+            server,
+            "POST",
+            expectedGraphQLAPIURL,
+            expectedRequirementsQueryName,
+            { name: expectedItemName, workers: 3 }
+        );
+
+        const { rerender } = rtlRender(
+            wrapWithTestProviders(
+                <Requirements
+                    selectedItemName={expectedItemName}
+                    workers={1}
+                />,
+                expectedGraphQLAPIURL
+            )
+        );
+        rerender(
+            wrapWithTestProviders(
+                <Requirements
+                    selectedItemName={expectedItemName}
+                    workers={2}
+                />,
+                expectedGraphQLAPIURL
+            )
+        );
+        rerender(
+            wrapWithTestProviders(
+                <Requirements
+                    selectedItemName={expectedItemName}
+                    workers={3}
+                />,
+                expectedGraphQLAPIURL
+            )
+        );
+        act(() => {
+            vi.advanceTimersByTime(500);
+        });
+        const { detailsUpToMatch } = await expectedLastRequest;
+
+        expect(detailsUpToMatch).not.toContainEqual(
+            expect.objectContaining({ workers: 2 })
+        );
+    });
+
+    afterAll(() => {
+        vi.useRealTimers();
     });
 });
 

--- a/ui/src/pages/Calculator/components/OptimalOutput/OptimalOutput.tsx
+++ b/ui/src/pages/Calculator/components/OptimalOutput/OptimalOutput.tsx
@@ -1,10 +1,15 @@
-import React from "react";
-import { useQuery } from "@apollo/client";
+import React, { useEffect } from "react";
+import { useLazyQuery } from "@apollo/client";
 
 import { gql } from "../../../../graphql/__generated__";
 import { OutputUnit } from "../../../../graphql/__generated__/graphql";
 import { DesiredOutputText } from "./styles";
-import { OutputUnitDisplayMappings, roundOutput } from "../../utils";
+import {
+    DEFAULT_DEBOUNCE,
+    OutputUnitDisplayMappings,
+    roundOutput,
+} from "../../utils";
+import { useDebounce } from "use-debounce";
 
 type OptimalOutputProps = {
     itemName: string;
@@ -24,9 +29,19 @@ function createOutputMessage(output: number, unit: OutputUnit): string {
 }
 
 function OptimalOutput({ itemName, workers, outputUnit }: OptimalOutputProps) {
-    const { data, error } = useQuery(GET_OPTIMAL_OUTPUT, {
-        variables: { name: itemName, workers, unit: outputUnit },
-    });
+    const [getOptimalOutput, { data, error }] =
+        useLazyQuery(GET_OPTIMAL_OUTPUT);
+    const [debouncedWorkers] = useDebounce(workers, DEFAULT_DEBOUNCE);
+
+    useEffect(() => {
+        getOptimalOutput({
+            variables: {
+                name: itemName,
+                workers: debouncedWorkers,
+                unit: outputUnit,
+            },
+        });
+    }, [itemName, debouncedWorkers, outputUnit]);
 
     if (error) {
         return (

--- a/ui/src/pages/Calculator/components/OptimalOutput/OptimalOutput.tsx
+++ b/ui/src/pages/Calculator/components/OptimalOutput/OptimalOutput.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import { useLazyQuery } from "@apollo/client";
+import { useDebounce } from "use-debounce";
 
 import { gql } from "../../../../graphql/__generated__";
 import { OutputUnit } from "../../../../graphql/__generated__/graphql";
@@ -9,7 +10,6 @@ import {
     OutputUnitDisplayMappings,
     roundOutput,
 } from "../../utils";
-import { useDebounce } from "use-debounce";
 
 type OptimalOutputProps = {
     itemName: string;

--- a/ui/src/pages/Calculator/components/Requirements/Requirements.tsx
+++ b/ui/src/pages/Calculator/components/Requirements/Requirements.tsx
@@ -1,5 +1,6 @@
-import React from "react";
-import { useQuery } from "@apollo/client";
+import React, { useEffect } from "react";
+import { useLazyQuery } from "@apollo/client";
+import { useDebounce } from "use-debounce";
 
 import {
     RequirementsTable,
@@ -9,6 +10,7 @@ import {
     NumberColumnCell,
 } from "./styles";
 import { gql } from "../../../../graphql/__generated__";
+import { DEFAULT_DEBOUNCE } from "../../utils";
 
 type RequirementsProps = {
     selectedItemName: string;
@@ -25,9 +27,22 @@ const GET_ITEM_REQUIREMENTS = gql(`
 `);
 
 function Requirements({ selectedItemName, workers }: RequirementsProps) {
-    const { loading, data, error } = useQuery(GET_ITEM_REQUIREMENTS, {
-        variables: { name: selectedItemName, workers },
-    });
+    const [getItemRequirements, { loading, data, error }] = useLazyQuery(
+        GET_ITEM_REQUIREMENTS,
+        {
+            variables: { name: selectedItemName, workers },
+        }
+    );
+    const [debouncedWorkers] = useDebounce(workers, DEFAULT_DEBOUNCE);
+
+    useEffect(() => {
+        getItemRequirements({
+            variables: {
+                name: selectedItemName,
+                workers: debouncedWorkers,
+            },
+        });
+    }, [selectedItemName, debouncedWorkers]);
 
     if (error) {
         return (

--- a/ui/src/pages/Calculator/utils/constants.ts
+++ b/ui/src/pages/Calculator/utils/constants.ts
@@ -1,0 +1,3 @@
+const DEFAULT_DEBOUNCE = 500;
+
+export { DEFAULT_DEBOUNCE };

--- a/ui/src/pages/Calculator/utils/index.ts
+++ b/ui/src/pages/Calculator/utils/index.ts
@@ -1,2 +1,3 @@
 export * from "./output-units";
 export * from "./round-output";
+export * from "./constants";

--- a/ui/src/test/utils.tsx
+++ b/ui/src/test/utils.tsx
@@ -25,6 +25,15 @@ function createApolloClient(
     });
 }
 
+function wrapWithApolloProvider(
+    children: ReactElement,
+    apiURL = defaultGraphQLURL
+) {
+    const client = createApolloClient(apiURL);
+
+    return <ApolloProvider client={client}>{children}</ApolloProvider>;
+}
+
 function renderWithRouterProvider(
     routerProps: RouterProviderProps,
     route = "/",
@@ -47,15 +56,18 @@ function renderWithTestProviders(
     children: ReactElement,
     apiURL = defaultGraphQLURL
 ) {
-    const client = createApolloClient(apiURL);
-
     return {
         ...render(
-            <ApolloProvider client={client}>
-                <ThemeProvider theme={darkTheme}>{children}</ThemeProvider>
-            </ApolloProvider>
+            wrapWithApolloProvider(
+                <ThemeProvider theme={darkTheme}>{children}</ThemeProvider>,
+                apiURL
+            )
         ),
     };
 }
 
-export { renderWithRouterProvider, renderWithTestProviders };
+export {
+    wrapWithApolloProvider,
+    renderWithRouterProvider,
+    renderWithTestProviders,
+};

--- a/ui/src/test/utils.tsx
+++ b/ui/src/test/utils.tsx
@@ -25,13 +25,17 @@ function createApolloClient(
     });
 }
 
-function wrapWithApolloProvider(
+function wrapWithTestProviders(
     children: ReactElement,
     apiURL = defaultGraphQLURL
 ) {
     const client = createApolloClient(apiURL);
 
-    return <ApolloProvider client={client}>{children}</ApolloProvider>;
+    return (
+        <ApolloProvider client={client}>
+            <ThemeProvider theme={darkTheme}>{children}</ThemeProvider>
+        </ApolloProvider>
+    );
 }
 
 function renderWithRouterProvider(
@@ -57,17 +61,12 @@ function renderWithTestProviders(
     apiURL = defaultGraphQLURL
 ) {
     return {
-        ...render(
-            wrapWithApolloProvider(
-                <ThemeProvider theme={darkTheme}>{children}</ThemeProvider>,
-                apiURL
-            )
-        ),
+        ...render(wrapWithTestProviders(children, apiURL)),
     };
 }
 
 export {
-    wrapWithApolloProvider,
+    wrapWithTestProviders,
     renderWithRouterProvider,
     renderWithTestProviders,
 };


### PR DESCRIPTION
# What

Debounced requirements and optimal output query (500ms)
Updated msw `waitForRequest` test util to return all matching operation details 

# Why

To reduce input noise/unnecessary requests to API

`waitForRequest` updates:
- To enable testing that intermediate input values (within debounce interval) are not sent to API