### PR TITLE
feat: 139 requirements query support tool modifiers

### DIFF
--- a/api/src/common/modifiers/index.ts
+++ b/api/src/common/modifiers/index.ts
@@ -15,4 +15,12 @@ function isAvailableToolSufficient(minimum: Tools, available: Tools): boolean {
     return availableToolModifier >= minimumToolModifier;
 }
 
-export { ToolModifierValues, isAvailableToolSufficient };
+function getMaxToolModifier(maximum: Tools, available: Tools): number {
+    const maximumToolModifier = ToolModifierValues[maximum];
+    const availableToolModifier = ToolModifierValues[available];
+    return availableToolModifier > maximumToolModifier
+        ? maximumToolModifier
+        : availableToolModifier;
+}
+
+export { ToolModifierValues, isAvailableToolSufficient, getMaxToolModifier };

--- a/api/src/common/modifiers/index.ts
+++ b/api/src/common/modifiers/index.ts
@@ -9,4 +9,10 @@ const ToolModifierValues: Readonly<Record<Tools, number>> = {
     [Tools.steel]: 8,
 };
 
-export { ToolModifierValues };
+function isAvailableToolSufficient(minimum: Tools, available: Tools): boolean {
+    const minimumToolModifier = ToolModifierValues[minimum];
+    const availableToolModifier = ToolModifierValues[available];
+    return availableToolModifier >= minimumToolModifier;
+}
+
+export { ToolModifierValues, isAvailableToolSufficient };

--- a/api/src/common/modifiers/index.ts
+++ b/api/src/common/modifiers/index.ts
@@ -1,21 +1,37 @@
-import { Tools } from "../../types";
+import { Tools as GraphQLSchemaTools } from "../../graphql/schema";
+import { Tools as JSONSchemaTools } from "../../types";
 
