### PR TITLE
feat: 137 optimal output support tool modifier

### DIFF
--- a/api/src/common/modifiers/index.ts
+++ b/api/src/common/modifiers/index.ts
@@ -1,0 +1,12 @@
+import { Tools } from "../../types";
+
+const ToolModifierValues: Readonly<Record<Tools, number>> = {
+    [Tools.none]: 1,
+    [Tools.stone]: 2,
+    [Tools.copper]: 4,
+    [Tools.iron]: 5.3,
+    [Tools.bronze]: 6.15,
+    [Tools.steel]: 8,
+};
+
+export { ToolModifierValues };

--- a/api/src/functions/add-item/domain/add-item.ts
+++ b/api/src/functions/add-item/domain/add-item.ts
@@ -1,22 +1,14 @@
 import Ajv from "ajv";
 
 import ItemsSchema from "../../../json/schemas/items.json";
-import { Items, Tools } from "../../../types";
+import { Items } from "../../../types";
 import { storeItem } from "../adapters/store-item";
 import type { AddItemPrimaryPort } from "../interfaces/add-item-primary-port";
+import { ToolModifierValues } from "../../../common/modifiers";
 
 const ajv = new Ajv();
 ajv.addKeyword("tsEnumNames");
 const validateItems = ajv.compile<Items>(ItemsSchema);
-
-const toolValues = new Map<Tools, number>([
-    [Tools.none, 1],
-    [Tools.stone, 2],
-    [Tools.copper, 4],
-    [Tools.iron, 5.3],
-    [Tools.bronze, 6.15],
-    [Tools.steel, 8],
-]);
 
 function parseItems(input: string): Items {
     try {
@@ -49,13 +41,10 @@ function validateRequirements(items: Items): void {
 
 function validateTools(items: Items): void {
     for (const item of items) {
-        const minToolValue = toolValues.get(item.minimumTool);
-        const maxToolValue = toolValues.get(item.maximumTool);
-        if (!minToolValue || !maxToolValue) {
-            throw new Error(
-                `Unable to validate item: ${item.name} tools, unknown hierarchy for tools: ${item.minimumTool}/${item.maximumTool}`
-            );
-        } else if (minToolValue > maxToolValue) {
+        ToolModifierValues;
+        const minToolValue = ToolModifierValues[item.minimumTool];
+        const maxToolValue = ToolModifierValues[item.maximumTool];
+        if (minToolValue > maxToolValue) {
             throw new Error(
                 `Invalid item: ${item.name}, minimum tool is better than maximum tool`
             );

--- a/api/src/functions/query-output/adapters/__tests__/mongodb-output-adapter.ts
+++ b/api/src/functions/query-output/adapters/__tests__/mongodb-output-adapter.ts
@@ -14,7 +14,7 @@ jest.mock("@colony-survival-calculator/mongodb-client", async () => {
 });
 
 import mockClient from "@colony-survival-calculator/mongodb-client";
-import type { Items } from "../../../../types";
+import { Items, Tools } from "../../../../types";
 import type { ItemOutputDetails } from "../../interfaces/output-database-port";
 
 const validItemName = "test item";
@@ -87,9 +87,18 @@ test.each([
                 createTime: 5,
                 output: 3,
                 requirements: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.copper,
             }),
         ],
-        [{ createTime: 5, output: 3 }],
+        [
+            {
+                createTime: 5,
+                output: 3,
+                minimumTool: Tools.none,
+                maximumTool: Tools.copper,
+            },
+        ],
     ],
     [
         "only relevant item details",
@@ -100,15 +109,26 @@ test.each([
                 createTime: 5,
                 output: 3,
                 requirements: [],
+                minimumTool: Tools.copper,
+                maximumTool: Tools.steel,
             }),
             createItem({
                 name: "another item",
                 createTime: 2,
                 output: 1,
                 requirements: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.steel,
             }),
         ],
-        [{ createTime: 5, output: 3 }],
+        [
+            {
+                createTime: 5,
+                output: 3,
+                minimumTool: Tools.copper,
+                maximumTool: Tools.steel,
+            },
+        ],
     ],
     [
         "nothing",

--- a/api/src/functions/query-output/adapters/mongodb-output-adapter.ts
+++ b/api/src/functions/query-output/adapters/mongodb-output-adapter.ts
@@ -22,7 +22,13 @@ const queryOutputDetails: OutputDatabasePort = async (name) => {
 
     return collection
         .find<Item>({ name })
-        .project<ItemOutputDetails>({ _id: 0, createTime: 1, output: 1 })
+        .project<ItemOutputDetails>({
+            _id: 0,
+            createTime: 1,
+            output: 1,
+            minimumTool: 1,
+            maximumTool: 1,
+        })
         .toArray();
 };
 

--- a/api/src/functions/query-output/domain/__tests__/output-calculator.test.ts
+++ b/api/src/functions/query-output/domain/__tests__/output-calculator.test.ts
@@ -181,4 +181,19 @@ describe("tool modifiers", () => {
             expect(actual).toBeCloseTo(expected);
         }
     );
+
+    test("returns output for max applicable tool for item if provided tool is better than max", async () => {
+        const expected = 1800;
+        const details = createItemOutputDetails(2, 3, Tools.none, Tools.copper);
+        mockQueryOutputDetails.mockResolvedValue([details]);
+
+        const actual = await calculateOutput(
+            validItemName,
+            validWorkers,
+            OutputUnit.MINUTES,
+            Tools.steel
+        );
+
+        expect(actual).toBeCloseTo(expected);
+    });
 });

--- a/api/src/functions/query-output/domain/__tests__/output-calculator.test.ts
+++ b/api/src/functions/query-output/domain/__tests__/output-calculator.test.ts
@@ -152,4 +152,33 @@ describe("tool modifiers", () => {
             ).rejects.toThrow(expectedError);
         }
     );
+
+    test.each([
+        [Tools.none, 450],
+        [Tools.stone, 900],
+        [Tools.copper, 1800],
+        [Tools.iron, 2385],
+        [Tools.bronze, 2767.5],
+        [Tools.steel, 3600],
+    ])(
+        "returns the expected output for item given applicable tool: %s",
+        async (provided: Tools, expected: number) => {
+            const details = createItemOutputDetails(
+                2,
+                3,
+                Tools.none,
+                Tools.steel
+            );
+            mockQueryOutputDetails.mockResolvedValue([details]);
+
+            const actual = await calculateOutput(
+                validItemName,
+                validWorkers,
+                OutputUnit.MINUTES,
+                provided
+            );
+
+            expect(actual).toBeCloseTo(expected);
+        }
+    );
 });

