### PR TITLE
feat: 130 add min max tool def

### DIFF
--- a/api/infra/main.tf
+++ b/api/infra/main.tf
@@ -64,7 +64,7 @@ resource "aws_s3_object" "items_json_seed" {
 
   etag = filemd5("${var.src_folder}/json/items.json")
 
-  depends_on = [aws_s3_bucket_notification.seed_notification]
+  depends_on = [aws_s3_bucket_notification.seed_notification, aws_lambda_function.add_item_lambda]
 }
 
 data "mongodbatlas_roles_org_id" "main" {}

--- a/api/scripts/ts-json-keywords.js
+++ b/api/scripts/ts-json-keywords.js
@@ -1,0 +1,3 @@
+module.exports = (ajv) => {
+    ajv.addKeyword("tsEnumNames");
+};

--- a/api/scripts/validate-json.sh
+++ b/api/scripts/validate-json.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-script_parent_dir=$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")
+script_dir=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
+script_parent_dir="$(dirname "$script_dir")"
 
 json_folder="$script_parent_dir/src/json"
 schema_folder="$json_folder/schemas"
 
-npx --yes ajv-cli -s "$schema_folder/items.json" -d "$json_folder/items.json"
+npx --yes ajv-cli validate -s "$schema_folder/items.json" \
+    -d "$json_folder/items.json" \
+    -c "$script_dir/ts-json-keywords.js"

--- a/api/src/functions/add-item/adapters/__tests__/store-item.test.ts
+++ b/api/src/functions/add-item/adapters/__tests__/store-item.test.ts
@@ -92,35 +92,35 @@ describe.each([
     [
         "a single item",
         [
-            createItem(
-                "test item 1",
-                2,
-                3,
-                [{ name: "test", amount: 1 }],
-                Tools.none,
-                Tools.steel
-            ),
+            createItem({
+                name: "test item 1",
+                createTime: 2,
+                output: 3,
+                requirements: [{ name: "test", amount: 1 }],
+                minimumTool: Tools.none,
+                maximumTool: Tools.steel,
+            }),
         ],
     ],
     [
         "multiple items",
         [
-            createItem(
-                "test item 1",
-                2,
-                3,
-                [{ name: "test", amount: 1 }],
-                Tools.copper,
-                Tools.bronze
-            ),
-            createItem(
-                "test item 2",
-                1,
-                4,
-                [{ name: "world", amount: 3 }],
-                Tools.none,
-                Tools.steel
-            ),
+            createItem({
+                name: "test item 1",
+                createTime: 2,
+                output: 3,
+                requirements: [{ name: "test", amount: 1 }],
+                minimumTool: Tools.copper,
+                maximumTool: Tools.bronze,
+            }),
+            createItem({
+                name: "test item 2",
+                createTime: 1,
+                output: 4,
+                requirements: [{ name: "world", amount: 3 }],
+                minimumTool: Tools.none,
+                maximumTool: Tools.steel,
+            }),
         ],
     ],
 ])("handles adding %s", (_: string, expected: Items) => {
@@ -145,8 +145,22 @@ describe.each([
 });
 
 test("removes any old entries prior to storing new items", async () => {
-    const oldItem = createItem("old", 1, 2, [], Tools.none, Tools.none);
-    const newItem = createItem("new", 2, 3, [], Tools.bronze, Tools.steel);
+    const oldItem = createItem({
+        name: "old",
+        createTime: 1,
+        output: 2,
+        requirements: [],
+        minimumTool: Tools.none,
+        maximumTool: Tools.none,
+    });
+    const newItem = createItem({
+        name: "new",
+        createTime: 2,
+        output: 3,
+        requirements: [],
+        minimumTool: Tools.bronze,
+        maximumTool: Tools.steel,
+    });
     const { storeItem } = await import("../store-item");
 
     await storeItem([oldItem]);

--- a/api/src/functions/add-item/adapters/__tests__/store-item.test.ts
+++ b/api/src/functions/add-item/adapters/__tests__/store-item.test.ts
@@ -2,7 +2,7 @@ import type { MongoMemoryServer } from "mongodb-memory-server";
 import { MongoClient } from "mongodb";
 
 import { createItem, createMemoryServer } from "../../../../../test/index";
-import type { Items } from "../../../../types";
+import { Items, Tools } from "../../../../types";
 
 const databaseName = "TestDatabase";
 const itemCollectionName = "Items";
@@ -91,13 +91,36 @@ describe("empty array handling", () => {
 describe.each([
     [
         "a single item",
-        [createItem("test item 1", 2, 3, [{ name: "test", amount: 1 }])],
+        [
+            createItem(
+                "test item 1",
+                2,
+                3,
+                [{ name: "test", amount: 1 }],
+                Tools.none,
+                Tools.steel
+            ),
+        ],
     ],
     [
         "multiple items",
         [
-            createItem("test item 1", 2, 3, [{ name: "test", amount: 1 }]),
-            createItem("test item 2", 1, 4, [{ name: "world", amount: 3 }]),
+            createItem(
+                "test item 1",
+                2,
+                3,
+                [{ name: "test", amount: 1 }],
+                Tools.copper,
+                Tools.bronze
+            ),
+            createItem(
+                "test item 2",
+                1,
+                4,
+                [{ name: "world", amount: 3 }],
+                Tools.none,
+                Tools.steel
+            ),
         ],
     ],
 ])("handles adding %s", (_: string, expected: Items) => {
@@ -122,8 +145,8 @@ describe.each([
 });
 
 test("removes any old entries prior to storing new items", async () => {
-    const oldItem = createItem("old", 1, 2, []);
-    const newItem = createItem("new", 2, 3, []);
+    const oldItem = createItem("old", 1, 2, [], Tools.none, Tools.none);
+    const newItem = createItem("new", 2, 3, [], Tools.bronze, Tools.steel);
     const { storeItem } = await import("../store-item");
 
     await storeItem([oldItem]);

--- a/api/src/functions/add-item/domain/__tests__/add-item.test.ts
+++ b/api/src/functions/add-item/domain/__tests__/add-item.test.ts
@@ -1,4 +1,4 @@
-import type { Items } from "../../../../types";
+import { Items, Tools } from "../../../../types";
 import { createItem } from "../../../../../test";
 
 import { storeItem } from "../../adapters/store-item";
@@ -11,10 +11,24 @@ const mockStoreItem = storeItem as jest.Mock;
 
 import { addItem } from "../add-item";
 
-const validItem = createItem("item name 1", 2, 3, [], 10, 2);
-const validItemWithReqs = createItem("item name 2", 1, 2, [
-    { name: "item name 1", amount: 2 },
-]);
+const validItem = createItem(
+    "item name 1",
+    2,
+    3,
+    [],
+    Tools.none,
+    Tools.none,
+    10,
+    2
+);
+const validItemWithReqs = createItem(
+    "item name 2",
+    1,
+    2,
+    [{ name: "item name 1", amount: 2 }],
+    Tools.none,
+    Tools.none
+);
 const validItems = [validItem, validItemWithReqs];
 
 const errorLogSpy = jest
@@ -38,6 +52,8 @@ describe.each([
                 createTime: 2,
                 output: 1,
                 requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
             },
         ]),
     ],
@@ -48,6 +64,8 @@ describe.each([
                 name: "test",
                 output: 1,
                 requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
             },
         ]),
     ],
@@ -59,6 +77,8 @@ describe.each([
                 createTime: "test",
                 output: 1,
                 requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
             },
         ]),
     ],
@@ -70,6 +90,8 @@ describe.each([
                 createTime: -1,
                 output: 1,
                 requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
             },
         ]),
     ],
@@ -80,6 +102,8 @@ describe.each([
                 name: "test",
                 createTime: 2,
                 requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
             },
         ]),
     ],
