### PR TITLE
feat: replace select with custom component

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -16,6 +16,7 @@
                 "@fortawesome/free-solid-svg-icons": "6.4.0",
                 "@fortawesome/react-fontawesome": "0.2.0",
                 "aws-appsync-auth-link": "3.0.7",
+                "downshift": "7.6.0",
                 "graphql": "16.6.0",
                 "normalize.css": "8.0.1",
                 "react": "18.2.0",
@@ -7058,6 +7059,11 @@
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "peer": true
         },
+        "node_modules/compute-scroll-into-view": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-2.0.4.tgz",
+            "integrity": "sha512-y/ZA3BGnxoM/QHHQ2Uy49CLtnWPbt4tTPpEEZiEmmiWBFKjej7nEyH8Ryz54jH0MLXflUYA3Er2zUxPSJu5R+g=="
+        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -7620,6 +7626,26 @@
             "engines": {
                 "node": ">=12"
             }
+        },
+        "node_modules/downshift": {
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/downshift/-/downshift-7.6.0.tgz",
+            "integrity": "sha512-VSoTVynTAsabou/hbZ6HJHUVhtBiVOjQoBsCPcQq5eAROIGP+9XKMp9asAKQ3cEcUP4oe0fFdD2pziUjhFY33Q==",
+            "dependencies": {
+                "@babel/runtime": "^7.14.8",
+                "compute-scroll-into-view": "^2.0.4",
+                "prop-types": "^15.7.2",
+                "react-is": "^17.0.2",
+                "tslib": "^2.3.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.12.0"
+            }
+        },
+        "node_modules/downshift/node_modules/react-is": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
         },
         "node_modules/dset": {
             "version": "3.1.2",
@@ -22011,6 +22037,11 @@
                 }
             }
         },
+        "compute-scroll-into-view": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-2.0.4.tgz",
+            "integrity": "sha512-y/ZA3BGnxoM/QHHQ2Uy49CLtnWPbt4tTPpEEZiEmmiWBFKjej7nEyH8Ryz54jH0MLXflUYA3Er2zUxPSJu5R+g=="
+        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -22462,6 +22493,25 @@
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
             "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
             "dev": true