-const ToolModifierValues: Readonly<Record<Tools, number>> = {
-    [Tools.none]: 1,
-    [Tools.stone]: 2,
-    [Tools.copper]: 4,
-    [Tools.iron]: 5.3,
-    [Tools.bronze]: 6.15,
-    [Tools.steel]: 8,
+const ToolModifierValues: Readonly<Record<JSONSchemaTools, number>> = {
+    [JSONSchemaTools.none]: 1,
+    [JSONSchemaTools.stone]: 2,
+    [JSONSchemaTools.copper]: 4,
+    [JSONSchemaTools.iron]: 5.3,
+    [JSONSchemaTools.bronze]: 6.15,
+    [JSONSchemaTools.steel]: 8,
 };
 
-function isAvailableToolSufficient(minimum: Tools, available: Tools): boolean {
+const ToolSchemaMap: Record<GraphQLSchemaTools, JSONSchemaTools> = {
+    NONE: JSONSchemaTools.none,
+    STONE: JSONSchemaTools.stone,
+    COPPER: JSONSchemaTools.copper,
+    IRON: JSONSchemaTools.iron,
+    BRONZE: JSONSchemaTools.bronze,
+    STEEL: JSONSchemaTools.steel,
+};
+
+function isAvailableToolSufficient(
+    minimum: JSONSchemaTools,
+    available: JSONSchemaTools
+): boolean {
     const minimumToolModifier = ToolModifierValues[minimum];
     const availableToolModifier = ToolModifierValues[available];
     return availableToolModifier >= minimumToolModifier;
 }
 
-function getMaxToolModifier(maximum: Tools, available: Tools): number {
+function getMaxToolModifier(
+    maximum: JSONSchemaTools,
+    available: JSONSchemaTools
+): number {
     const maximumToolModifier = ToolModifierValues[maximum];
     const availableToolModifier = ToolModifierValues[available];
     return availableToolModifier > maximumToolModifier
@@ -23,4 +39,9 @@ function getMaxToolModifier(maximum: Tools, available: Tools): number {
         : availableToolModifier;
 }
 
-export { ToolModifierValues, isAvailableToolSufficient, getMaxToolModifier };
+export {
+    ToolSchemaMap,
+    ToolModifierValues,
+    isAvailableToolSufficient,
+    getMaxToolModifier,
+};

--- a/api/src/functions/query-output/domain/__tests__/output-calculator.test.ts
+++ b/api/src/functions/query-output/domain/__tests__/output-calculator.test.ts
@@ -124,7 +124,7 @@ test.each([
     }
 );
 
-describe("tool modifiers", () => {
+describe("handles tool modifiers", () => {
     test.each([
         ["stone min, none provided", Tools.stone, Tools.none],
         ["copper min, stone provided", Tools.copper, Tools.stone],
@@ -136,7 +136,6 @@ describe("tool modifiers", () => {
         async (_: string, minimum: Tools, provided: Tools) => {
             const details = createItemOutputDetails(2, 3, minimum, Tools.steel);
             mockQueryOutputDetails.mockResolvedValue([details]);
-
             const expectedError = new Error(
                 `Unable to create item with available tools, minimum tool is: ${minimum.toLowerCase()}`
             );

--- a/api/src/functions/query-output/domain/output-calculator.ts
+++ b/api/src/functions/query-output/domain/output-calculator.ts
@@ -1,5 +1,5 @@
 import {
-    ToolModifierValues,
+    getMaxToolModifier,
     isAvailableToolSufficient,
 } from "../../../common/modifiers";
 import { Tools } from "../../../types";
@@ -30,14 +30,6 @@ async function getItemOutputDetails(
     } catch {
         throw new Error(INTERNAL_SERVER_ERROR);
     }
-}
-
-function getMaxToolModifier(maximum: Tools, available: Tools): number {
-    const maximumToolModifier = ToolModifierValues[maximum];
-    const availableToolModifier = ToolModifierValues[available];
-    return availableToolModifier > maximumToolModifier
-        ? maximumToolModifier
-        : availableToolModifier;
 }
 
 const calculateOutput: QueryOutputPrimaryPort = async (

--- a/api/src/functions/query-output/domain/output-calculator.ts
+++ b/api/src/functions/query-output/domain/output-calculator.ts
@@ -1,4 +1,7 @@
-import { ToolModifierValues } from "../../../common/modifiers";
+import {
+    ToolModifierValues,
+    isAvailableToolSufficient,
+} from "../../../common/modifiers";
 import { Tools } from "../../../types";
 import { queryOutputDetails } from "../adapters/mongodb-output-adapter";
 import type { ItemOutputDetails } from "../interfaces/output-database-port";
@@ -27,12 +30,6 @@ async function getItemOutputDetails(
     } catch {
         throw new Error(INTERNAL_SERVER_ERROR);
     }
-}
-
-function isAvailableToolSufficient(minimum: Tools, available: Tools): boolean {
-    const minimumToolModifier = ToolModifierValues[minimum];
-    const availableToolModifier = ToolModifierValues[available];
-    return availableToolModifier >= minimumToolModifier;
 }
 
 function getMaxToolModifier(maximum: Tools, available: Tools): number {

--- a/api/src/functions/query-output/handler.ts
+++ b/api/src/functions/query-output/handler.ts
@@ -1,17 +1,8 @@
-import type { QueryOutputArgs, Tools } from "../../graphql/schema";
+import type { QueryOutputArgs } from "../../graphql/schema";
 import type { GraphQLEventHandler } from "../../interfaces/GraphQLEventHandler";
-import { Tools as SchemaTools } from "../../types";
 import { calculateOutput } from "./domain/output-calculator";
 import { OutputUnit } from "./interfaces/query-output-primary-port";
-
-const toolMap: Record<Tools, SchemaTools> = {
-    NONE: SchemaTools.none,
-    STONE: SchemaTools.stone,
-    COPPER: SchemaTools.copper,
-    IRON: SchemaTools.iron,
-    BRONZE: SchemaTools.bronze,
-    STEEL: SchemaTools.steel,
-};
+import { ToolSchemaMap } from "../../common/modifiers";
 
 const handler: GraphQLEventHandler<QueryOutputArgs, number> = async (event) => {
     const { name, workers, unit, maxAvailableTool } = event.arguments;
@@ -20,7 +11,7 @@ const handler: GraphQLEventHandler<QueryOutputArgs, number> = async (event) => {
         name,
         workers,
         OutputUnit[unit],
-        maxAvailableTool ? toolMap[maxAvailableTool] : undefined
+        maxAvailableTool ? ToolSchemaMap[maxAvailableTool] : undefined
     );
 };
 

--- a/api/src/functions/query-requirements/adapters/__tests__/mongodb-requirements-adapter.test.ts
+++ b/api/src/functions/query-requirements/adapters/__tests__/mongodb-requirements-adapter.test.ts
@@ -2,7 +2,7 @@ import type { MongoMemoryServer } from "mongodb-memory-server";
 import { MongoClient } from "mongodb";
 
 import { createItem, createMemoryServer } from "../../../../../test/index";
-import type { Items } from "../../../../types";
+import { Items, Tools } from "../../../../types";
 
 const databaseName = "TestDatabase";
 const itemCollectionName = "Items";
@@ -83,6 +83,8 @@ test("returns only the specified item if only that item is stored in the items c
         createTime: 2,
         output: 3,
         requirements: [],
+        minimumTool: Tools.none,
+        maximumTool: Tools.steel,
     });
     await storeItems([{ ...stored }]);
     const { queryRequirements } = await import(
@@ -104,12 +106,16 @@ test.each([
                 createTime: 1,
                 output: 2,
                 requirements: [],
+                minimumTool: Tools.copper,
+                maximumTool: Tools.steel,
             }),
             createItem({
                 name: validItemName,
                 createTime: 2,
                 output: 4,
                 requirements: [{ name: "required item 1", amount: 4 }],
+                minimumTool: Tools.stone,
+                maximumTool: Tools.steel,
             }),
         ],
         [
@@ -118,12 +124,16 @@ test.each([
                 createTime: 1,
                 output: 2,
                 requirements: [],
+                minimumTool: Tools.copper,
+                maximumTool: Tools.steel,
             }),
             createItem({
                 name: validItemName,
                 createTime: 2,
                 output: 4,
                 requirements: [{ name: "required item 1", amount: 4 }],
+                minimumTool: Tools.stone,
+                maximumTool: Tools.steel,
             }),
         ],
     ],
@@ -239,12 +249,16 @@ test.each([
                 createTime: 3,
                 output: 4,
                 requirements: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.steel,
             }),
             createItem({
                 name: "required item 1",
                 createTime: 1,
                 output: 2,
                 requirements: [{ name: "required item 2", amount: 5 }],
+                minimumTool: Tools.copper,
+                maximumTool: Tools.bronze,
             }),
             createItem({
                 name: validItemName,
@@ -259,12 +273,16 @@ test.each([
                 createTime: 3,
                 output: 4,
                 requirements: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.steel,
             }),
             createItem({
                 name: "required item 1",
                 createTime: 1,
                 output: 2,
                 requirements: [{ name: "required item 2", amount: 5 }],
+                minimumTool: Tools.copper,
+                maximumTool: Tools.bronze,
             }),
             createItem({
                 name: validItemName,

--- a/api/src/functions/query-requirements/domain/__tests__/query-requirements.test.ts
+++ b/api/src/functions/query-requirements/domain/__tests__/query-requirements.test.ts
@@ -454,4 +454,68 @@ describe("handles tool modifiers", () => {
 
         expect(requirement.workers).toBeCloseTo(20);
     });
+
+    test("reduces required workers for requirement if tool provided is applicable to requirement and not input item", async () => {
+        const requiredItemName = "another item";
+        const requiredItem = createItem({
+            name: requiredItemName,
+            createTime: 2,
+            output: 3,
+            requirements: [],
+            minimumTool: Tools.none,
+            maximumTool: Tools.steel,
+        });
+        const item = createItem({
+            name: validItemName,
+            createTime: 2,
+            output: 3,
+            requirements: [{ name: requiredItem.name, amount: 3 }],
+            minimumTool: Tools.none,
+            maximumTool: Tools.none,
+        });
+        mockMongoDBQueryRequirements.mockResolvedValue([item, requiredItem]);
+
+        const actual = await queryRequirements(
+            validItemName,
+            validWorkers,
+            Tools.steel
+        );
+        const requirement = actual.find(
+            (value) => value.name === requiredItemName
+        ) as RequiredWorkers;
+
+        expect(requirement.workers).toBeCloseTo(0.625);
+    });
+
+    test("reduces required workers for required item to max applicable to requirement given better tool applicable to only requirement", async () => {
+        const requiredItemName = "another item";
+        const requiredItem = createItem({
+            name: requiredItemName,
+            createTime: 2,
+            output: 3,
+            requirements: [],
+            minimumTool: Tools.none,
+            maximumTool: Tools.copper,
+        });
+        const item = createItem({
+            name: validItemName,
+            createTime: 2,
+            output: 3,
+            requirements: [{ name: requiredItem.name, amount: 3 }],
+            minimumTool: Tools.none,
+            maximumTool: Tools.none,
+        });
+        mockMongoDBQueryRequirements.mockResolvedValue([item, requiredItem]);
+
+        const actual = await queryRequirements(
+            validItemName,
+            validWorkers,
+            Tools.steel
+        );
+        const requirement = actual.find(
+            (value) => value.name === requiredItemName
+        ) as RequiredWorkers;
+
+        expect(requirement.workers).toBeCloseTo(1.25);
+    });
 });

--- a/api/src/functions/query-requirements/domain/query-requirements.ts
+++ b/api/src/functions/query-requirements/domain/query-requirements.ts
@@ -46,9 +46,16 @@ function calculateRequirements(
             );
         }
 
+        const requiredItemModifier = getMaxToolModifier(
+            requiredItem.maximumTool,
+            maxAvailableTool
+        );
+
         const requiredPerSecond =
             requirement.amount / inputItemModifiedCreateTime;
-        const producedPerSecond = requiredItem.output / requiredItem.createTime;
+        const producedPerSecond =
+            requiredItem.output /
+            (requiredItem.createTime / requiredItemModifier);
         const demandPerSecond = requiredPerSecond / producedPerSecond;
         const requiredWorkers = demandPerSecond * inputDesiredWorkers;
 

--- a/api/src/functions/query-requirements/handler.ts
+++ b/api/src/functions/query-requirements/handler.ts
@@ -1,3 +1,4 @@
+import { ToolSchemaMap } from "../../common/modifiers";
 import type { QueryRequirementArgs, Requirement } from "../../graphql/schema";
 import type { GraphQLEventHandler } from "../../interfaces/GraphQLEventHandler";
 import { queryRequirements } from "./domain/query-requirements";
@@ -6,9 +7,13 @@ const handler: GraphQLEventHandler<
     QueryRequirementArgs,
     Requirement[]
 > = async (event) => {
-    const { name, workers } = event.arguments;
+    const { name, workers, maxAvailableTool } = event.arguments;
 
-    return await queryRequirements(name, workers);
+    return await queryRequirements(
+        name,
+        workers,
+        maxAvailableTool ? ToolSchemaMap[maxAvailableTool] : undefined
+    );
 };
 
 export { handler };

--- a/api/src/functions/query-requirements/interfaces/query-requirements-primary-port.ts
+++ b/api/src/functions/query-requirements/interfaces/query-requirements-primary-port.ts
@@ -1,10 +1,14 @@
+import { Tools } from "../../../types";
+
 type RequiredWorkers = {
     name: string;
     workers: number;
 };
 
 interface QueryRequirementsPrimaryPort {
-    (name: string, workers: number): Promise<RequiredWorkers[]>;
+    (name: string, workers: number, maxAvailableTool?: Tools): Promise<
+        RequiredWorkers[]
+    >;
 }
 
 export type { RequiredWorkers, QueryRequirementsPrimaryPort };

--- a/api/src/graphql/schema.graphql
+++ b/api/src/graphql/schema.graphql
@@ -31,7 +31,11 @@ enum Tools {
 
 type Query {
     item(name: ID): [Item!]!
-    requirement(name: ID!, workers: Int!): [Requirement!]!
+    requirement(
+        name: ID!
+        workers: Int!
+        maxAvailableTool: Tools
+    ): [Requirement!]!
     output(
         name: ID!
         workers: Int!


### PR DESCRIPTION
Resolves #139 

# What

Updated requirements query to take max available tool as optional input
- Factors in the provided tool when calculating required workers
- Defaults to no tool provided to prevent breaking change

# Why

To allow accurate required worker output 
- Each item has their own specific max tool level that can be applied to it, resulting in less workers to produce a requirement if the input item cannot be sped up by the provided tool and vice versa

Enables changes to the UI to support selecting max available tool