@@ -91,6 +115,8 @@ describe.each([
                 createTime: 1,
                 output: "test",
                 requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
             },
         ]),
     ],
@@ -102,6 +128,8 @@ describe.each([
                 createTime: 1,
                 output: -1,
                 requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
             },
         ]),
     ],
@@ -112,6 +140,8 @@ describe.each([
                 name: "test",
                 createTime: 2,
                 output: 1,
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
             },
         ]),
     ],
@@ -123,6 +153,8 @@ describe.each([
                 createTime: 2,
                 output: 1,
                 requires: "test",
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
             },
         ]),
     ],
@@ -134,6 +166,8 @@ describe.each([
                 createTime: 2,
                 output: 1,
                 requires: ["test"],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
             },
         ]),
     ],
@@ -145,6 +179,8 @@ describe.each([
                 createTime: 2,
                 output: 1,
                 requires: [{ amount: 1 }],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
             },
         ]),
     ],
@@ -156,12 +192,16 @@ describe.each([
                 createTime: 2,
                 output: 1,
                 requires: [{ name: "wibble" }],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
             },
             {
                 name: "wibble",
                 createTime: 1,
                 output: 1,
                 requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
             },
         ]),
     ],
@@ -173,12 +213,16 @@ describe.each([
                 createTime: 2,
                 output: 1,
                 requires: [{ name: "wibble", amount: "test" }],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
             },
             {
                 name: "wibble",
                 createTime: 1,
                 output: 1,
                 requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
             },
         ]),
     ],
@@ -191,6 +235,8 @@ describe.each([
                 output: 1,
                 requires: [],
                 size: "wibble",
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
             },
         ]),
     ],
@@ -205,6 +251,8 @@ describe.each([
                 size: {
                     height: 1,
                 },
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
             },
         ]),
     ],
@@ -220,6 +268,8 @@ describe.each([
                     width: "test",
                     height: 1,
                 },
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
             },
         ]),
     ],
@@ -234,6 +284,8 @@ describe.each([
                 size: {
                     width: 1,
                 },
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
             },
         ]),
     ],
@@ -249,6 +301,74 @@ describe.each([
                     width: 1,
                     height: "test",
                 },
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
+            },
+        ]),
+    ],
+    [
+        "an item with a missing minimum tool",
+        JSON.stringify([
+            {
+                name: "test",
+                createTime: 2,
+                output: 1,
+                requires: [],
+                size: {
+                    width: 1,
+                    height: 1,
+                },
+                maximumTool: Tools.none,
+            },
+        ]),
+    ],
+    [
+        "an item with an unknown minimum tool",
+        JSON.stringify([
+            {
+                name: "test",
+                createTime: 2,
+                output: 1,
+                requires: [],
+                size: {
+                    width: 1,
+                    height: 1,
+                },
+                minimumTool: "unknown",
+                maximumTool: Tools.none,
+            },
+        ]),
+    ],
+    [
+        "an item with a missing maximum tool",
+        JSON.stringify([
+            {
+                name: "test",
+                createTime: 2,
+                output: 1,
+                requires: [],
+                size: {
+                    width: 1,
+                    height: 1,
+                },
+                minimumTool: Tools.none,
+            },
+        ]),
+    ],
+    [
+        "an item with an unknown maximum tool",
+        JSON.stringify([
+            {
+                name: "test",
+                createTime: 2,
+                output: 1,
+                requires: [],
+                size: {
+                    width: 1,
+                    height: 1,
+                },
+                minimumTool: Tools.none,
+                maximumTool: "unknown",
             },
         ]),
     ],

--- a/api/src/functions/add-item/domain/__tests__/add-item.test.ts
+++ b/api/src/functions/add-item/domain/__tests__/add-item.test.ts
@@ -12,24 +12,24 @@ const mockStoreItem = storeItem as jest.Mock;
 import { addItem } from "../add-item";
 import { Item } from "../../../../graphql/schema";
 