--- a/api/src/functions/query-output/domain/output-calculator.ts
+++ b/api/src/functions/query-output/domain/output-calculator.ts
@@ -1,3 +1,4 @@
+import { Tools } from "../../../types";
 import { queryOutputDetails } from "../adapters/mongodb-output-adapter";
 import type { ItemOutputDetails } from "../interfaces/output-database-port";
 import type { QueryOutputPrimaryPort } from "../interfaces/query-output-primary-port";
@@ -8,7 +9,28 @@ const INVALID_ITEM_NAME_ERROR =
 const INVALID_WORKERS_ERROR =
     "Invalid number of workers provided, must be a positive number";
 const UNKNOWN_ITEM_ERROR = "Unknown item provided";
+const TOOL_LEVEL_ERROR_PREFIX =
+    "Unable to create item with available tools, minimum tool is:";
 const INTERNAL_SERVER_ERROR = "Internal server error";
+
+const toolValues = new Map<Tools, number>([
+    [Tools.none, 1],
+    [Tools.stone, 2],
+    [Tools.copper, 4],
+    [Tools.iron, 5.3],
+    [Tools.bronze, 6.15],
+    [Tools.steel, 8],
+]);
+
+function isAvailableToolSufficient(minimum: Tools, available: Tools): boolean {
+    const minimumToolModifier = toolValues.get(minimum);
+    const availableToolModifier = toolValues.get(available);
+    if (!minimumToolModifier || !availableToolModifier) {
+        throw new Error(INTERNAL_SERVER_ERROR);
+    }
+
+    return availableToolModifier > minimumToolModifier;
+}
 
 async function getItemOutputDetails(
     name: string
@@ -25,7 +47,12 @@ async function getItemOutputDetails(
     }
 }
 