+        },
+        "downshift": {
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/downshift/-/downshift-7.6.0.tgz",
+            "integrity": "sha512-VSoTVynTAsabou/hbZ6HJHUVhtBiVOjQoBsCPcQq5eAROIGP+9XKMp9asAKQ3cEcUP4oe0fFdD2pziUjhFY33Q==",
+            "requires": {
+                "@babel/runtime": "^7.14.8",
+                "compute-scroll-into-view": "^2.0.4",
+                "prop-types": "^15.7.2",
+                "react-is": "^17.0.2",
+                "tslib": "^2.3.0"
+            },
+            "dependencies": {
+                "react-is": {
+                    "version": "17.0.2",
+                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+                    "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+                }
+            }
         },
         "dset": {
             "version": "3.1.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -32,6 +32,7 @@
         "@fortawesome/free-solid-svg-icons": "6.4.0",
         "@fortawesome/react-fontawesome": "0.2.0",
         "aws-appsync-auth-link": "3.0.7",
+        "downshift": "7.6.0",
         "graphql": "16.6.0",
         "normalize.css": "8.0.1",
         "react": "18.2.0",

--- a/ui/src/common/components/Selector/Selector.tsx
+++ b/ui/src/common/components/Selector/Selector.tsx
@@ -10,6 +10,7 @@ interface SelectorProps<Item> extends UseSelectProps<Item> {
     itemToDisplayText: (item: Item) => string;
     defaultSelectedItem: Item;
     palette?: ColorPallettes;
+    className?: string;
 }
 
 function Selector<Item>({
@@ -19,6 +20,7 @@ function Selector<Item>({
     labelText,
     defaultSelectedItem,
     palette = "secondary",
+    className,
 }: SelectorProps<Item>) {
     const {
         isOpen,
@@ -33,7 +35,7 @@ function Selector<Item>({
     });
 
     return (
-        <Container pallette={palette}>
+        <Container pallette={palette} className={className}>
             <label {...getLabelProps()}>{labelText}</label>
             <ToggleButton {...getToggleButtonProps()} pallette={palette}>
                 <span>

--- a/ui/src/common/components/Selector/Selector.tsx
+++ b/ui/src/common/components/Selector/Selector.tsx
@@ -2,12 +2,14 @@ import React from "react";
 import { useSelect, UseSelectProps } from "downshift";
 
 import { Container, Item, Menu, ToggleButton } from "./styles";
+import { ColorPallettes } from "../..";
 
 interface SelectorProps<Item> extends UseSelectProps<Item> {
     labelText: string;
     itemToKey: (item: Item, index: number) => string;
     itemToDisplayText: (item: Item) => string;
     defaultSelectedItem: Item;
+    palette?: ColorPallettes;
 }
 
 function Selector<Item>({
@@ -16,6 +18,7 @@ function Selector<Item>({
     itemToDisplayText,
     labelText,
     defaultSelectedItem,
+    palette = "secondary",
 }: SelectorProps<Item>) {
     const {
         isOpen,
@@ -30,22 +33,23 @@ function Selector<Item>({
     });
 
     return (
-        <Container>
+        <Container pallette={palette}>
             <label {...getLabelProps()}>{labelText}</label>
-            <ToggleButton {...getToggleButtonProps()}>
+            <ToggleButton {...getToggleButtonProps()} pallette={palette}>
                 <span>
                     {itemToDisplayText(
                         selectedItem ? selectedItem : defaultSelectedItem
                     )}
                 </span>
             </ToggleButton>
-            <Menu {...getMenuProps()} isOpen={isOpen}>
+            <Menu {...getMenuProps()} isOpen={isOpen} pallette={palette}>
                 {isOpen ? (
                     <>
                         {items.map((item, index) => (
                             <Item
                                 key={itemToKey(item, index)}
                                 {...getItemProps({ item, index })}
+                                pallette={palette}
                             >
                                 {itemToDisplayText(item)}
                             </Item>

--- a/ui/src/common/components/Selector/Selector.tsx
+++ b/ui/src/common/components/Selector/Selector.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { useSelect, UseSelectProps } from "downshift";
+
+import { Container, Item, Menu, ToggleButton } from "./styles";
+
+interface SelectorProps<Item> extends UseSelectProps<Item> {
+    labelText: string;
+    itemToKey: (item: Item, index: number) => string;
+    itemToDisplayText: (item: Item) => string;
+    defaultSelectedItem: Item;
+}
+
+function Selector<Item>({
+    items,
+    itemToKey,
+    itemToDisplayText,
+    labelText,
+    defaultSelectedItem,
+}: SelectorProps<Item>) {
+    const {
+        isOpen,
+        selectedItem,
+        getLabelProps,
+        getToggleButtonProps,
+        getMenuProps,
+        getItemProps,
+    } = useSelect({
+        items,
+        defaultSelectedItem,
+    });
+
+    return (
+        <Container>
+            <label {...getLabelProps()}>{labelText}</label>
+            <ToggleButton {...getToggleButtonProps()}>
+                <span>
+                    {itemToDisplayText(
+                        selectedItem ? selectedItem : defaultSelectedItem
+                    )}
+                </span>
+            </ToggleButton>
+            <Menu {...getMenuProps()} isOpen={isOpen}>
+                {isOpen ? (
+                    <>
+                        {items.map((item, index) => (
+                            <Item
+                                key={itemToKey(item, index)}
+                                {...getItemProps({ item, index })}
+                            >
+                                {itemToDisplayText(item)}
+                            </Item>
+                        ))}
+                    </>
+                ) : null}
+            </Menu>
+        </Container>
+    );
+}
+
+export { Selector };

--- a/ui/src/common/components/Selector/Selector.tsx
+++ b/ui/src/common/components/Selector/Selector.tsx
@@ -1,7 +1,14 @@
 import React from "react";
 import { useSelect, UseSelectProps, UseSelectStateChange } from "downshift";
+import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
 
-import { Container, Item, Menu, ToggleButton } from "./styles";
+import {
+    Container,
+    Item,
+    Menu,
+    ToggleButton,
+    ToggleIndicatorIcon,
+} from "./styles";
 import { ColorPallettes } from "../..";
 
 interface SelectorProps<Item> extends Pick<UseSelectProps<Item>, "items"> {
@@ -52,6 +59,7 @@ function Selector<Item>({
                         selectedItem ? selectedItem : defaultSelectedItem
                     )}
                 </span>
+                <ToggleIndicatorIcon icon={faChevronDown} selected={isOpen} />
             </ToggleButton>
             <Menu {...getMenuProps()} isOpen={isOpen} pallette={palette}>
                 {isOpen ? (

--- a/ui/src/common/components/Selector/Selector.tsx
+++ b/ui/src/common/components/Selector/Selector.tsx
@@ -1,27 +1,35 @@
 import React from "react";
-import { useSelect, UseSelectProps } from "downshift";
+import { useSelect, UseSelectProps, UseSelectStateChange } from "downshift";
 
 import { Container, Item, Menu, ToggleButton } from "./styles";
 import { ColorPallettes } from "../..";
 
-interface SelectorProps<Item> extends UseSelectProps<Item> {
+interface SelectorProps<Item> extends Pick<UseSelectProps<Item>, "items"> {
     labelText: string;
     itemToKey: (item: Item, index: number) => string;
     itemToDisplayText: (item: Item) => string;
     defaultSelectedItem: Item;
+    onSelectedItemChange?: (item?: Item) => void;
     palette?: ColorPallettes;
     className?: string;
 }
 
 function Selector<Item>({
     items,
+    labelText,
     itemToKey,
     itemToDisplayText,
-    labelText,
     defaultSelectedItem,
+    onSelectedItemChange,
     palette = "secondary",
     className,
 }: SelectorProps<Item>) {
+    const handleSelectedItemChange = (changes: UseSelectStateChange<Item>) => {
+        if (onSelectedItemChange) {
+            onSelectedItemChange(changes.selectedItem ?? undefined);
+        }
+    };
+
     const {
         isOpen,
         selectedItem,
@@ -32,6 +40,7 @@ function Selector<Item>({
     } = useSelect({
         items,
         defaultSelectedItem,
+        onSelectedItemChange: handleSelectedItemChange,
     });
 
     return (

--- a/ui/src/common/components/Selector/__tests__/Selector.test.tsx
+++ b/ui/src/common/components/Selector/__tests__/Selector.test.tsx
@@ -1,0 +1,188 @@
+import React from "react";
+import { act, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import Selector from "..";
+import { renderWithTestProviders as render } from "../../../../test/utils";
+
+type Item = { name: string };
+
+function createItem(itemName: string): Item {
+    return { name: itemName };
+}
+
+function itemToKey(item: Item, index: number): string {
+    return `${item.name}-${index}`;
+}
+
+function itemToDisplayText(item: Item): string {
+    return item.name;
+}
+
+async function clickSelect(label: string): Promise<void> {
+    const user = userEvent.setup();
+    const select = await screen.findByRole("combobox", {
+        name: label,
+    });
+    await act(async () => {
+        await user.click(select);
+    });
+}
+
+async function clickOption(option: string): Promise<void> {
+    const user = userEvent.setup();
+    const optionElement = await screen.findByRole("option", {
+        name: option,
+    });
+    await act(async () => {
+        await user.click(optionElement);
+    });
+}
+
+const items: Item[] = [createItem("test item 1"), createItem("test item 2")];
+const expectedLabelText = "Label text:";
+
+it("renders a select with the provided label text", async () => {
+    render(
+        <Selector
+            items={items}
+            labelText={expectedLabelText}
+            defaultSelectedItem={items[0]}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+        />
+    );
+
+    expect(
+        await screen.findByRole("combobox", { name: expectedLabelText })
+    ).toBeVisible();
+});
+
+it("does not render any options by default", async () => {
+    render(
+        <Selector
+            items={items}
+            labelText={expectedLabelText}
+            defaultSelectedItem={items[0]}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+        />
+    );
+    await screen.findByRole("combobox", { name: expectedLabelText });
+
+    for (const item of items) {
+        expect(
+            screen.queryByRole("option", { name: item.name })
+        ).not.toBeInTheDocument();
+    }
+});
+
+it("shows the provided default value as the default shown item", async () => {
+    const expectedDefaultItem = items[0];
+
+    render(
+        <Selector
+            items={items}
+            labelText={expectedLabelText}
+            defaultSelectedItem={expectedDefaultItem}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+        />
+    );
+
+    expect(
+        await screen.findByRole("combobox", { name: expectedLabelText })
+    ).toHaveTextContent(expectedDefaultItem.name);
+});
+
+it("show each item provided as an option in the select when clicked", async () => {
+    render(
+        <Selector
+            items={items}
+            labelText={expectedLabelText}
+            defaultSelectedItem={items[0]}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+        />
+    );
+    await clickSelect(expectedLabelText);
+
+    for (const item of items) {
+        expect(
+            await screen.findByRole("option", { name: item.name })
+        ).toBeVisible();
+    }
+});
+
+it("shows the provided default item as selected in the option list by default", async () => {
+    const expectedDefaultItem = items[0];
+
+    render(
+        <Selector
+            items={items}
+            labelText={expectedLabelText}
+            defaultSelectedItem={expectedDefaultItem}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+        />
+    );
+    await clickSelect(expectedLabelText);
+
+    expect(
+        await screen.findByRole("option", {
+            name: expectedDefaultItem.name,
+            selected: true,
+        })
+    ).toBeVisible();
+});
+
+it("updates the shown item when a different item is selected", async () => {
+    const expectedShownItem = items[1];
+
+    render(
+        <Selector
+            items={items}
+            labelText={expectedLabelText}
+            defaultSelectedItem={items[0]}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+        />
+    );
+    await clickSelect(expectedLabelText);
+    await clickOption(expectedShownItem.name);
+
+    expect(
+        await screen.findByRole("combobox", { name: expectedLabelText })
+    ).toHaveTextContent(expectedShownItem.name);
+});
+
+it("updates the selected item in the option list after a different item is selected", async () => {
+    const expectedSelectedItem = items[1];
+    const expectedDeselectedItem = items[0];
+
+    render(
+        <Selector
+            items={items}
+            labelText={expectedLabelText}
+            defaultSelectedItem={expectedDeselectedItem}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+        />
+    );
+    await clickSelect(expectedLabelText);
+    await clickOption(expectedSelectedItem.name);
+    await clickSelect(expectedLabelText);
+
+    expect(
+        await screen.findByRole("option", {
+            name: expectedSelectedItem.name,
+            selected: true,
+        })
+    ).toBeVisible();
+    expect(
+        screen.getByRole("option", {
+            name: expectedDeselectedItem.name,
+            selected: false,
+        })
+    ).toBeVisible();
+});

--- a/ui/src/common/components/Selector/__tests__/Selector.test.tsx
+++ b/ui/src/common/components/Selector/__tests__/Selector.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { act, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
 
 import Selector from "..";
 import { renderWithTestProviders as render } from "../../../../test/utils";
@@ -185,4 +186,26 @@ it("updates the selected item in the option list after a different item is selec
             selected: false,
         })
     ).toBeVisible();
+});
+
+test("calls the provided on change function when an item is selected", async () => {
+    const mockOnItemChange = vi.fn();
+    const expectedItem = items[1];
+
+    render(
+        <Selector
+            items={items}
+            labelText={expectedLabelText}
+            defaultSelectedItem={items[0]}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+            onSelectedItemChange={mockOnItemChange}
+        />
+    );
+    await clickSelect(expectedLabelText);
+    await clickOption(expectedItem.name);
+    await screen.findByText(expectedItem.name);
+
+    expect(mockOnItemChange).toHaveBeenCalledTimes(1);
+    expect(mockOnItemChange).toHaveBeenCalledWith(expectedItem);
 });

--- a/ui/src/common/components/Selector/index.ts
+++ b/ui/src/common/components/Selector/index.ts
@@ -1,0 +1,3 @@
+import { Selector } from "./Selector";
+
+export default Selector;

--- a/ui/src/common/components/Selector/styles.tsx
+++ b/ui/src/common/components/Selector/styles.tsx
@@ -1,0 +1,53 @@
+import styled, { css } from "styled-components";
+
+export const Container = styled.div`
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    color: ${({ theme }) => theme.color.secondary.on_container};
+`;
+
+export const ToggleButton = styled.div`
+    ${({ theme }) => css`
+        background-color: ${theme.color.secondary.container};
+        border: 1px solid ${theme.color.secondary.container};
+
+        :hover,
+        :focus-within {
+            border-color: ${theme.color.secondary.on_container};
+        }
+    `};
+
+    padding: 0.5rem;
+    border-radius: 0.25rem;
+    margin-bottom: 0.5rem;
+`;
+
+type MenuProps = {
+    isOpen: boolean;
+};
+
+export const Menu = styled.div<MenuProps>`
+    ${({ theme, isOpen }) => css`
+        background-color: ${theme.color.secondary.container};
+        display: ${!isOpen ? "none" : "inline-block"};
+    `};
+
+    position: absolute;
+    z-index: 1;
+    width: 100%;
+    margin-top: 4rem;
+    padding: 0.25rem 0rem;
+    border-radius: 0.25rem;
+    list-style-type: none;
+`;
+
+export const Item = styled.li`
+    ${({ theme }) => css`
+        :hover {
+            background-color: ${theme.color.secondary.outline};
+        }
+    `};
+
+    padding: 0.5rem;
+`;

--- a/ui/src/common/components/Selector/styles.tsx
+++ b/ui/src/common/components/Selector/styles.tsx
@@ -1,20 +1,25 @@
 import styled, { css } from "styled-components";
+import { ColorPallettes } from "../../types";
 
-export const Container = styled.div`
+type CommonProps = {
+    pallette: ColorPallettes;
+};
+
+export const Container = styled.div<CommonProps>`
     position: relative;
     display: flex;
     flex-direction: column;
-    color: ${({ theme }) => theme.color.secondary.on_container};
+    color: ${({ theme, pallette }) => theme.color[pallette].on_container};
 `;
 
-export const ToggleButton = styled.div`
-    ${({ theme }) => css`
-        background-color: ${theme.color.secondary.container};
-        border: 1px solid ${theme.color.secondary.container};
+export const ToggleButton = styled.div<CommonProps>`
+    ${({ theme, pallette }) => css`
+        background-color: ${theme.color[pallette].container};
+        border: 1px solid ${theme.color[pallette].container};
 
         :hover,
         :focus-within {
-            border-color: ${theme.color.secondary.on_container};
+            border-color: ${theme.color[pallette].on_container};
         }
     `};
 
@@ -25,11 +30,11 @@ export const ToggleButton = styled.div`
 
 type MenuProps = {
     isOpen: boolean;
-};
+} & CommonProps;
 
 export const Menu = styled.div<MenuProps>`
-    ${({ theme, isOpen }) => css`
-        background-color: ${theme.color.secondary.container};
+    ${({ theme, isOpen, pallette }) => css`
+        background-color: ${theme.color[pallette].container};
         display: ${!isOpen ? "none" : "inline-block"};
     `};
 
@@ -42,10 +47,10 @@ export const Menu = styled.div<MenuProps>`
     list-style-type: none;
 `;
 
-export const Item = styled.li`
-    ${({ theme }) => css`
+export const Item = styled.li<CommonProps>`
+    ${({ theme, pallette }) => css`
         :hover {
-            background-color: ${theme.color.secondary.outline};
+            background-color: ${theme.color[pallette].outline};
         }
     `};
 

--- a/ui/src/common/components/Selector/styles.tsx
+++ b/ui/src/common/components/Selector/styles.tsx
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+
 import { ColorPallettes } from "../../types";
 
 type CommonProps = {
@@ -9,11 +10,11 @@ export const Container = styled.div<CommonProps>`
     position: relative;
     display: flex;
     flex-direction: column;
-    color: ${({ theme, pallette }) => theme.color[pallette].on_container};
 `;
 
 export const ToggleButton = styled.div<CommonProps>`
     ${({ theme, pallette }) => css`
+        color: ${theme.color[pallette].on_container};
         background-color: ${theme.color[pallette].container};
         border: 1px solid ${theme.color[pallette].container};
 
@@ -34,6 +35,7 @@ type MenuProps = {
 
 export const Menu = styled.div<MenuProps>`
     ${({ theme, isOpen, pallette }) => css`
+        color: ${theme.color[pallette].on_container};
         background-color: ${theme.color[pallette].container};
         display: ${!isOpen ? "none" : "inline-block"};
     `};

--- a/ui/src/common/components/Selector/styles.tsx
+++ b/ui/src/common/components/Selector/styles.tsx
@@ -1,6 +1,10 @@
 import styled, { css } from "styled-components";
 
 import { ColorPallettes } from "../../types";
+import {
+    FontAwesomeIcon,
+    FontAwesomeIconProps,
+} from "@fortawesome/react-fontawesome";
 
 type CommonProps = {
     pallette: ColorPallettes;
@@ -24,9 +28,30 @@ export const ToggleButton = styled.div<CommonProps>`
         }
     `};
 
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     padding: 0.5rem;
     border-radius: 0.25rem;
     margin-bottom: 0.5rem;
+`;
+
+interface ToggleIndicatorIconProps extends FontAwesomeIconProps {
+    selected: boolean;
+}
+
+export const ToggleIndicatorIcon = styled(
+    FontAwesomeIcon
+)<ToggleIndicatorIconProps>`
+    ${({ selected }) => {
+        if (selected) {
+            return css`
+                transform: scaleY(-1);
+            `;
+        }
+    }}
+
+    transition: all 0.2s ease-in;
 `;
 
 type MenuProps = {

--- a/ui/src/common/components/index.ts
+++ b/ui/src/common/components/index.ts
@@ -1,0 +1,1 @@
+export * from "./Selector";

--- a/ui/src/common/index.ts
+++ b/ui/src/common/index.ts
@@ -1,0 +1,2 @@
+export * from "./components";
+export * from "./types";

--- a/ui/src/common/types/index.ts
+++ b/ui/src/common/types/index.ts
@@ -1,0 +1,1 @@
+export * from "./theme";

--- a/ui/src/common/types/theme.ts
+++ b/ui/src/common/types/theme.ts
@@ -1,0 +1,10 @@
+import { DefaultTheme } from "styled-components";
+import { KeyColor } from "../../theme";
+
+type KeyColorKeys<T> = {
+    [K in keyof T]: T[K] extends KeyColor ? K : never;
+}[keyof T];
+
+type ColorPallettes = KeyColorKeys<DefaultTheme["color"]>;
+
+export type { ColorPallettes };

--- a/ui/src/pages/Calculator/__tests__/Calculator-item-selection.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-item-selection.test.tsx
@@ -10,13 +10,14 @@ import {
     expectedRequirementsQueryName,
     expectedOutputQueryName,
     expectedItemNameQueryName,
-    selectItemAndWorkers,
     expectedOutputUnitLabel,
     expectedItemSelectLabel,
     expectedWorkerInputLabel,
     ItemName,
     expectedDesiredOutputHeader,
     expectedToolSelectLabel,
+    openSelectMenu,
+    selectOption,
 } from "./utils";
 import { expectedItemDetailsQueryName } from "./utils";
 
@@ -222,24 +223,25 @@ test("renders a select for the desired output selector if item names are returne
 
 test("renders each item name returned as an option in the combo box", async () => {
     render(<Calculator />);
-    await screen.findByRole("combobox", { name: expectedItemSelectLabel });
+    await openSelectMenu({ selectLabel: expectedItemSelectLabel });
 
     for (const expected of items) {
         expect(
             screen.getByRole("option", { name: expected.name })
-        ).toBeInTheDocument();
+        ).toBeVisible();
     }
 });
 
 test("renders the first option in the item name list as selected by default", async () => {
     render(<Calculator />);
+    await openSelectMenu({ selectLabel: expectedItemSelectLabel });
 
     expect(
         await screen.findByRole("option", {
             name: items[0].name,
             selected: true,
         })
-    ).toBeInTheDocument();
+    ).toBeVisible();
 });
 
 test("requests item details on the first option in the item name list without selection", async () => {
@@ -268,8 +270,10 @@ test("requests item details for newly selected item if selection is changed", as
     );
 
     render(<Calculator />, expectedGraphQLAPIURL);
-    await screen.findByRole("combobox", { name: expectedItemSelectLabel });
-    await selectItemAndWorkers({ itemName: expectedItemName });
+    await selectOption({
+        selectLabel: expectedItemSelectLabel,
+        optionName: expectedItemName,
+    });
     const { matchedRequestDetails } = await expectedRequest;
 
     expect(matchedRequestDetails.variables).toEqual({

--- a/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
@@ -15,7 +15,9 @@ import {
     expectedItemNameQueryName,
     expectedOutputPrefix,
     expectedOutputQueryName,
+    expectedOutputUnitLabel,
     expectedRequirementsQueryName,
+    openSelectMenu,
     selectItemAndWorkers,
     selectOutputUnit,
 } from "./utils";
@@ -55,17 +57,19 @@ test.each(["Minutes", "Game days"])(
     "renders the %s option in the output unit selector",
     async (unit: string) => {
         render(<Calculator />, expectedGraphQLAPIURL);
+        await openSelectMenu({ selectLabel: expectedOutputUnitLabel });
 
         expect(
             await screen.findByRole("option", {
                 name: unit,
             })
-        ).toBeInTheDocument();
+        ).toBeVisible();
     }
 );
 
 test("selects the Minutes option by default", async () => {
     render(<Calculator />, expectedGraphQLAPIURL);
+    await openSelectMenu({ selectLabel: expectedOutputUnitLabel });
 
     expect(
         await screen.findByRole("option", {

--- a/ui/src/pages/Calculator/__tests__/Calculator-tool-selection.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-tool-selection.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { graphql } from "msw";
 import { setupServer } from "msw/node";
-import { screen, within } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 
 import {
     ItemName,
@@ -10,6 +10,7 @@ import {
     expectedOutputQueryName,
     expectedRequirementsQueryName,
     expectedToolSelectLabel,
+    openSelectMenu,
     selectItemAndWorkers,
     selectTool,
 } from "./utils";
@@ -57,24 +58,18 @@ test.each(["None", "Stone", "Copper", "Iron", "Bronze", "Steel"])(
     "renders the %s tool option in the tool selector",
     async (tool: string) => {
         render(<Calculator />, expectedGraphQLAPIURL);
-        const toolSelect = await screen.findByRole("combobox", {
-            name: expectedToolSelectLabel,
-        });
+        await openSelectMenu({ selectLabel: expectedToolSelectLabel });
 
-        expect(
-            within(toolSelect).getByRole("option", { name: tool })
-        ).toBeInTheDocument();
+        expect(await screen.findByRole("option", { name: tool })).toBeVisible();
     }
 );
 
 test("renders none as the selected tool by default", async () => {
     render(<Calculator />);
-    const toolSelect = await screen.findByRole("combobox", {
-        name: expectedToolSelectLabel,
-    });
+    await openSelectMenu({ selectLabel: expectedToolSelectLabel });
 
     expect(
-        within(toolSelect).getByRole("option", { name: "None", selected: true })
+        await screen.findByRole("option", { name: "None", selected: true })
     ).toBeVisible();
 });
 

--- a/ui/src/pages/Calculator/__tests__/utils/input-utils.ts
+++ b/ui/src/pages/Calculator/__tests__/utils/input-utils.ts
@@ -10,6 +10,33 @@ import {
 import { OutputUnit, Tools } from "../../../../graphql/__generated__/graphql";
 import { OutputUnitSelectorMappings, ToolSelectorMappings } from "../../utils";
 
+async function openSelectMenu({ selectLabel }: { selectLabel: string }) {
+    const user = userEvent.setup();
+    const select = await screen.findByRole("combobox", { name: selectLabel });
+
+    await act(async () => {
+        await user.click(select);
+    });
+}
+
+async function selectOption({
+    optionName,
+    selectLabel,
+}: {
+    optionName: string;
+    selectLabel?: string;
+}) {
+    if (selectLabel) {
+        await openSelectMenu({ selectLabel });
+    }
+
+    const user = userEvent.setup();
+    const option = await screen.findByRole("option", { name: optionName });
+    await act(async () => {
+        await user.click(option);
+    });
+}
+
 async function selectItemAndWorkers({
     itemName,
     workers,
@@ -29,44 +56,37 @@ async function selectItemAndWorkers({
             await user.clear(workerInput);
         }
 
-        if (itemName) {
-            await user.selectOptions(
-                await screen.findByRole("combobox", {
-                    name: expectedItemSelectLabel,
-                }),
-                itemName
-            );
-        }
-
         if (workers) {
             await user.type(workerInput, workers.toString());
         }
     });
+
+    if (itemName) {
+        await selectOption({
+            selectLabel: expectedItemSelectLabel,
+            optionName: itemName,
+        });
+    }
 }
 
 async function selectOutputUnit(unit: OutputUnit) {
-    const user = userEvent.setup();
-    const unitComboBox = await screen.findByRole("combobox", {
-        name: expectedOutputUnitLabel,
-    });
-
-    await act(async () => {
-        await user.selectOptions(
-            unitComboBox,
-            OutputUnitSelectorMappings[unit]
-        );
+    return selectOption({
+        selectLabel: expectedOutputUnitLabel,
+        optionName: OutputUnitSelectorMappings[unit],
     });
 }
 
 async function selectTool(tool: Tools) {
-    const user = userEvent.setup();
-    const toolSelect = await screen.findByRole("combobox", {
-        name: expectedToolSelectLabel,
-    });
-
-    await act(async () => {
-        await user.selectOptions(toolSelect, ToolSelectorMappings[tool]);
+    return selectOption({
+        selectLabel: expectedToolSelectLabel,
+        optionName: ToolSelectorMappings[tool],
     });
 }
 
-export { selectItemAndWorkers, selectOutputUnit, selectTool };
+export {
+    openSelectMenu,
+    selectOption,
+    selectItemAndWorkers,
+    selectOutputUnit,
+    selectTool,
+};

--- a/ui/src/pages/Calculator/components/ItemSelector/ItemSelector.tsx
+++ b/ui/src/pages/Calculator/components/ItemSelector/ItemSelector.tsx
@@ -1,29 +1,30 @@
-import React, { FormEvent } from "react";
+import React from "react";
 
 import { Item } from "../../../../graphql/__generated__/graphql";
+import Selector from "../../../../common/components/Selector";
 
-type ItemNames = Pick<Item, "name">[];
+type ItemName = Pick<Item, "name">;
 
 type ItemSelectorProps = {
-    items: ItemNames;
+    items: ItemName[];
     onItemChange: (item: string) => void;
 };
 
 function ItemSelector({ items, onItemChange }: ItemSelectorProps) {
-    const handleItemChange = (event: FormEvent<HTMLSelectElement>) => {
-        const name = event.currentTarget.value;
-        onItemChange(name);
+    const handleItemChange = (selectedItem?: ItemName) => {
+        if (selectedItem) onItemChange(selectedItem.name);
     };
 
     return (
-        <>
-            <label htmlFor="output-select">Item:</label>
-            <select id="output-select" onChange={handleItemChange}>
-                {Object.values(items).map((item) => (
-                    <option key={item.name}>{item.name}</option>
-                ))}
-            </select>
-        </>
+        <Selector
+            items={items}
+            itemToKey={(item) => item.name}
+            itemToDisplayText={(item) => item.name}
+            labelText="Item:"
+            defaultSelectedItem={items[0]}
+            onSelectedItemChange={handleItemChange}
+            palette="secondary"
+        />
     );
 }
 

--- a/ui/src/pages/Calculator/components/OutputUnitSelector/OutputUnitSelector.tsx
+++ b/ui/src/pages/Calculator/components/OutputUnitSelector/OutputUnitSelector.tsx
@@ -1,36 +1,30 @@
-import React, { FormEvent } from "react";
+import React from "react";
 
 import { OutputUnit } from "../../../../graphql/__generated__/graphql";
-import {
-    OutputUnitSelectorMappings,
-    OutputUnitSelectorReverseMappings,
-} from "../../utils";
+import { OutputUnitSelectorMappings } from "../../utils";
+import Selector from "../../../../common/components/Selector";
 
 type ItemSelectorProps = {
     onUnitChange: (unit: OutputUnit) => void;
 };
 
+const outputUnits = Object.values(OutputUnit);
+
 function OutputUnitSelector({ onUnitChange }: ItemSelectorProps) {
-    const handleUnitChange = (event: FormEvent<HTMLSelectElement>) => {
-        const unit = event.currentTarget.value;
-        onUnitChange(OutputUnitSelectorReverseMappings[unit]);
+    const handleUnitChange = (selectedUnit?: OutputUnit) => {
+        if (selectedUnit) onUnitChange(selectedUnit);
     };
 
     return (
-        <>
-            <label htmlFor="units-select">Desired output units:</label>
-            <select
-                id="units-select"
-                onChange={handleUnitChange}
-                defaultValue={OutputUnitSelectorMappings[OutputUnit.Minutes]}
-            >
-                {Object.values(OutputUnit).map((unit) => (
-                    <option key={unit}>
-                        {OutputUnitSelectorMappings[unit]}
-                    </option>
-                ))}
-            </select>
-        </>
+        <Selector
+            items={outputUnits}
+            itemToKey={(unit) => unit}
+            itemToDisplayText={(unit) => OutputUnitSelectorMappings[unit]}
+            labelText="Desired output units:"
+            defaultSelectedItem={outputUnits[1]}
+            onSelectedItemChange={handleUnitChange}
+            palette="secondary"
+        />
     );
 }
 

--- a/ui/src/pages/Calculator/components/Requirements/Requirements.tsx
+++ b/ui/src/pages/Calculator/components/Requirements/Requirements.tsx
@@ -8,6 +8,7 @@ import {
     TextColumnCell,
     NumberColumnHeader,
     NumberColumnCell,
+    Header,
 } from "./styles";
 import { gql } from "../../../../graphql/__generated__";
 import { Tools } from "../../../../graphql/__generated__/graphql";
@@ -63,7 +64,7 @@ function Requirements({
 
     return (
         <>
-            <h2>Requirements:</h2>
+            <Header>Requirements:</Header>
             <RequirementsTable>
                 <thead>
                     <tr>

--- a/ui/src/pages/Calculator/components/Requirements/styles.ts
+++ b/ui/src/pages/Calculator/components/Requirements/styles.ts
@@ -1,13 +1,17 @@
 import styled from "styled-components";
 
+export const Header = styled.h2`
+    margin-bottom: 0rem;
+`;
+
 export const RequirementsTable = styled.table`
-    background-color: ${(props) => props.theme.color.secondary.container};
+    background-color: ${(props) => props.theme.color.tertiary.container};
     border-radius: 0.5rem;
 
     th {
         padding: 1rem 0.5rem;
         border-bottom: 1.5px solid
-            ${(props) => props.theme.color.secondary.on_container};
+            ${(props) => props.theme.color.tertiary.on_container};
     }
 
     td {
@@ -16,7 +20,7 @@ export const RequirementsTable = styled.table`
 
     tbody > tr:not(:last-child) > td {
         border-bottom: 1px solid
-            ${(props) => props.theme.color.secondary.on_container};
+            ${(props) => props.theme.color.tertiary.on_container};
     }
 `;
 

--- a/ui/src/pages/Calculator/components/ToolSelector/ToolSelector.tsx
+++ b/ui/src/pages/Calculator/components/ToolSelector/ToolSelector.tsx
@@ -1,33 +1,30 @@
-import React, { FormEvent } from "react";
+import React from "react";
 
 import { Tools } from "../../../../graphql/__generated__/graphql";
 import { ToolSelectorMappings } from "../../utils";
+import Selector from "../../../../common/components/Selector";
 
 type ToolSelectorProps = {
     onToolChange: (unit: Tools) => void;
 };
 
+const tools = Object.values(Tools);
+
 function ToolSelector({ onToolChange }: ToolSelectorProps) {
-    const handleToolChange = (event: FormEvent<HTMLSelectElement>) => {
-        const selected = event.currentTarget.value as Tools;
-        onToolChange(selected);
+    const handleToolChange = (selectedTool?: Tools) => {
+        if (selectedTool) onToolChange(selectedTool);
     };
 
     return (
-        <>
-            <label htmlFor="tool-select">Tools:</label>
-            <select
-                id="tool-select"
-                defaultValue={Tools.None}
-                onChange={handleToolChange}
-            >
-                {Object.values(Tools).map((tool) => (
-                    <option key={tool} value={tool}>
-                        {ToolSelectorMappings[tool]}
-                    </option>
-                ))}
-            </select>
-        </>
+        <Selector
+            items={tools}
+            itemToKey={(tool) => tool}
+            itemToDisplayText={(tool) => ToolSelectorMappings[tool]}
+            labelText="Tools:"
+            defaultSelectedItem={tools[3]}
+            onSelectedItemChange={handleToolChange}
+            palette="secondary"
+        />
     );
 }
 

--- a/ui/src/pages/Calculator/components/WorkerInput/WorkerInput.tsx
+++ b/ui/src/pages/Calculator/components/WorkerInput/WorkerInput.tsx
@@ -1,4 +1,5 @@
 import React, { FormEvent, useState } from "react";
+import { Container } from "./styles";
 
 type ItemSelectorProps = {
     onWorkerChange: (workers?: number) => void;
@@ -19,7 +20,7 @@ function WorkerInput({ onWorkerChange }: ItemSelectorProps) {
     };
 
     return (
-        <>
+        <Container>
             <label htmlFor="worker-input">Workers:</label>
             <input
                 id="worker-input"
@@ -31,7 +32,7 @@ function WorkerInput({ onWorkerChange }: ItemSelectorProps) {
                     Invalid input, must be a positive non-zero whole number
                 </span>
             ) : null}
-        </>
+        </Container>
     );
 }
 

--- a/ui/src/pages/Calculator/components/WorkerInput/styles.tsx
+++ b/ui/src/pages/Calculator/components/WorkerInput/styles.tsx
@@ -1,0 +1,6 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+`;

--- a/ui/src/pages/Calculator/styles.tsx
+++ b/ui/src/pages/Calculator/styles.tsx
@@ -4,11 +4,10 @@ export const CalculatorContainer = styled.div`
     display: flex;
     flex-direction: column;
 
-    * {
-        margin-bottom: 0.75rem;
-    }
+    row-gap: 0.75rem;
 `;
 
 export const CalculatorHeader = styled.h2`
-    margin-top: 0;
+    margin-top: 0rem;
+    margin-bottom: 0rem;
 `;

--- a/ui/src/pages/Calculator/utils/output-units.ts
+++ b/ui/src/pages/Calculator/utils/output-units.ts
@@ -10,14 +10,4 @@ const OutputUnitSelectorMappings: Readonly<Record<OutputUnit, string>> = {
     [OutputUnit.GameDays]: "Game days",
 };
 
-const OutputUnitSelectorReverseMappings: Readonly<Record<string, OutputUnit>> =
-    {
-        Minutes: OutputUnit.Minutes,
-        "Game days": OutputUnit.GameDays,
-    };
-
-export {
-    OutputUnitDisplayMappings,
-    OutputUnitSelectorMappings,
-    OutputUnitSelectorReverseMappings,
-};
+export { OutputUnitDisplayMappings, OutputUnitSelectorMappings };

--- a/ui/src/routes/components/SiteLayout/theme.ts
+++ b/ui/src/routes/components/SiteLayout/theme.ts
@@ -18,18 +18,21 @@ const lightTheme: DefaultTheme = {
             on_main: "#ffffff",
             container: "#b6ebff",
             on_container: "#001f28",
+            outline: "#7adcf1",
         },
         secondary: {
             main: "#4c626a",
             on_main: "#ffffff",
             container: "#cfe6f0",
             on_container: "#071e26",
+            outline: "#8ca7b7",
         },
         tertiary: {
             main: "#5a5c7e",
             on_main: "#ffffff",
             container: "#e0e0ff",
             on_container: "#161937",
+            outline: "#a4a4ff",
         },
         error: {
             main: "#ba1a1a",
@@ -49,7 +52,6 @@ const lightTheme: DefaultTheme = {
             main: "#dbe4e8",
             on_main: "#40484c",
         },
-        outline: "#70787c",
     },
 };
 
@@ -61,18 +63,21 @@ const darkTheme: DefaultTheme = {
             on_main: "#003543",
             container: "#004e60",
             on_container: "#b6ebff",
+            outline: "#00a2c2",
         },
         secondary: {
             main: "#b3cad4",
             on_main: "#1e333b",
             container: "#344a52",
             on_container: "#cfe6f0",
+            outline: "#3d5c6e",
         },
         tertiary: {
             main: "#c2c3eb",
             on_main: "#2b2e4d",
             container: "#424465",
             on_container: "#e0e0ff",
+            outline: "#7b7abf",
         },
         error: {
             main: "#ffb4ab",
@@ -92,7 +97,6 @@ const darkTheme: DefaultTheme = {
             main: "#40484c",
             on_main: "#bfc8cc",
         },
-        outline: "#8a9296",
     },
 };
 

--- a/ui/src/theme.d.ts
+++ b/ui/src/theme.d.ts
@@ -5,6 +5,7 @@ type KeyColor = {
     on_main: string;
     container: string;
     on_container: string;
+    outline: string;
 };
 
 type SurfaceTone = {
@@ -21,11 +22,10 @@ declare module "styled-components" {
             primary: KeyColor;
             secondary: KeyColor;
             tertiary: KeyColor;
-            error: KeyColor;
+            error: Omit<KeyColor, "outline">;
             background: SurfaceTone;
             surface: SurfaceTone;
             surface_variant: SurfaceTone;
-            outline: string;
         };
         typography: {
             family: string;

--- a/ui/src/theme.d.ts
+++ b/ui/src/theme.d.ts
@@ -32,3 +32,5 @@ declare module "styled-components" {
         };
     }
 }
+
+export type { KeyColor };


### PR DESCRIPTION
# What

Added custom `Selector` component using downshift library
Updated all usages of native select element with new component
Updated theme colors to include outline color for each palette

# Why

To enable easier customization of select to:
- Match theme
- Add bespoke styling
- Enable future updates to allow auto-complete text

Previously the native select's did not match the theme at all, nor would they react if the theme changed between modes