-const validItem = createItem(
-    "item name 1",
-    2,
-    3,
-    [],
-    Tools.none,
-    Tools.none,
-    10,
-    2
-);
-const validItemWithReqs = createItem(
-    "item name 2",
-    1,
-    2,
-    [{ name: "item name 1", amount: 2 }],
-    Tools.none,
-    Tools.none
-);
+const validItem = createItem({
+    name: "item name 1",
+    createTime: 2,
+    output: 3,
+    requirements: [],
+    minimumTool: Tools.none,
+    maximumTool: Tools.none,
+    width: 10,
+    height: 2,
+});
+const validItemWithReqs = createItem({
+    name: "item name 2",
+    createTime: 1,
+    output: 2,
+    requirements: [{ name: "item name 1", amount: 2 }],
+    minimumTool: Tools.none,
+    maximumTool: Tools.none,
+});
 const validItems = [validItem, validItemWithReqs];
 
 const errorLogSpy = jest
@@ -405,27 +405,62 @@ describe.each([
     ],
     [
         "invalid min/max tool combination (none above stone)",
-        createItem("test item", 1, 2, [], Tools.stone, Tools.none),
+        createItem({
+            name: "test item",
+            createTime: 1,
+            output: 2,
+            requirements: [],
+            minimumTool: Tools.stone,
+            maximumTool: Tools.none,
+        }),
         "Invalid item: test item, minimum tool is better than maximum tool",
     ],
     [
         "invalid min/max tool combination (stone above copper)",
-        createItem("test item", 1, 2, [], Tools.copper, Tools.stone),
+        createItem({
+            name: "test item",
+            createTime: 1,
+            output: 2,
+            requirements: [],
+            minimumTool: Tools.copper,
+            maximumTool: Tools.stone,
+        }),
         "Invalid item: test item, minimum tool is better than maximum tool",
     ],
     [
         "invalid min/max tool combination (copper above iron)",
-        createItem("test item", 1, 2, [], Tools.iron, Tools.copper),
+        createItem({
+            name: "test item",
+            createTime: 1,
+            output: 2,
+            requirements: [],
+            minimumTool: Tools.iron,
+            maximumTool: Tools.copper,
+        }),
         "Invalid item: test item, minimum tool is better than maximum tool",
     ],
     [
         "invalid min/max tool combination (iron above bronze)",
-        createItem("test item", 1, 2, [], Tools.bronze, Tools.iron),
+        createItem({
+            name: "test item",
+            createTime: 1,
+            output: 2,
+            requirements: [],
+            minimumTool: Tools.bronze,
+            maximumTool: Tools.iron,
+        }),
         "Invalid item: test item, minimum tool is better than maximum tool",
     ],
     [
         "invalid min/max tool combination (bronze above steel)",
-        createItem("test item", 1, 2, [], Tools.steel, Tools.bronze),
+        createItem({
+            name: "test item",
+            createTime: 1,
+            output: 2,
+            requirements: [],
+            minimumTool: Tools.steel,
+            maximumTool: Tools.bronze,
+        }),
         "Invalid item: test item, minimum tool is better than maximum tool",
     ],
 ])("handles item with %s", (_: string, item: Item, expectedError: string) => {

--- a/api/src/functions/add-item/domain/add-item.ts
+++ b/api/src/functions/add-item/domain/add-item.ts
@@ -6,6 +6,7 @@ import { storeItem } from "../adapters/store-item";
 import type { AddItemPrimaryPort } from "../interfaces/add-item-primary-port";
 
 const ajv = new Ajv();
+ajv.addKeyword("tsEnumNames");
 const validateItems = ajv.compile<Items>(ItemsSchema);
 
 function parseItems(input: string): Items {
@@ -17,7 +18,10 @@ function parseItems(input: string): Items {
             throw validateItems.errors;
         }
     } catch (ex) {
-        throw `Validation Error: ${ex}`;
+        const errorContent =
+            ex instanceof Error ? ex.message : JSON.stringify(ex);
+
+        throw `Validation Error: ${errorContent}`;
     }
 }
 

--- a/api/src/functions/add-item/domain/add-item.ts
+++ b/api/src/functions/add-item/domain/add-item.ts
@@ -1,13 +1,22 @@
 import Ajv from "ajv";
 
 import ItemsSchema from "../../../json/schemas/items.json";
-import type { Items } from "../../../types";
+import { Items, Tools } from "../../../types";
 import { storeItem } from "../adapters/store-item";
 import type { AddItemPrimaryPort } from "../interfaces/add-item-primary-port";
 
 const ajv = new Ajv();
 ajv.addKeyword("tsEnumNames");
 const validateItems = ajv.compile<Items>(ItemsSchema);
+
+const toolValues = new Map<Tools, number>([
+    [Tools.none, 1],
+    [Tools.stone, 2],
+    [Tools.copper, 4],
+    [Tools.iron, 5.3],
+    [Tools.bronze, 6.15],
+    [Tools.steel, 8],
+]);
 
 function parseItems(input: string): Items {
     try {
@@ -25,16 +34,39 @@ function parseItems(input: string): Items {
     }
 }
 
-const addItem: AddItemPrimaryPort = async (items) => {
-    const parsedItems = parseItems(items);
-    const itemMap = new Set<string>(parsedItems.map((item) => item.name));
-    for (const item of parsedItems) {
+function validateRequirements(items: Items): void {
+    const itemMap = new Set<string>(items.map((item) => item.name));
+    for (const item of items) {
         for (const requirement of item.requires) {
             if (!itemMap.has(requirement.name)) {
-                throw `Missing requirement: ${requirement.name} in ${item.name}`;
+                throw new Error(
+                    `Missing requirement: ${requirement.name} in ${item.name}`
+                );
             }
         }
     }
+}
+
+function validateTools(items: Items): void {
+    for (const item of items) {
+        const minToolValue = toolValues.get(item.minimumTool);
+        const maxToolValue = toolValues.get(item.maximumTool);
+        if (!minToolValue || !maxToolValue) {
+            throw new Error(
+                `Unable to validate item: ${item.name} tools, unknown hierarchy for tools: ${item.minimumTool}/${item.maximumTool}`
+            );
+        } else if (minToolValue > maxToolValue) {
+            throw new Error(
+                `Invalid item: ${item.name}, minimum tool is better than maximum tool`
+            );
+        }
+    }
+}
+
+const addItem: AddItemPrimaryPort = async (items) => {
+    const parsedItems = parseItems(items);
+    validateRequirements(parsedItems);
+    validateTools(parsedItems);
 
     try {
         return await storeItem(parsedItems);

--- a/api/src/functions/query-item/__tests__/handler.test.ts
+++ b/api/src/functions/query-item/__tests__/handler.test.ts
@@ -64,13 +64,40 @@ test.each([
     ["none received", []],
     [
         "multiple received w/ no farm sizes",
-        [createItem("test 1", 1, 3, []), createItem("test 2", 4, 6, [])],
+        [
+            createItem({
+                name: "test 1",
+                createTime: 1,
+                output: 3,
+                requirements: [],
+            }),
+            createItem({
+                name: "test 2",
+                createTime: 4,
+                output: 6,
+                requirements: [],
+            }),
+        ],
     ],
     [
         "multiple received w/ farm sizes",
         [
-            createItem("test 1", 1, 3, [], 1, 2),
-            createItem("test 2", 4, 6, [], 3, 4),
+            createItem({
+                name: "test 1",
+                createTime: 1,
+                output: 3,
+                requirements: [],
+                width: 1,
+                height: 2,
+            }),
+            createItem({
+                name: "test 2",
+                createTime: 4,
+                output: 6,
+                requirements: [],
+                width: 3,
+                height: 4,
+            }),
         ],
     ],
 ])(

--- a/api/src/functions/query-item/adapters/__tests__/mongodb-query-item.test.ts
+++ b/api/src/functions/query-item/adapters/__tests__/mongodb-query-item.test.ts
@@ -77,13 +77,30 @@ test("returns an empty array if no items are stored in the items collection", as
 test.each([
     [
         "a single item",
-        [createItem("test item 1", 2, 3, [{ name: "test", amount: 1 }])],
+        [
+            createItem({
+                name: "test item 1",
+                createTime: 2,
+                output: 3,
+                requirements: [{ name: "test", amount: 1 }],
+            }),
+        ],
     ],
     [
         "multiple items",
         [
-            createItem("test item 1", 2, 3, [{ name: "test", amount: 1 }]),
-            createItem("test item 2", 1, 4, [{ name: "world", amount: 3 }]),
+            createItem({
+                name: "test item 1",
+                createTime: 2,
+                output: 3,
+                requirements: [{ name: "test", amount: 1 }],
+            }),
+            createItem({
+                name: "test item 2",
+                createTime: 1,
+                output: 4,
+                requirements: [{ name: "world", amount: 3 }],
+            }),
         ],
     ],
 ])(
@@ -101,10 +118,21 @@ test.each([
 
 test("returns only the specified item given an item name provided and multiple items in collection", async () => {
     const expectedItemName = "expected test item 1";
-    const expected = createItem(expectedItemName, 2, 3, [
-        { name: "test", amount: 1 },
-    ]);
-    const stored = [createItem("another item", 3, 5, []), expected];
+    const expected = createItem({
+        name: expectedItemName,
+        createTime: 2,
+        output: 3,
+        requirements: [{ name: "test", amount: 1 }],
+    });
+    const stored = [
+        createItem({
+            name: "another item",
+            createTime: 3,
+            output: 5,
+            requirements: [],
+        }),
+        expected,
+    ];
     await storeItems(stored);
     const { queryItem } = await import("../mongodb-query-item");
 
@@ -115,7 +143,12 @@ test("returns only the specified item given an item name provided and multiple i
 });
 
 test("returns no items if no stored items match the provided item name in collection", async () => {
-    const stored = createItem("another item", 3, 5, []);
+    const stored = createItem({
+        name: "another item",
+        createTime: 3,
+        output: 5,
+        requirements: [],
+    });
     const expectedItemName = "expected test item 1";
     await storeItems([stored]);
     const { queryItem } = await import("../mongodb-query-item");

--- a/api/src/functions/query-item/domain/__tests__/query-item.test.ts
+++ b/api/src/functions/query-item/domain/__tests__/query-item.test.ts
@@ -34,13 +34,40 @@ test.each([
     ["none received", []],
     [
         "multiple received w/ no farm sizes",
-        [createItem("test 1", 1, 3, []), createItem("test 2", 4, 6, [])],
+        [
+            createItem({
+                name: "test 1",
+                createTime: 1,
+                output: 3,
+                requirements: [],
+            }),
+            createItem({
+                name: "test 2",
+                createTime: 4,
+                output: 6,
+                requirements: [],
+            }),
+        ],
     ],
     [
         "multiple received w/ farm sizes",
         [
-            createItem("test 1", 1, 3, [], 1, 2),
-            createItem("test 2", 4, 6, [], 3, 4),
+            createItem({
+                name: "test 1",
+                createTime: 1,
+                output: 3,
+                requirements: [],
+                width: 1,
+                height: 2,
+            }),
+            createItem({
+                name: "test 2",
+                createTime: 4,
+                output: 6,
+                requirements: [],
+                width: 3,
+                height: 4,
+            }),
         ],
     ],
 ])(

--- a/api/src/functions/query-output/adapters/__tests__/mongodb-output-adapter.ts
+++ b/api/src/functions/query-output/adapters/__tests__/mongodb-output-adapter.ts
@@ -81,15 +81,32 @@ test.each([
     [
         "only relevant item details",
         "only one item stored in database",
-        [createItem(validItemName, 5, 3, [])],
+        [
+            createItem({
+                name: validItemName,
+                createTime: 5,
+                output: 3,
+                requirements: [],
+            }),
+        ],
         [{ createTime: 5, output: 3 }],
     ],
     [
         "only relevant item details",
         "multiple items stored in database",
         [
-            createItem(validItemName, 5, 3, []),
-            createItem("another item", 2, 1, []),
+            createItem({
+                name: validItemName,
+                createTime: 5,
+                output: 3,
+                requirements: [],
+            }),
+            createItem({
+                name: "another item",
+                createTime: 2,
+                output: 1,
+                requirements: [],
+            }),
         ],
         [{ createTime: 5, output: 3 }],
     ],
@@ -97,8 +114,18 @@ test.each([
         "nothing",
         "no relevant items stored in database",
         [
-            createItem("another item", 2, 1, []),
-            createItem("yet another item", 5, 3, []),
+            createItem({
+                name: "another item",
+                createTime: 2,
+                output: 1,
+                requirements: [],
+            }),
+            createItem({
+                name: "yet another item",
+                createTime: 5,
+                output: 3,
+                requirements: [],
+            }),
         ],
         [],
     ],

--- a/api/src/functions/query-requirements/adapters/__tests__/mongodb-requirements-adapter.test.ts
+++ b/api/src/functions/query-requirements/adapters/__tests__/mongodb-requirements-adapter.test.ts
@@ -78,7 +78,12 @@ test("returns an empty array if no items are stored in the items collection", as
 });
 
 test("returns only the specified item if only that item is stored in the items collection", async () => {
-    const stored = createItem(validItemName, 2, 3, []);
+    const stored = createItem({
+        name: validItemName,
+        createTime: 2,
+        output: 3,
+        requirements: [],
+    });
     await storeItems([{ ...stored }]);
     const { queryRequirements } = await import(
         "../mongodb-requirements-adapter"
@@ -94,78 +99,179 @@ test.each([
     [
         "an item with a single requirement and no nested requirements",
         [
-            createItem("required item 1", 1, 2, []),
-            createItem(validItemName, 2, 4, [
-                { name: "required item 1", amount: 4 },
-            ]),
+            createItem({
+                name: "required item 1",
+                createTime: 1,
+                output: 2,
+                requirements: [],
+            }),
+            createItem({
+                name: validItemName,
+                createTime: 2,
+                output: 4,
+                requirements: [{ name: "required item 1", amount: 4 }],
+            }),
         ],
         [
-            createItem("required item 1", 1, 2, []),
-            createItem(validItemName, 2, 4, [
-                { name: "required item 1", amount: 4 },
-            ]),
+            createItem({
+                name: "required item 1",
+                createTime: 1,
+                output: 2,
+                requirements: [],
+            }),
+            createItem({
+                name: validItemName,
+                createTime: 2,
+                output: 4,
+                requirements: [{ name: "required item 1", amount: 4 }],
+            }),
         ],
     ],
     [
         "an item with multiple requirements and no nested requirements",
         [
-            createItem("required item 2", 3, 4, []),
-            createItem("required item 1", 1, 2, []),
-            createItem(validItemName, 2, 4, [
-                { name: "required item 1", amount: 4 },
-                { name: "required item 2", amount: 5 },
-            ]),
+            createItem({
+                name: "required item 2",
+                createTime: 3,
+                output: 4,
+                requirements: [],
+            }),
+            createItem({
+                name: "required item 1",
+                createTime: 1,
+                output: 2,
+                requirements: [],
+            }),
+            createItem({
+                name: validItemName,
+                createTime: 2,
+                output: 4,
+                requirements: [
+                    { name: "required item 1", amount: 4 },
+                    { name: "required item 2", amount: 5 },
+                ],
+            }),
         ],
         [
-            createItem("required item 2", 3, 4, []),
-            createItem("required item 1", 1, 2, []),
-            createItem(validItemName, 2, 4, [
-                { name: "required item 1", amount: 4 },
-                { name: "required item 2", amount: 5 },
-            ]),
+            createItem({
+                name: "required item 2",
+                createTime: 3,
+                output: 4,
+                requirements: [],
+            }),
+            createItem({
+                name: "required item 1",
+                createTime: 1,
+                output: 2,
+                requirements: [],
+            }),
+            createItem({
+                name: validItemName,
+                createTime: 2,
+                output: 4,
+                requirements: [
+                    { name: "required item 1", amount: 4 },
+                    { name: "required item 2", amount: 5 },
+                ],
+            }),
         ],
     ],
     [
         "an item with multiple requirements and other unrelated items stored",
         [
-            createItem("unrelated item", 3, 2, [
-                { name: "required item 1", amount: 2 },
-            ]),
-            createItem("required item 2", 3, 4, []),
-            createItem("required item 1", 1, 2, []),
-            createItem(validItemName, 2, 4, [
-                { name: "required item 1", amount: 4 },
-                { name: "required item 2", amount: 5 },
-            ]),
+            createItem({
+                name: "unrelated item",
+                createTime: 3,
+                output: 2,
+                requirements: [{ name: "required item 1", amount: 2 }],
+            }),
+            createItem({
+                name: "required item 2",
+                createTime: 3,
+                output: 4,
+                requirements: [],
+            }),
+            createItem({
+                name: "required item 1",
+                createTime: 1,
+                output: 2,
+                requirements: [],
+            }),
+            createItem({
+                name: validItemName,
+                createTime: 2,
+                output: 4,
+                requirements: [
+                    { name: "required item 1", amount: 4 },
+                    { name: "required item 2", amount: 5 },
+                ],
+            }),
         ],
         [
-            createItem("required item 2", 3, 4, []),
-            createItem("required item 1", 1, 2, []),
-            createItem(validItemName, 2, 4, [
-                { name: "required item 1", amount: 4 },
-                { name: "required item 2", amount: 5 },
-            ]),
+            createItem({
+                name: "required item 2",
+                createTime: 3,
+                output: 4,
+                requirements: [],
+            }),
+            createItem({
+                name: "required item 1",
+                createTime: 1,
+                output: 2,
+                requirements: [],
+            }),
+            createItem({
+                name: validItemName,
+                createTime: 2,
+                output: 4,
+                requirements: [
+                    { name: "required item 1", amount: 4 },
+                    { name: "required item 2", amount: 5 },
+                ],
+            }),
         ],
     ],
     [
         "an item with multiple nested requirements",
         [
-            createItem("required item 2", 3, 4, []),
-            createItem("required item 1", 1, 2, [
-                { name: "required item 2", amount: 5 },
-            ]),
-            createItem(validItemName, 2, 4, [
-                { name: "required item 1", amount: 4 },
-            ]),
+            createItem({
+                name: "required item 2",
+                createTime: 3,
+                output: 4,
+                requirements: [],
+            }),
+            createItem({
+                name: "required item 1",
+                createTime: 1,
+                output: 2,
+                requirements: [{ name: "required item 2", amount: 5 }],
+            }),
+            createItem({
+                name: validItemName,
+                createTime: 2,
+                output: 4,
+                requirements: [{ name: "required item 1", amount: 4 }],
+            }),
         ],
         [
-            createItem("required item 2", 3, 4, []),
-            createItem("required item 1", 1, 2, [
-                { name: "required item 2", amount: 5 },
-            ]),
-            createItem(validItemName, 2, 4, [
-                { name: "required item 1", amount: 4 },
-            ]),
+            createItem({
+                name: "required item 2",
+                createTime: 3,
+                output: 4,
+                requirements: [],
+            }),
+            createItem({
+                name: "required item 1",
+                createTime: 1,
+                output: 2,
+                requirements: [{ name: "required item 2", amount: 5 }],
+            }),
+            createItem({
+                name: validItemName,
+                createTime: 2,
+                output: 4,
+                requirements: [{ name: "required item 1", amount: 4 }],
+            }),
         ],
     ],
 ])(

--- a/api/src/functions/query-requirements/domain/__tests__/query-requirements.test.ts
+++ b/api/src/functions/query-requirements/domain/__tests__/query-requirements.test.ts
@@ -44,7 +44,12 @@ test.each([
 );
 
 test("calls the database adapter to get the requirements given valid input", async () => {
-    const item = createItem(validItemName, 2, 3, []);
+    const item = createItem({
+        name: validItemName,
+        createTime: 2,
+        output: 3,
+        requirements: [],
+    });
     mockMongoDBQueryRequirements.mockResolvedValue([item]);
 
     await queryRequirements(validItemName, validWorkers);
@@ -64,7 +69,12 @@ test("throws an error if no requirements are returned at all (item does not exis
 });
 
 test("throws an error if the provided item details are not returned from DB", async () => {
-    const item = createItem("another item", 2, 3, []);
+    const item = createItem({
+        name: "another item",
+        createTime: 2,
+        output: 3,
+        requirements: [],
+    });
     mockMongoDBQueryRequirements.mockResolvedValue([item]);
     const expectedError = new Error("Unknown item provided");
 
@@ -75,7 +85,12 @@ test("throws an error if the provided item details are not returned from DB", as
 });
 
 test("returns an empty array if the provided item has no requirements", async () => {
-    const item = createItem(validItemName, 2, 3, []);
+    const item = createItem({
+        name: validItemName,
+        createTime: 2,
+        output: 3,
+        requirements: [],
+    });
     mockMongoDBQueryRequirements.mockResolvedValue([item]);
 
     const actual = await queryRequirements(validItemName, validWorkers);
@@ -84,9 +99,12 @@ test("returns an empty array if the provided item has no requirements", async ()
 });
 
 test("throws an error if provided item requires an item that does not exist in database", async () => {
-    const item = createItem(validItemName, 2, 3, [
-        { name: "unknown item", amount: 4 },
-    ]);
+    const item = createItem({
+        name: validItemName,
+        createTime: 2,
+        output: 3,
+        requirements: [{ name: "unknown item", amount: 4 }],
+    });
     mockMongoDBQueryRequirements.mockResolvedValue([item]);
     const expectedError = new Error("Internal server error");
 
@@ -97,10 +115,18 @@ test("throws an error if provided item requires an item that does not exist in d
 });
 
 test("returns requirement given item with a single requirement and no nested requirements", async () => {
-    const requiredItem = createItem("required item", 3, 4, []);
-    const item = createItem(validItemName, 2, 3, [
-        { name: requiredItem.name, amount: 4 },
-    ]);
+    const requiredItem = createItem({
+        name: "required item",
+        createTime: 3,
+        output: 4,
+        requirements: [],
+    });
+    const item = createItem({
+        name: validItemName,
+        createTime: 2,
+        output: 3,
+        requirements: [{ name: requiredItem.name, amount: 4 }],
+    });
     mockMongoDBQueryRequirements.mockResolvedValue([item, requiredItem]);
 
     const actual = await queryRequirements(validItemName, validWorkers);
@@ -111,12 +137,27 @@ test("returns requirement given item with a single requirement and no nested req
 });
 
 test("returns requirements given item with multiple requirements and no nested requirements", async () => {
-    const requiredItem1 = createItem("required item 1", 3, 4, []);
-    const requiredItem2 = createItem("required item 2", 4, 2, []);
-    const item = createItem(validItemName, 2, 3, [
-        { name: requiredItem1.name, amount: 4 },
-        { name: requiredItem2.name, amount: 6 },
-    ]);
+    const requiredItem1 = createItem({
+        name: "required item 1",
+        createTime: 3,
+        output: 4,
+        requirements: [],
+    });
+    const requiredItem2 = createItem({
+        name: "required item 2",
+        createTime: 4,
+        output: 2,
+        requirements: [],
+    });
+    const item = createItem({
+        name: validItemName,
+        createTime: 2,
+        output: 3,
+        requirements: [
+            { name: requiredItem1.name, amount: 4 },
+            { name: requiredItem2.name, amount: 6 },
+        ],
+    });
     mockMongoDBQueryRequirements.mockResolvedValue([
         item,
         requiredItem1,
@@ -133,13 +174,24 @@ test("returns requirements given item with multiple requirements and no nested r
 });
 
 test("returns requirements given item with single nested requirement", async () => {
-    const requiredItem2 = createItem("required item 2", 4, 2, []);
-    const requiredItem1 = createItem("required item 1", 3, 4, [
-        { name: requiredItem2.name, amount: 6 },
-    ]);
-    const item = createItem(validItemName, 2, 3, [
-        { name: requiredItem1.name, amount: 4 },
-    ]);
+    const requiredItem2 = createItem({
+        name: "required item 2",
+        createTime: 4,
+        output: 2,
+        requirements: [],
+    });
+    const requiredItem1 = createItem({
+        name: "required item 1",
+        createTime: 3,
+        output: 4,
+        requirements: [{ name: requiredItem2.name, amount: 6 }],
+    });
+    const item = createItem({
+        name: validItemName,
+        createTime: 2,
+        output: 3,
+        requirements: [{ name: requiredItem1.name, amount: 4 }],
+    });
     mockMongoDBQueryRequirements.mockResolvedValue([
         item,
         requiredItem1,
@@ -156,15 +208,33 @@ test("returns requirements given item with single nested requirement", async () 
 });
 
 test("returns requirements given item with multiple different nested requirements", async () => {
-    const requiredItem3 = createItem("required item 3", 4, 2, []);
-    const requiredItem2 = createItem("required item 2", 4, 2, []);
-    const requiredItem1 = createItem("required item 1", 3, 4, [
-        { name: requiredItem2.name, amount: 6 },
-        { name: requiredItem3.name, amount: 4 },
-    ]);
-    const item = createItem(validItemName, 2, 3, [
-        { name: requiredItem1.name, amount: 4 },
-    ]);
+    const requiredItem3 = createItem({
+        name: "required item 3",
+        createTime: 4,
+        output: 2,
+        requirements: [],
+    });
+    const requiredItem2 = createItem({
+        name: "required item 2",
+        createTime: 4,
+        output: 2,
+        requirements: [],
+    });
+    const requiredItem1 = createItem({
+        name: "required item 1",
+        createTime: 3,
+        output: 4,
+        requirements: [
+            { name: requiredItem2.name, amount: 6 },
+            { name: requiredItem3.name, amount: 4 },
+        ],
+    });
+    const item = createItem({
+        name: validItemName,
+        createTime: 2,
+        output: 3,
+        requirements: [{ name: requiredItem1.name, amount: 4 }],
+    });
     mockMongoDBQueryRequirements.mockResolvedValue([
         item,
         requiredItem1,
@@ -183,16 +253,36 @@ test("returns requirements given item with multiple different nested requirement
 });
 
 test("returns combined requirements given item with multiple nested requirements with common requirement", async () => {
-    const requiredItem3 = createItem("required item 3", 4, 2, []);
-    const requiredItem2 = createItem("required item 2", 4, 2, []);
-    const requiredItem1 = createItem("required item 1", 3, 4, [
-        { name: requiredItem2.name, amount: 6 },
-        { name: requiredItem3.name, amount: 4 },
-    ]);
-    const item = createItem(validItemName, 2, 3, [
-        { name: requiredItem1.name, amount: 4 },
-        { name: requiredItem3.name, amount: 2 },
-    ]);
+    const requiredItem3 = createItem({
+        name: "required item 3",
+        createTime: 4,
+        output: 2,
+        requirements: [],
+    });
+    const requiredItem2 = createItem({
+        name: "required item 2",
+        createTime: 4,
+        output: 2,
+        requirements: [],
+    });
+    const requiredItem1 = createItem({
+        name: "required item 1",
+        createTime: 3,
+        output: 4,
+        requirements: [
+            { name: requiredItem2.name, amount: 6 },
+            { name: requiredItem3.name, amount: 4 },
+        ],
+    });
+    const item = createItem({
+        name: validItemName,
+        createTime: 2,
+        output: 3,
+        requirements: [
+            { name: requiredItem1.name, amount: 4 },
+            { name: requiredItem3.name, amount: 2 },
+        ],
+    });
     mockMongoDBQueryRequirements.mockResolvedValue([
         item,
         requiredItem1,

--- a/api/src/json/items.json
+++ b/api/src/json/items.json
@@ -3,7 +3,9 @@
         "name": "Berry",
         "createTime": 8.5,
         "output": 1,
-        "requires": []
+        "requires": [],
+        "minimumTool": "none",
+        "maximumTool": "none"
     },
     {
         "name": "Berry Meal",
@@ -14,13 +16,17 @@
                 "name": "Berry",
                 "amount": 8
             }
-        ]
+        ],
+        "minimumTool": "none",
+        "maximumTool": "none"
     },
     {
         "name": "Wheat",
         "createTime": 1440,
         "output": 100,
         "requires": [],
+        "minimumTool": "none",
+        "maximumTool": "none",
         "size": {
             "width": 10,
             "height": 10
@@ -31,6 +37,8 @@
         "createTime": 720,
         "output": 44,
         "requires": [],
+        "minimumTool": "none",
+        "maximumTool": "none",
         "size": {
             "width": 3,
             "height": 33
@@ -45,13 +53,17 @@
                 "name": "Log",
                 "amount": 1
             }
-        ]
+        ],
+        "minimumTool": "none",
+        "maximumTool": "steel"
     },
     {
         "name": "Clay",
         "createTime": 20,
         "output": 1,
-        "requires": []
+        "requires": [],
+        "minimumTool": "none",
+        "maximumTool": "steel"
     },
     {
         "name": "Empty Pot",
@@ -66,7 +78,9 @@
                 "name": "Planks",
                 "amount": 1
             }
-        ]
+        ],
+        "minimumTool": "none",
+        "maximumTool": "copper"
     },
     {
         "name": "Pot of Flour",
@@ -81,7 +95,9 @@
                 "name": "Empty Pot",
                 "amount": 1
             }
-        ]
+        ],
+        "minimumTool": "none",
+        "maximumTool": "none"
     },
     {
         "name": "Firewood",
@@ -92,7 +108,9 @@
                 "name": "Planks",
                 "amount": 1
             }
-        ]
+        ],
+        "minimumTool": "none",
+        "maximumTool": "steel"
     },
     {
         "name": "Pot of Water",
@@ -103,7 +121,9 @@
                 "name": "Empty Pot",
                 "amount": 1
             }
-        ]
+        ],
+        "minimumTool": "none",
+        "maximumTool": "none"
     },
     {
         "name": "Bread",
@@ -122,6 +142,8 @@
                 "name": "Pot of Water",
                 "amount": 1
             }
-        ]
+        ],
+        "minimumTool": "none",
+        "maximumTool": "steel"
     }
 ]

--- a/api/src/json/schemas/items.json
+++ b/api/src/json/schemas/items.json
@@ -44,6 +44,12 @@
                     "additionalProperties": false
                 }
             },
+            "minimumTool": {
+                "$ref": "#/definitions/tools"
+            },
+            "maximumTool": {
+                "$ref": "#/definitions/tools"
+            },
             "size": {
                 "description": "Optimal size of crafting area, only provided for farms",
                 "type": "object",
@@ -63,7 +69,30 @@
                 "additionalProperties": false
             }
         },
-        "required": ["name", "createTime", "output", "requires"],
+        "required": [
+            "name",
+            "createTime",
+            "output",
+            "requires",
+            "minimumTool",
+            "maximumTool"
+        ],
         "additionalProperties": false
+    },
+    "definitions": {
+        "tools": {
+            "title": "Tools",
+            "description": "A level of tool that can be used to create items in Colony Survival",
+            "type": "string",
+            "tsEnumNames": [
+                "none",
+                "stone",
+                "copper",
+                "iron",
+                "bronze",
+                "steel"
+            ],
+            "enum": ["none", "stone", "copper", "iron", "bronze", "steel"]
+        }
     }
 }

--- a/api/test/item-utils.ts
+++ b/api/test/item-utils.ts
@@ -7,34 +7,25 @@ function createRequirements(name: string, amount: number): Requirement {
     };
 }
 
-function createItem(
-    name: string,
-    createTime: number,
-    output: number,
-    requirements: Requirements,
-    minimumTool: Tools,
-    maximumTool: Tools
-): Item;
-function createItem(
-    name: string,
-    createTime: number,
-    output: number,
-    requirements: Requirements,
-    minimumTool: Tools,
-    maximumTool: Tools,
-    width: number,
-    height: number
-): Item;
-function createItem(
-    name: string,
-    createTime: number,
-    output: number,
-    requirements: Requirements,
-    minimumTool: Tools = Tools.none,
-    maximumTool: Tools = Tools.none,
-    width?: number,
-    height?: number
-): Item {
+function createItem({
+    name,
+    createTime,
+    output,
+    requirements,
+    minimumTool = Tools.none,
+    maximumTool = Tools.none,
+    width,
+    height,
+}: {
+    name: string;
+    createTime: number;
+    output: number;
+    requirements: Requirements;
+    minimumTool?: Tools;
+    maximumTool?: Tools;
+    width?: number;
+    height?: number;
+}): Item {
     return {
         name,
         createTime,

--- a/api/test/item-utils.ts
+++ b/api/test/item-utils.ts
@@ -1,4 +1,4 @@
-import type { Item, Requirement, Requirements } from "../src/types";
+import { Item, Requirement, Requirements, Tools } from "../src/types";
 
 function createRequirements(name: string, amount: number): Requirement {
     return {
@@ -11,13 +11,17 @@ function createItem(
     name: string,
     createTime: number,
     output: number,
-    requirements: Requirements
+    requirements: Requirements,
+    minimumTool: Tools,
+    maximumTool: Tools
 ): Item;
 function createItem(
     name: string,
     createTime: number,
     output: number,
     requirements: Requirements,
+    minimumTool: Tools,
+    maximumTool: Tools,
     width: number,
     height: number
 ): Item;
@@ -26,6 +30,8 @@ function createItem(
     createTime: number,
     output: number,
     requirements: Requirements,
+    minimumTool: Tools = Tools.none,
+    maximumTool: Tools = Tools.none,
     width?: number,
     height?: number
 ): Item {
@@ -35,6 +41,8 @@ function createItem(
         output,
         requires: requirements,
         ...(width && height ? { size: { width, height } } : {}),
+        minimumTool,
+        maximumTool,
     };
 }
 


### PR DESCRIPTION
Resolves #130 

# What

Updated API infra to ensure add item lambda is updated prior to updating seed JSON file in S3
Updated JSON item schema to require a min and max tool for each item in static list of items
- Including updates to supporting validation scripts to validate the static json adheres to the new schema

Updated Add Item lambda/resolver to:
- Validate provided JSON seed file against items schema
- Validate that each provided item has a valid set of min/max tools (Minimum tool cannot be higher in hierarchy than maximum tool)

# Why

To enable the support of tool modifiers into the calculator
- Different items have different applicable tools, so we need to know what the min/max tools are

S3 seed object - add item lambda requirement:
- To prevent the S3 event from hitting the lambda before changes are added to support new JSON properties (min/max tools in this case)