-const calculateOutput: QueryOutputPrimaryPort = async (name, workers, unit) => {
+const calculateOutput: QueryOutputPrimaryPort = async (
+    name,
+    workers,
+    unit,
+    maxAvailableTool
+) => {
     if (name === "") {
         throw new Error(INVALID_ITEM_NAME_ERROR);
     }
@@ -37,6 +64,18 @@ const calculateOutput: QueryOutputPrimaryPort = async (name, workers, unit) => {
     const outputDetails = await getItemOutputDetails(name);
     if (!outputDetails) {
         throw new Error(UNKNOWN_ITEM_ERROR);
+    }
+
+    if (maxAvailableTool) {
+        const sufficientTool = isAvailableToolSufficient(
+            outputDetails.minimumTool,
+            maxAvailableTool
+        );
+        if (!sufficientTool) {
+            throw new Error(
+                `${TOOL_LEVEL_ERROR_PREFIX} ${outputDetails.minimumTool}`
+            );
+        }
     }
 
     const outputPerSecond = outputDetails.output / outputDetails.createTime;

--- a/api/src/functions/query-output/domain/output-calculator.ts
+++ b/api/src/functions/query-output/domain/output-calculator.ts
@@ -1,3 +1,4 @@
+import { ToolModifierValues } from "../../../common/modifiers";
 import { Tools } from "../../../types";
 import { queryOutputDetails } from "../adapters/mongodb-output-adapter";
 import type { ItemOutputDetails } from "../interfaces/output-database-port";
@@ -12,15 +13,6 @@ const UNKNOWN_ITEM_ERROR = "Unknown item provided";
 const TOOL_LEVEL_ERROR_PREFIX =
     "Unable to create item with available tools, minimum tool is:";
 const INTERNAL_SERVER_ERROR = "Internal server error";
-
-const toolValues = new Map<Tools, number>([
-    [Tools.none, 1],
-    [Tools.stone, 2],
-    [Tools.copper, 4],
-    [Tools.iron, 5.3],
-    [Tools.bronze, 6.15],
-    [Tools.steel, 8],
-]);
 
 async function getItemOutputDetails(
     name: string
@@ -38,22 +30,14 @@ async function getItemOutputDetails(
 }
 
 function isAvailableToolSufficient(minimum: Tools, available: Tools): boolean {
-    const minimumToolModifier = toolValues.get(minimum);
-    const availableToolModifier = toolValues.get(available);
-    if (!minimumToolModifier || !availableToolModifier) {
-        throw new Error(INTERNAL_SERVER_ERROR);
-    }
-
+    const minimumToolModifier = ToolModifierValues[minimum];
+    const availableToolModifier = ToolModifierValues[available];
     return availableToolModifier >= minimumToolModifier;
 }
 
 function getMaxToolModifier(maximum: Tools, available: Tools): number {
-    const maximumToolModifier = toolValues.get(maximum);
-    const availableToolModifier = toolValues.get(available);
-    if (!maximumToolModifier || !availableToolModifier) {
-        throw new Error(INTERNAL_SERVER_ERROR);
-    }
-
+    const maximumToolModifier = ToolModifierValues[maximum];
+    const availableToolModifier = ToolModifierValues[available];
     return availableToolModifier > maximumToolModifier
         ? maximumToolModifier
         : availableToolModifier;

--- a/api/src/functions/query-output/domain/output-calculator.ts
+++ b/api/src/functions/query-output/domain/output-calculator.ts
@@ -51,13 +51,16 @@ function isAvailableToolSufficient(minimum: Tools, available: Tools): boolean {
     return availableToolModifier >= minimumToolModifier;
 }
 
-function getMaxToolModifier(available: Tools): number {
+function getMaxToolModifier(maximum: Tools, available: Tools): number {
+    const maximumToolModifier = toolValues.get(maximum);
     const availableToolModifier = toolValues.get(available);
-    if (!availableToolModifier) {
+    if (!maximumToolModifier || !availableToolModifier) {
         throw new Error(INTERNAL_SERVER_ERROR);
     }
 
-    return availableToolModifier;
+    return availableToolModifier > maximumToolModifier
+        ? maximumToolModifier
+        : availableToolModifier;
 }
 
 function calculateOptimalOutput(
@@ -103,7 +106,10 @@ const calculateOutput: QueryOutputPrimaryPort = async (
             );
         }
 
-        const toolModifier = getMaxToolModifier(maxAvailableTool);
+        const toolModifier = getMaxToolModifier(
+            outputDetails.maximumTool,
+            maxAvailableTool
+        );
         return calculateOptimalOutput(
             outputDetails.output,
             outputDetails.createTime,

--- a/api/src/functions/query-output/handler.ts
+++ b/api/src/functions/query-output/handler.ts
@@ -1,11 +1,27 @@
-import type { QueryOutputArgs } from "../../graphql/schema";
+import type { QueryOutputArgs, Tools } from "../../graphql/schema";
 import type { GraphQLEventHandler } from "../../interfaces/GraphQLEventHandler";
+import { Tools as SchemaTools } from "../../types";
 import { calculateOutput } from "./domain/output-calculator";
 import { OutputUnit } from "./interfaces/query-output-primary-port";
 
+const toolMap: Record<Tools, SchemaTools> = {
+    NONE: SchemaTools.none,
+    STONE: SchemaTools.stone,
+    COPPER: SchemaTools.copper,
+    IRON: SchemaTools.iron,
+    BRONZE: SchemaTools.bronze,
+    STEEL: SchemaTools.steel,
+};
+
 const handler: GraphQLEventHandler<QueryOutputArgs, number> = async (event) => {
-    const { name, workers, unit } = event.arguments;
-    return calculateOutput(name, workers, OutputUnit[unit]);
+    const { name, workers, unit, maxAvailableTool } = event.arguments;
+
+    return calculateOutput(
+        name,
+        workers,
+        OutputUnit[unit],
+        maxAvailableTool ? toolMap[maxAvailableTool] : undefined
+    );
 };
 
 export { handler };

--- a/api/src/functions/query-output/interfaces/output-database-port.ts
+++ b/api/src/functions/query-output/interfaces/output-database-port.ts
@@ -1,6 +1,9 @@
 import type { Item } from "../../../types";
 
-type ItemOutputDetails = Pick<Item, "createTime" | "output">;
+type ItemOutputDetails = Pick<
+    Item,
+    "createTime" | "output" | "minimumTool" | "maximumTool"
+>;
 
 interface OutputDatabasePort {
     (name: string): Promise<ItemOutputDetails[]>;

--- a/api/src/functions/query-output/interfaces/query-output-primary-port.ts
+++ b/api/src/functions/query-output/interfaces/query-output-primary-port.ts
@@ -1,10 +1,17 @@
+import { Tools } from "../../../types";
+
 enum OutputUnit {
     GAME_DAYS = "GAME_DAYS",
     MINUTES = "MINUTES",
 }
 
 interface QueryOutputPrimaryPort {
-    (name: string, workers: number, unit: OutputUnit): Promise<number>;
+    (
+        name: string,
+        workers: number,
+        unit: OutputUnit,
+        maxAvailableTool?: Tools
+    ): Promise<number>;
 }
 
 export { OutputUnit, QueryOutputPrimaryPort };

--- a/api/src/graphql/schema.graphql
+++ b/api/src/graphql/schema.graphql
@@ -20,10 +20,24 @@ enum OutputUnit {
     GAME_DAYS
 }
 
+enum Tools {
+    NONE
+    STONE
+    COPPER
+    IRON
+    BRONZE
+    STEEL
+}
+
 type Query {
     item(name: ID): [Item!]!
     requirement(name: ID!, workers: Int!): [Requirement!]!
-    output(name: ID!, workers: Int!, unit: OutputUnit!): Float!
+    output(
+        name: ID!
+        workers: Int!
+        unit: OutputUnit!
+        maxAvailableTool: Tools
+    ): Float!
 }
 
 schema {


### PR DESCRIPTION
Resolves #137 

# What

Updated output query resolver to allow providing a tool as input. The tool is used to modify the optimal output if it can be used.
- Optional, if no tool is provided, then it defaults to no modifier (Not a breaking change)

Extracted tool modifier values out of add item lambda to ensure consistency across the various lambda's that will use these modifier values

# Why

To represent the effect that tools inside the game can have on the production output of a given worker. 
- Once supported by requirements query resolver, it will enable the selection of tools on the UI