### PR TITLE
feat: 141 allow tool selection

### DIFF
--- a/ui/src/pages/Calculator/Calculator.tsx
+++ b/ui/src/pages/Calculator/Calculator.tsx
@@ -10,6 +10,7 @@ import { CalculatorContainer, CalculatorHeader } from "./styles";
 import { OutputUnit } from "../../graphql/__generated__/graphql";
 import OptimalOutput from "./components/OptimalOutput";
 import { gql } from "../../graphql/__generated__";
+import ToolSelector from "./components/ToolSelector";
 
 const GET_ITEM_NAMES_QUERY = gql(`
     query GetItemNames {
@@ -74,6 +75,7 @@ function Calculator() {
                         onItemChange={setSelectedItem}
                     />
                     <WorkerInput onWorkerChange={setWorkers} />
+                    <ToolSelector />
                     <OutputUnitSelector onUnitChange={setSelectedOutputUnit} />
                 </>
             ) : null}

--- a/ui/src/pages/Calculator/Calculator.tsx
+++ b/ui/src/pages/Calculator/Calculator.tsx
@@ -101,6 +101,7 @@ function Calculator() {
                         <Requirements
                             selectedItemName={selectedItem}
                             workers={workers}
+                            maxAvailableTool={selectedTool}
                         />
                     ) : null}
                 </>

--- a/ui/src/pages/Calculator/Calculator.tsx
+++ b/ui/src/pages/Calculator/Calculator.tsx
@@ -7,7 +7,7 @@ import OutputUnitSelector from "./components/OutputUnitSelector";
 import Requirements from "./components/Requirements";
 import ErrorBoundary from "./components/ErrorBoundary";
 import { CalculatorContainer, CalculatorHeader } from "./styles";
-import { OutputUnit } from "../../graphql/__generated__/graphql";
+import { OutputUnit, Tools } from "../../graphql/__generated__/graphql";
 import OptimalOutput from "./components/OptimalOutput";
 import { gql } from "../../graphql/__generated__";
 import ToolSelector from "./components/ToolSelector";
@@ -47,6 +47,7 @@ function Calculator() {
     );
 
     const [workers, setWorkers] = useState<number>();
+    const [selectedTool, setSelectedTool] = useState<Tools>();
     const [selectedOutputUnit, setSelectedOutputUnit] = useState<OutputUnit>(
         OutputUnit.Minutes
     );
@@ -75,7 +76,7 @@ function Calculator() {
                         onItemChange={setSelectedItem}
                     />
                     <WorkerInput onWorkerChange={setWorkers} />
-                    <ToolSelector />
+                    <ToolSelector onToolChange={setSelectedTool} />
                     <OutputUnitSelector onUnitChange={setSelectedOutputUnit} />
                 </>
             ) : null}
@@ -93,6 +94,7 @@ function Calculator() {
                             itemName={selectedItem}
                             workers={workers}
                             outputUnit={selectedOutputUnit}
+                            maxAvailableTool={selectedTool}
                         />
                     ) : null}
                     {workers && selectedItem ? (

--- a/ui/src/pages/Calculator/__tests__/Calculator-item-selection.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-item-selection.test.tsx
@@ -16,6 +16,7 @@ import {
     expectedWorkerInputLabel,
     ItemName,
     expectedDesiredOutputHeader,
+    expectedToolSelectLabel,
 } from "./utils";
 import { expectedItemDetailsQueryName } from "./utils";
 
@@ -155,8 +156,9 @@ describe("given no item names returned", () => {
         );
     });
 
-    test("does not render a combo box for the desired output", () => {
+    test("does not render a combo box for the desired output", async () => {
         render(<Calculator />);
+        await screen.findByRole("alert");
 
         expect(
             screen.queryByRole("combobox", {
@@ -165,8 +167,9 @@ describe("given no item names returned", () => {
         ).not.toBeInTheDocument();
     });
 
-    test("does not render a worker input box", () => {
+    test("does not render a worker input box", async () => {
         render(<Calculator />);
+        await screen.findByRole("alert");
 
         expect(
             screen.queryByLabelText(expectedWorkerInputLabel, {
@@ -175,8 +178,20 @@ describe("given no item names returned", () => {
         ).not.toBeInTheDocument();
     });
 
-    test("does not render a combo box for the desired output units", () => {
+    test("does not render a select for tools", async () => {
         render(<Calculator />);
+        await screen.findByRole("alert");
+
+        expect(
+            screen.queryByRole("combobox", {
+                name: expectedToolSelectLabel,
+            })
+        ).not.toBeInTheDocument();
+    });
+
+    test("does not render a combo box for the desired output units", async () => {
+        render(<Calculator />);
+        await screen.findByRole("alert");
 
         expect(
             screen.queryByRole("combobox", {
@@ -322,4 +337,8 @@ test("renders an unhandled error message if an exception occurs fetching item de
     expect(await screen.findByRole("alert")).toHaveTextContent(
         expectedNetworkExceptionError
     );
+});
+
+afterAll(() => {
+    server.close();
 });

--- a/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
@@ -98,7 +98,7 @@ test("queries optimal output if item and workers inputted with default unit sele
     });
 });
 
-test("queries optimal output if item annd workers inputted with non-default unit selected", async () => {
+test("queries optimal output if item and workers inputted with non-default unit selected", async () => {
     const expectedWorkers = 5;
     const expectedRequest = waitForRequest(
         server,

--- a/ui/src/pages/Calculator/__tests__/Calculator-tool-selection.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-tool-selection.test.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { graphql } from "msw";
+import { setupServer } from "msw/node";
+import { screen, within } from "@testing-library/react";
+
+import {
+    ItemName,
+    expectedItemDetailsQueryName,
+    expectedItemNameQueryName,
+    expectedOutputQueryName,
+    expectedRequirementsQueryName,
+    expectedToolSelectLabel,
+} from "./utils";
+import { renderWithTestProviders as render } from "../../../test/utils";
+import Calculator from "../Calculator";
+
+const expectedGraphQLAPIURL = "http://localhost:3000/graphql";
+const item: ItemName = { name: "Item 1" };
+
+const server = setupServer(
+    graphql.query(expectedItemNameQueryName, (_, res, ctx) => {
+        return res(ctx.data({ item: [item] }));
+    }),
+    graphql.query(expectedItemDetailsQueryName, (_, res, ctx) => {
+        return res(ctx.data({ item: [] }));
+    }),
+    graphql.query(expectedRequirementsQueryName, (_, res, ctx) => {
+        return res(ctx.data({ requirement: [] }));
+    }),
+    graphql.query(expectedOutputQueryName, (_, res, ctx) => {
+        return res(ctx.data({ output: 5.2 }));
+    })
+);
+
+beforeAll(() => {
+    server.listen();
+});
+
+beforeEach(() => {
+    server.resetHandlers();
+    server.events.removeAllListeners();
+});
+
+test("renders a select for tools", async () => {
+    render(<Calculator />, expectedGraphQLAPIURL);
+
+    expect(
+        await screen.findByRole("combobox", { name: expectedToolSelectLabel })
+    ).toBeVisible();
+});
+
+test.each(["None", "Stone", "Copper", "Iron", "Bronze", "Steel"])(
+    "renders the %s tool option in the tool selector",
+    async (tool: string) => {
+        render(<Calculator />, expectedGraphQLAPIURL);
+        const toolSelect = await screen.findByRole("combobox", {
+            name: expectedToolSelectLabel,
+        });
+
+        expect(
+            within(toolSelect).getByRole("option", { name: tool })
+        ).toBeInTheDocument();
+    }
+);
+
+test("renders none as the selected tool by default", async () => {
+    render(<Calculator />);
+    const toolSelect = await screen.findByRole("combobox", {
+        name: expectedToolSelectLabel,
+    });
+
+    expect(
+        within(toolSelect).getByRole("option", { name: "None", selected: true })
+    ).toBeVisible();
+});
+
+afterAll(() => {
+    server.close();
+});

--- a/ui/src/pages/Calculator/__tests__/Calculator-tool-selection.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-tool-selection.test.tsx
@@ -79,6 +79,7 @@ test("renders none as the selected tool by default", async () => {
 });
 
 test("queries optimal output with provided tool if non default selected", async () => {
+    const expectedTool = Tools.Steel;
     const expectedWorkers = 5;
     const expectedRequest = waitForRequest(
         server,
@@ -88,7 +89,7 @@ test("queries optimal output with provided tool if non default selected", async 
     );
 
     render(<Calculator />, expectedGraphQLAPIURL);
-    await selectTool(Tools.Steel);
+    await selectTool(expectedTool);
     await selectItemAndWorkers({
         itemName: item.name,
         workers: expectedWorkers,
@@ -99,11 +100,12 @@ test("queries optimal output with provided tool if non default selected", async 
         name: item.name,
         workers: expectedWorkers,
         unit: OutputUnit.Minutes,
-        maxAvailableTool: Tools.Steel,
+        maxAvailableTool: expectedTool,
     });
 });
 
 test("queries optimal output again if tool is changed after first query", async () => {
+    const expectedTool = Tools.Copper;
     const expectedWorkers = 5;
     const expectedRequest = waitForRequest(
         server,
@@ -114,7 +116,7 @@ test("queries optimal output again if tool is changed after first query", async 
             name: item.name,
             workers: expectedWorkers,
             unit: OutputUnit.Minutes,
-            maxAvailableTool: Tools.Copper,
+            maxAvailableTool: expectedTool,
         }
     );
 
@@ -124,7 +126,58 @@ test("queries optimal output again if tool is changed after first query", async 
         itemName: item.name,
         workers: expectedWorkers,
     });
-    await selectTool(Tools.Copper);
+    await selectTool(expectedTool);
+
+    await expect(expectedRequest).resolves.not.toThrow();
+});
+
+test("queries requirements with provided tool if non default selected", async () => {
+    const expectedTool = Tools.Steel;
+    const expectedWorkers = 5;
+    const expectedRequest = waitForRequest(
+        server,
+        "POST",
+        expectedGraphQLAPIURL,
+        expectedRequirementsQueryName
+    );
+
+    render(<Calculator />, expectedGraphQLAPIURL);
+    await selectTool(expectedTool);
+    await selectItemAndWorkers({
+        itemName: item.name,
+        workers: expectedWorkers,
+    });
+    const { matchedRequestDetails } = await expectedRequest;
+
+    expect(matchedRequestDetails.variables).toEqual({
+        name: item.name,
+        workers: expectedWorkers,
+        maxAvailableTool: expectedTool,
+    });
+});
+
+test("queries requirements again if tool is changed after first query", async () => {
+    const expectedTool = Tools.Copper;
+    const expectedWorkers = 5;
+    const expectedRequest = waitForRequest(
+        server,
+        "POST",
+        expectedGraphQLAPIURL,
+        expectedRequirementsQueryName,
+        {
+            name: item.name,
+            workers: expectedWorkers,
+            maxAvailableTool: expectedTool,
+        }
+    );
+
+    render(<Calculator />, expectedGraphQLAPIURL);
+    await selectTool(Tools.Steel);
+    await selectItemAndWorkers({
+        itemName: item.name,
+        workers: expectedWorkers,
+    });
+    await selectTool(expectedTool);
 
     await expect(expectedRequest).resolves.not.toThrow();
 });

--- a/ui/src/pages/Calculator/__tests__/utils/constants.ts
+++ b/ui/src/pages/Calculator/__tests__/utils/constants.ts
@@ -7,6 +7,7 @@ const expectedDesiredOutputHeader = "Desired output:";
 const expectedItemSelectLabel = "Item:";
 const expectedWorkerInputLabel = "Workers:";
 const expectedOutputUnitLabel = "Desired output units:";
+const expectedToolSelectLabel = "Tools:";
 const expectedOutputPrefix = "Optimal output:";
 const expectedFarmSizeNotePrefix = "Calculations use optimal farm size:";
 
@@ -19,6 +20,7 @@ export {
     expectedItemSelectLabel,
     expectedWorkerInputLabel,
     expectedOutputUnitLabel,
+    expectedToolSelectLabel,
     expectedOutputPrefix,
     expectedFarmSizeNotePrefix,
 };

--- a/ui/src/pages/Calculator/__tests__/utils/input-utils.ts
+++ b/ui/src/pages/Calculator/__tests__/utils/input-utils.ts
@@ -4,10 +4,11 @@ import userEvent from "@testing-library/user-event";
 import {
     expectedItemSelectLabel,
     expectedOutputUnitLabel,
+    expectedToolSelectLabel,
     expectedWorkerInputLabel,
 } from "./constants";
-import { OutputUnit } from "../../../../graphql/__generated__/graphql";
-import { OutputUnitSelectorMappings } from "../../utils";
+import { OutputUnit, Tools } from "../../../../graphql/__generated__/graphql";
+import { OutputUnitSelectorMappings, ToolSelectorMappings } from "../../utils";
 
 async function selectItemAndWorkers({
     itemName,
@@ -57,4 +58,15 @@ async function selectOutputUnit(unit: OutputUnit) {
     });
 }
 
-export { selectItemAndWorkers, selectOutputUnit };
+async function selectTool(tool: Tools) {
+    const user = userEvent.setup();
+    const toolSelect = await screen.findByRole("combobox", {
+        name: expectedToolSelectLabel,
+    });
+
+    await act(async () => {
+        await user.selectOptions(toolSelect, ToolSelectorMappings[tool]);
+    });
+}
+
+export { selectItemAndWorkers, selectOutputUnit, selectTool };

--- a/ui/src/pages/Calculator/components/OptimalOutput/OptimalOutput.tsx
+++ b/ui/src/pages/Calculator/components/OptimalOutput/OptimalOutput.tsx
@@ -3,7 +3,7 @@ import { useLazyQuery } from "@apollo/client";
 import { useDebounce } from "use-debounce";
 
 import { gql } from "../../../../graphql/__generated__";
-import { OutputUnit } from "../../../../graphql/__generated__/graphql";
+import { OutputUnit, Tools } from "../../../../graphql/__generated__/graphql";
 import { DesiredOutputText } from "./styles";
 import {
     DEFAULT_DEBOUNCE,
@@ -15,11 +15,12 @@ type OptimalOutputProps = {
     itemName: string;
     workers: number;
     outputUnit: OutputUnit;
+    maxAvailableTool?: Tools;
 };
 
 const GET_OPTIMAL_OUTPUT = gql(`
-    query GetOptimalOutput($name: ID!, $workers: Int!, $unit: OutputUnit!) {
-        output(name: $name, workers: $workers, unit: $unit)
+    query GetOptimalOutput($name: ID!, $workers: Int!, $unit: OutputUnit!, $maxAvailableTool: Tools) {
+        output(name: $name, workers: $workers, unit: $unit, maxAvailableTool: $maxAvailableTool)
     }
 `);
 
@@ -28,7 +29,12 @@ function createOutputMessage(output: number, unit: OutputUnit): string {
     return `Optimal output: ${roundOutput(output)} per ${unitDisplayString}`;
 }
 
-function OptimalOutput({ itemName, workers, outputUnit }: OptimalOutputProps) {
+function OptimalOutput({
+    itemName,
+    workers,
+    outputUnit,
+    maxAvailableTool,
+}: OptimalOutputProps) {
     const [getOptimalOutput, { data, error }] =
         useLazyQuery(GET_OPTIMAL_OUTPUT);
     const [debouncedWorkers] = useDebounce(workers, DEFAULT_DEBOUNCE);
@@ -39,9 +45,10 @@ function OptimalOutput({ itemName, workers, outputUnit }: OptimalOutputProps) {
                 name: itemName,
                 workers: debouncedWorkers,
                 unit: outputUnit,
+                maxAvailableTool,
             },
         });
-    }, [itemName, debouncedWorkers, outputUnit]);
+    }, [itemName, debouncedWorkers, outputUnit, maxAvailableTool]);
 
     if (error) {
         return (

--- a/ui/src/pages/Calculator/components/Requirements/Requirements.tsx
+++ b/ui/src/pages/Calculator/components/Requirements/Requirements.tsx
@@ -10,28 +10,31 @@ import {
     NumberColumnCell,
 } from "./styles";
 import { gql } from "../../../../graphql/__generated__";
+import { Tools } from "../../../../graphql/__generated__/graphql";
 import { DEFAULT_DEBOUNCE } from "../../utils";
 
 type RequirementsProps = {
     selectedItemName: string;
     workers: number;
+    maxAvailableTool?: Tools;
 };
 
 const GET_ITEM_REQUIREMENTS = gql(`
-    query GetItemRequirements($name: ID!, $workers: Int!) {
-        requirement(name: $name, workers: $workers) {
+    query GetItemRequirements($name: ID!, $workers: Int!, $maxAvailableTool: Tools) {
+        requirement(name: $name, workers: $workers, maxAvailableTool: $maxAvailableTool) {
             name
             workers
         }
     }
 `);
 
-function Requirements({ selectedItemName, workers }: RequirementsProps) {
+function Requirements({
+    selectedItemName,
+    workers,
+    maxAvailableTool,
+}: RequirementsProps) {
     const [getItemRequirements, { loading, data, error }] = useLazyQuery(
-        GET_ITEM_REQUIREMENTS,
-        {
-            variables: { name: selectedItemName, workers },
-        }
+        GET_ITEM_REQUIREMENTS
     );
     const [debouncedWorkers] = useDebounce(workers, DEFAULT_DEBOUNCE);
 
@@ -40,9 +43,10 @@ function Requirements({ selectedItemName, workers }: RequirementsProps) {
             variables: {
                 name: selectedItemName,
                 workers: debouncedWorkers,
+                maxAvailableTool,
             },
         });
-    }, [selectedItemName, debouncedWorkers]);
+    }, [selectedItemName, debouncedWorkers, maxAvailableTool]);
 
     if (error) {
         return (

--- a/ui/src/pages/Calculator/components/ToolSelector/ToolSelector.tsx
+++ b/ui/src/pages/Calculator/components/ToolSelector/ToolSelector.tsx
@@ -1,21 +1,26 @@
-import React from "react";
+import React, { FormEvent } from "react";
 
 import { Tools } from "../../../../graphql/__generated__/graphql";
+import { ToolSelectorMappings } from "../../utils";
 
-const ToolSelectorMappings: Readonly<Record<Tools, string>> = {
-    [Tools.None]: "None",
-    [Tools.Stone]: "Stone",
-    [Tools.Copper]: "Copper",
-    [Tools.Iron]: "Iron",
-    [Tools.Bronze]: "Bronze",
-    [Tools.Steel]: "Steel",
+type ToolSelectorProps = {
+    onToolChange: (unit: Tools) => void;
 };
 
-function ToolSelector() {
+function ToolSelector({ onToolChange }: ToolSelectorProps) {
+    const handleToolChange = (event: FormEvent<HTMLSelectElement>) => {
+        const selected = event.currentTarget.value as Tools;
+        onToolChange(selected);
+    };
+
     return (
         <>
             <label htmlFor="tool-select">Tools:</label>
-            <select id="tool-select" defaultValue={Tools.None}>
+            <select
+                id="tool-select"
+                defaultValue={Tools.None}
+                onChange={handleToolChange}
+            >
                 {Object.values(Tools).map((tool) => (
                     <option key={tool} value={tool}>
                         {ToolSelectorMappings[tool]}

--- a/ui/src/pages/Calculator/components/ToolSelector/ToolSelector.tsx
+++ b/ui/src/pages/Calculator/components/ToolSelector/ToolSelector.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+import { Tools } from "../../../../graphql/__generated__/graphql";
+
+const ToolSelectorMappings: Readonly<Record<Tools, string>> = {
+    [Tools.None]: "None",
+    [Tools.Stone]: "Stone",
+    [Tools.Copper]: "Copper",
+    [Tools.Iron]: "Iron",
+    [Tools.Bronze]: "Bronze",
+    [Tools.Steel]: "Steel",
+};
+
+function ToolSelector() {
+    return (
+        <>
+            <label htmlFor="tool-select">Tools:</label>
+            <select id="tool-select" defaultValue={Tools.None}>
+                {Object.values(Tools).map((tool) => (
+                    <option key={tool} value={tool}>
+                        {ToolSelectorMappings[tool]}
+                    </option>
+                ))}
+            </select>
+        </>
+    );
+}
+
+export { ToolSelector };

--- a/ui/src/pages/Calculator/components/ToolSelector/index.ts
+++ b/ui/src/pages/Calculator/components/ToolSelector/index.ts
@@ -1,0 +1,3 @@
+import { ToolSelector } from "./ToolSelector";
+
+export default ToolSelector;

--- a/ui/src/pages/Calculator/utils/index.ts
+++ b/ui/src/pages/Calculator/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./output-units";
+export * from "./tools";
 export * from "./round-output";
 export * from "./constants";

--- a/ui/src/pages/Calculator/utils/tools.ts
+++ b/ui/src/pages/Calculator/utils/tools.ts
@@ -1,0 +1,12 @@
+import { Tools } from "../../../graphql/__generated__/graphql";
+
+const ToolSelectorMappings: Readonly<Record<Tools, string>> = {
+    [Tools.None]: "None",
+    [Tools.Stone]: "Stone",
+    [Tools.Copper]: "Copper",
+    [Tools.Iron]: "Iron",
+    [Tools.Bronze]: "Bronze",
+    [Tools.Steel]: "Steel",
+};
+
+export { ToolSelectorMappings };


### PR DESCRIPTION
Resolves #141 

# What

Updated UI to include tool selector
- Provides selected tool to `output` and `requirements` queries on API

# Why

To allow the user to specify the tools that they are currently using, such that they can get more accurate optimal output and requirement figures based on usage of those tools