### PR TITLE
feat: style worker input

### DIFF
--- a/ui/src/common/components/Input/Input.tsx
+++ b/ui/src/common/components/Input/Input.tsx
@@ -3,8 +3,8 @@ import { Container, LabelContainer } from "./styles";
 
 type InputProps<Type> = Pick<HTMLAttributes<HTMLInputElement>, "inputMode"> & {
     label: string;
-    onChange: (value: Type) => void;
-    isValid: (value: unknown) => value is Type;
+    onChange: (value?: Type) => void;
+    parseValue: (value: unknown) => Type;
     errorMessage?: string;
     className?: string;
 };
@@ -12,7 +12,7 @@ type InputProps<Type> = Pick<HTMLAttributes<HTMLInputElement>, "inputMode"> & {
 function Input<Type>({
     label,
     onChange,
-    isValid,
+    parseValue,
     errorMessage,
     inputMode,
     className,
@@ -21,11 +21,13 @@ function Input<Type>({
 
     const handleChange = (event: FormEvent<HTMLInputElement>) => {
         const input = event.currentTarget.value;
-        if (isValid(input)) {
-            onChange(input);
+        try {
+            const parsedValue = parseValue(input);
+            onChange(parsedValue);
             setIsInvalid(false);
-        } else {
+        } catch {
             setIsInvalid(true);
+            onChange(undefined);
         }
     };
 

--- a/ui/src/common/components/Input/Input.tsx
+++ b/ui/src/common/components/Input/Input.tsx
@@ -1,11 +1,14 @@
 import React, { FormEvent, HTMLAttributes, useState } from "react";
-import { Container, LabelContainer } from "./styles";
+
+import { Container, LabelContainer, Input as StyledInput } from "./styles";
+import { ColorPalettes } from "../..";
 
 type InputProps<Type> = Pick<HTMLAttributes<HTMLInputElement>, "inputMode"> & {
     label: string;
     onChange: (value?: Type) => void;
     parseValue: (value: unknown) => Type;
     errorMessage?: string;
+    palette?: ColorPalettes;
     className?: string;
 };
 
@@ -15,6 +18,7 @@ function Input<Type>({
     parseValue,
     errorMessage,
     inputMode,
+    palette = "secondary",
     className,
 }: InputProps<Type>) {
     const [isInvalid, setIsInvalid] = useState<boolean>(false);
@@ -35,10 +39,11 @@ function Input<Type>({
         <Container className={className}>
             <LabelContainer>
                 {label}
-                <input
+                <StyledInput
                     inputMode={inputMode}
                     onChange={handleChange}
                     aria-invalid={isInvalid}
+                    palette={palette}
                 />
             </LabelContainer>
             {isInvalid && errorMessage ? (

--- a/ui/src/common/components/Input/Input.tsx
+++ b/ui/src/common/components/Input/Input.tsx
@@ -1,0 +1,49 @@
+import React, { FormEvent, HTMLAttributes, useState } from "react";
+import { Container, LabelContainer } from "./styles";
+
+type InputProps<Type> = Pick<HTMLAttributes<HTMLInputElement>, "inputMode"> & {
+    label: string;
+    onChange: (value: Type) => void;
+    isValid: (value: unknown) => value is Type;
+    errorMessage?: string;
+    className?: string;
+};
+
+function Input<Type>({
+    label,
+    onChange,
+    isValid,
+    errorMessage,
+    inputMode,
+    className,
+}: InputProps<Type>) {
+    const [isInvalid, setIsInvalid] = useState<boolean>(false);
+
+    const handleChange = (event: FormEvent<HTMLInputElement>) => {
+        const input = event.currentTarget.value;
+        if (isValid(input)) {
+            onChange(input);
+            setIsInvalid(false);
+        } else {
+            setIsInvalid(true);
+        }
+    };
+
+    return (
+        <Container className={className}>
+            <LabelContainer>
+                {label}
+                <input
+                    inputMode={inputMode}
+                    onChange={handleChange}
+                    aria-invalid={isInvalid}
+                />
+            </LabelContainer>
+            {isInvalid && errorMessage ? (
+                <span role="alert">{errorMessage}</span>
+            ) : null}
+        </Container>
+    );
+}
+
+export { Input };

--- a/ui/src/common/components/Input/__tests__/Input.test.tsx
+++ b/ui/src/common/components/Input/__tests__/Input.test.tsx
@@ -39,8 +39,13 @@ async function clearInput({ label }: { label: string }): Promise<void> {
     });
 }
 
-function isValid(value: unknown): value is number {
-    return !isNaN(Number(value));
+function parseValue(value: unknown): number {
+    const parsed = Number(value);
+    if (isNaN(parsed)) {
+        throw new Error();
+    }
+
+    return parsed;
 }
 
 beforeEach(() => {
@@ -51,7 +56,7 @@ test("renders an input with the provided label text", async () => {
     render(
         <Input
             label={expectedLabelText}
-            isValid={isValid}
+            parseValue={parseValue}
             onChange={mockOnChangeHandler}
         />
     );
@@ -69,20 +74,20 @@ test("calls the provided on change handler if a valid input is entered", async (
     render(
         <Input
             label={expectedLabelText}
-            isValid={isValid}
+            parseValue={parseValue}
             onChange={mockOnChangeHandler}
         />
     );
     await typeValue({ label: expectedLabelText, value: expectedValue });
 
-    expect(mockOnChangeHandler).toHaveBeenCalledWith(expectedValue);
+    expect(mockOnChangeHandler).toHaveBeenLastCalledWith(Number(expectedValue));
 });
 
 test("renders the provided error message if an invalid input is entered", async () => {
     render(
         <Input
             label={expectedLabelText}
-            isValid={isValid}
+            parseValue={parseValue}
             onChange={mockOnChangeHandler}
             errorMessage={expectedErrorMessage}
         />
@@ -98,7 +103,7 @@ test("does not render an error message by default", async () => {
     render(
         <Input
             label={expectedLabelText}
-            isValid={isValid}
+            parseValue={parseValue}
             onChange={mockOnChangeHandler}
             errorMessage={expectedErrorMessage}
         />
@@ -114,7 +119,7 @@ test("does not render an error message if invalid input is entered with no error
     render(
         <Input
             label={expectedLabelText}
-            isValid={isValid}
+            parseValue={parseValue}
             onChange={mockOnChangeHandler}
         />
     );
@@ -127,7 +132,7 @@ test("sets the input to invalid if an invalid input is entered", async () => {
     render(
         <Input
             label={expectedLabelText}
-            isValid={isValid}
+            parseValue={parseValue}
             onChange={mockOnChangeHandler}
         />
     );
@@ -144,7 +149,7 @@ test("does not set the input to invalid by default", async () => {
     render(
         <Input
             label={expectedLabelText}
-            isValid={isValid}
+            parseValue={parseValue}
             onChange={mockOnChangeHandler}
         />
     );
@@ -160,7 +165,7 @@ test("clears invalid state after changing input to valid input", async () => {
     render(
         <Input
             label={expectedLabelText}
-            isValid={isValid}
+            parseValue={parseValue}
             onChange={mockOnChangeHandler}
         />
     );
@@ -185,7 +190,7 @@ test("clears error message if provided after changing input to valid input", asy
     render(
         <Input
             label={expectedLabelText}
-            isValid={isValid}
+            parseValue={parseValue}
             onChange={mockOnChangeHandler}
             errorMessage={expectedErrorMessage}
         />
@@ -197,4 +202,17 @@ test("clears error message if provided after changing input to valid input", asy
     await clearInput({ label: expectedLabelText });
 
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+});
+
+test("provides undefined to change handler if invalid input is provided", async () => {
+    render(
+        <Input
+            label={expectedLabelText}
+            parseValue={parseValue}
+            onChange={mockOnChangeHandler}
+        />
+    );
+    await typeValue({ label: expectedLabelText, value: invalidInput });
+
+    expect(mockOnChangeHandler).toHaveBeenLastCalledWith(undefined);
 });

--- a/ui/src/common/components/Input/__tests__/Input.test.tsx
+++ b/ui/src/common/components/Input/__tests__/Input.test.tsx
@@ -1,0 +1,200 @@
+import React from "react";
+import { act, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import { renderWithTestProviders as render } from "../../../../test/utils";
+import Input from "..";
+
+const expectedLabelText = "Label:";
+const expectedErrorMessage = "A test error message";
+const invalidInput = "test";
+const mockOnChangeHandler = vi.fn();
+
+async function typeValue({
+    label,
+    value,
+}: {
+    label: string;
+    value: string;
+}): Promise<void> {
+    const user = userEvent.setup();
+    const input = await screen.findByLabelText(label, {
+        selector: "input",
+    });
+
+    await act(async () => {
+        await user.type(input, value);
+    });
+}
+
+async function clearInput({ label }: { label: string }): Promise<void> {
+    const user = userEvent.setup();
+    const input = await screen.findByLabelText(label, {
+        selector: "input",
+    });
+
+    await act(async () => {
+        await user.clear(input);
+    });
+}
+
+function isValid(value: unknown): value is number {
+    return !isNaN(Number(value));
+}
+
+beforeEach(() => {
+    mockOnChangeHandler.mockReset();
+});
+
+test("renders an input with the provided label text", async () => {
+    render(
+        <Input
+            label={expectedLabelText}
+            isValid={isValid}
+            onChange={mockOnChangeHandler}
+        />
+    );
+
+    expect(
+        await screen.findByLabelText(expectedLabelText, {
+            selector: "input",
+        })
+    ).toBeVisible();
+});
+
+test("calls the provided on change handler if a valid input is entered", async () => {
+    const expectedValue = "123";
+
+    render(
+        <Input
+            label={expectedLabelText}
+            isValid={isValid}
+            onChange={mockOnChangeHandler}
+        />
+    );
+    await typeValue({ label: expectedLabelText, value: expectedValue });
+
+    expect(mockOnChangeHandler).toHaveBeenCalledWith(expectedValue);
+});
+
+test("renders the provided error message if an invalid input is entered", async () => {
+    render(
+        <Input
+            label={expectedLabelText}
+            isValid={isValid}
+            onChange={mockOnChangeHandler}
+            errorMessage={expectedErrorMessage}
+        />
+    );
+    await typeValue({ label: expectedLabelText, value: invalidInput });
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toBeVisible();
+    expect(alert).toHaveTextContent(expectedErrorMessage);
+});
+
+test("does not render an error message by default", async () => {
+    render(
+        <Input
+            label={expectedLabelText}
+            isValid={isValid}
+            onChange={mockOnChangeHandler}
+            errorMessage={expectedErrorMessage}
+        />
+    );
+    await screen.findByLabelText(expectedLabelText, {
+        selector: "input",
+    });
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+});
+
+test("does not render an error message if invalid input is entered with no error message provided", async () => {
+    render(
+        <Input
+            label={expectedLabelText}
+            isValid={isValid}
+            onChange={mockOnChangeHandler}
+        />
+    );
+    await typeValue({ label: expectedLabelText, value: invalidInput });
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+});
+
+test("sets the input to invalid if an invalid input is entered", async () => {
+    render(
+        <Input
+            label={expectedLabelText}
+            isValid={isValid}
+            onChange={mockOnChangeHandler}
+        />
+    );
+    await typeValue({ label: expectedLabelText, value: invalidInput });
+
+    expect(
+        await screen.findByLabelText(expectedLabelText, {
+            selector: "input",
+        })
+    ).toBeInvalid();
+});
+
+test("does not set the input to invalid by default", async () => {
+    render(
+        <Input
+            label={expectedLabelText}
+            isValid={isValid}
+            onChange={mockOnChangeHandler}
+        />
+    );
+
+    expect(
+        await screen.findByLabelText(expectedLabelText, {
+            selector: "input",
+        })
+    ).toBeValid();
+});
+
+test("clears invalid state after changing input to valid input", async () => {
+    render(
+        <Input
+            label={expectedLabelText}
+            isValid={isValid}
+            onChange={mockOnChangeHandler}
+        />
+    );
+    await typeValue({ label: expectedLabelText, value: invalidInput });
+
+    expect(
+        await screen.findByLabelText(expectedLabelText, {
+            selector: "input",
+        })
+    ).toBeInvalid();
+
+    await clearInput({ label: expectedLabelText });
+
+    expect(
+        await screen.findByLabelText(expectedLabelText, {
+            selector: "input",
+        })
+    ).toBeValid();
+});
+
+test("clears error message if provided after changing input to valid input", async () => {
+    render(
+        <Input
+            label={expectedLabelText}
+            isValid={isValid}
+            onChange={mockOnChangeHandler}
+            errorMessage={expectedErrorMessage}
+        />
+    );
+    await typeValue({ label: expectedLabelText, value: invalidInput });
+
+    expect(await screen.findByRole("alert")).toBeVisible();
+
+    await clearInput({ label: expectedLabelText });
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+});

--- a/ui/src/common/components/Input/index.ts
+++ b/ui/src/common/components/Input/index.ts
@@ -1,0 +1,3 @@
+import { Input } from "./Input";
+
+export default Input;

--- a/ui/src/common/components/Input/styles.tsx
+++ b/ui/src/common/components/Input/styles.tsx
@@ -1,4 +1,6 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
+
+import { ColorPalettes } from "../../types";
 
 export const Container = styled.div`
     display: flex;
@@ -8,4 +10,35 @@ export const Container = styled.div`
 export const LabelContainer = styled.label`
     display: flex;
     flex-direction: column;
+`;
+
+type InputProps = {
+    palette: ColorPalettes;
+};
+
+export const Input = styled.input<InputProps>`
+    ${({ theme, palette, "aria-invalid": invalid }) => css`
+        color: ${theme.color[palette].on_container};
+        background-color: ${theme.color[palette].container};
+        border: 1px solid ${theme.color[palette].container};
+
+        :hover,
+        :focus {
+            border-color: ${theme.color[palette].on_container};
+        }
+
+        ${invalid &&
+        css`
+            border-color: ${theme.color.error.main};
+
+            :hover,
+            :focus {
+                border-color: ${theme.color.error.main};
+            }
+        `}
+    `}
+
+    padding: 0.5rem;
+    border-radius: 0.25rem;
+    outline: none;
 `;

--- a/ui/src/common/components/Input/styles.tsx
+++ b/ui/src/common/components/Input/styles.tsx
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+`;
+
+export const LabelContainer = styled.label`
+    display: flex;
+    flex-direction: column;
+`;

--- a/ui/src/common/components/Selector/Selector.tsx
+++ b/ui/src/common/components/Selector/Selector.tsx
@@ -9,7 +9,7 @@ import {
     ToggleButton,
     ToggleIndicatorIcon,
 } from "./styles";
-import { ColorPallettes } from "../..";
+import { ColorPalettes } from "../..";
 
 interface SelectorProps<Item> extends Pick<UseSelectProps<Item>, "items"> {
     labelText: string;
@@ -17,7 +17,7 @@ interface SelectorProps<Item> extends Pick<UseSelectProps<Item>, "items"> {
     itemToDisplayText: (item: Item) => string;
     defaultSelectedItem: Item;
     onSelectedItemChange?: (item?: Item) => void;
-    palette?: ColorPallettes;
+    palette?: ColorPalettes;
     className?: string;
 }
 
@@ -51,9 +51,9 @@ function Selector<Item>({
     });
 
     return (
-        <Container pallette={palette} className={className}>
+        <Container palette={palette} className={className}>
             <label {...getLabelProps()}>{labelText}</label>
-            <ToggleButton {...getToggleButtonProps()} pallette={palette}>
+            <ToggleButton {...getToggleButtonProps()} palette={palette}>
                 <span>
                     {itemToDisplayText(
                         selectedItem ? selectedItem : defaultSelectedItem
@@ -61,14 +61,14 @@ function Selector<Item>({
                 </span>
                 <ToggleIndicatorIcon icon={faChevronDown} selected={isOpen} />
             </ToggleButton>
-            <Menu {...getMenuProps()} isOpen={isOpen} pallette={palette}>
+            <Menu {...getMenuProps()} isOpen={isOpen} palette={palette}>
                 {isOpen ? (
                     <>
                         {items.map((item, index) => (
                             <Item
                                 key={itemToKey(item, index)}
                                 {...getItemProps({ item, index })}
-                                pallette={palette}
+                                palette={palette}
                             >
                                 {itemToDisplayText(item)}
                             </Item>

--- a/ui/src/common/components/Selector/styles.tsx
+++ b/ui/src/common/components/Selector/styles.tsx
@@ -1,13 +1,13 @@
 import styled, { css } from "styled-components";
-
-import { ColorPallettes } from "../../types";
 import {
     FontAwesomeIcon,
     FontAwesomeIconProps,
 } from "@fortawesome/react-fontawesome";
 
+import { ColorPalettes } from "../../types";
+
 type CommonProps = {
-    pallette: ColorPallettes;
+    palette: ColorPalettes;
 };
 
 export const Container = styled.div<CommonProps>`
@@ -17,14 +17,14 @@ export const Container = styled.div<CommonProps>`
 `;
 
 export const ToggleButton = styled.div<CommonProps>`
-    ${({ theme, pallette }) => css`
-        color: ${theme.color[pallette].on_container};
-        background-color: ${theme.color[pallette].container};
-        border: 1px solid ${theme.color[pallette].container};
+    ${({ theme, palette }) => css`
+        color: ${theme.color[palette].on_container};
+        background-color: ${theme.color[palette].container};
+        border: 1px solid ${theme.color[palette].container};
 
         :hover,
         :focus-within {
-            border-color: ${theme.color[pallette].on_container};
+            border-color: ${theme.color[palette].on_container};
         }
     `};
 
@@ -58,9 +58,9 @@ type MenuProps = {
 } & CommonProps;
 
 export const Menu = styled.div<MenuProps>`
-    ${({ theme, isOpen, pallette }) => css`
-        color: ${theme.color[pallette].on_container};
-        background-color: ${theme.color[pallette].container};
+    ${({ theme, isOpen, palette }) => css`
+        color: ${theme.color[palette].on_container};
+        background-color: ${theme.color[palette].container};
         display: ${!isOpen ? "none" : "inline-block"};
     `};
 
@@ -74,9 +74,9 @@ export const Menu = styled.div<MenuProps>`
 `;
 
 export const Item = styled.li<CommonProps>`
-    ${({ theme, pallette }) => css`
+    ${({ theme, palette }) => css`
         :hover {
-            background-color: ${theme.color[pallette].outline};
+            background-color: ${theme.color[palette].outline};
         }
     `};
 

--- a/ui/src/common/components/Selector/styles.tsx
+++ b/ui/src/common/components/Selector/styles.tsx
@@ -33,7 +33,6 @@ export const ToggleButton = styled.div<CommonProps>`
     align-items: center;
     padding: 0.5rem;
     border-radius: 0.25rem;
-    margin-bottom: 0.5rem;
 `;
 
 interface ToggleIndicatorIconProps extends FontAwesomeIconProps {

--- a/ui/src/common/components/index.ts
+++ b/ui/src/common/components/index.ts
@@ -1,1 +1,4 @@
-export * from "./Selector";
+import Selector from "./Selector";
+import Input from "./Input";
+
+export { Selector, Input };

--- a/ui/src/common/types/theme.ts
+++ b/ui/src/common/types/theme.ts
@@ -5,6 +5,6 @@ type KeyColorKeys<T> = {
     [K in keyof T]: T[K] extends KeyColor ? K : never;
 }[keyof T];
 
-type ColorPallettes = KeyColorKeys<DefaultTheme["color"]>;
+type ColorPalettes = KeyColorKeys<DefaultTheme["color"]>;
 
-export type { ColorPallettes };
+export type { ColorPalettes };

--- a/ui/src/pages/Calculator/__tests__/Calculator.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator.test.tsx
@@ -65,7 +65,7 @@ describe("worker input rendering", () => {
             await screen.findByLabelText(expectedWorkerInputLabel, {
                 selector: "input",
             })
-        );
+        ).toBeVisible();
     });
 
     test("does not render an error message by default", async () => {

--- a/ui/src/pages/Calculator/components/ItemSelector/ItemSelector.tsx
+++ b/ui/src/pages/Calculator/components/ItemSelector/ItemSelector.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { Item } from "../../../../graphql/__generated__/graphql";
-import Selector from "../../../../common/components/Selector";
+import { Selector } from "../../../../common/components";
 
 type ItemName = Pick<Item, "name">;
 

--- a/ui/src/pages/Calculator/components/OutputUnitSelector/OutputUnitSelector.tsx
+++ b/ui/src/pages/Calculator/components/OutputUnitSelector/OutputUnitSelector.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { OutputUnit } from "../../../../graphql/__generated__/graphql";
 import { OutputUnitSelectorMappings } from "../../utils";
-import Selector from "../../../../common/components/Selector";
+import { Selector } from "../../../../common/components";
 
 type ItemSelectorProps = {
     onUnitChange: (unit: OutputUnit) => void;

--- a/ui/src/pages/Calculator/components/ToolSelector/ToolSelector.tsx
+++ b/ui/src/pages/Calculator/components/ToolSelector/ToolSelector.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { Tools } from "../../../../graphql/__generated__/graphql";
 import { ToolSelectorMappings } from "../../utils";
-import Selector from "../../../../common/components/Selector";
+import { Selector } from "../../../../common/components";
 
 type ToolSelectorProps = {
     onToolChange: (unit: Tools) => void;

--- a/ui/src/pages/Calculator/components/WorkerInput/WorkerInput.tsx
+++ b/ui/src/pages/Calculator/components/WorkerInput/WorkerInput.tsx
@@ -1,38 +1,29 @@
-import React, { FormEvent, useState } from "react";
-import { Container } from "./styles";
+import React from "react";
+
+import { Input } from "../../../../common/components";
 
 type ItemSelectorProps = {
     onWorkerChange: (workers?: number) => void;
 };
 
 function WorkerInput({ onWorkerChange }: ItemSelectorProps) {
-    const [isInvalid, setIsInvalid] = useState<boolean>(false);
-
-    const handleWorkerChange = (event: FormEvent<HTMLInputElement>) => {
-        const input = Number(event.currentTarget.value);
-        if (isNaN(input) || input <= 0 || input % 1 !== 0) {
-            setIsInvalid(true);
-            onWorkerChange(undefined);
-        } else {
-            setIsInvalid(false);
-            onWorkerChange(input);
+    const parseValue = (value: unknown): number => {
+        const input = Number(value);
+        if (!isNaN(input) && input > 0 && input % 1 === 0) {
+            return input;
         }
+
+        throw new Error();
     };
 
     return (
-        <Container>
-            <label htmlFor="worker-input">Workers:</label>
-            <input
-                id="worker-input"
-                inputMode="numeric"
-                onChange={handleWorkerChange}
-            ></input>
-            {isInvalid ? (
-                <span role="alert">
-                    Invalid input, must be a positive non-zero whole number
-                </span>
-            ) : null}
-        </Container>
+        <Input
+            label="Workers:"
+            parseValue={parseValue}
+            onChange={onWorkerChange}
+            errorMessage="Invalid input, must be a positive non-zero whole number"
+            inputMode="numeric"
+        />
     );
 }
 

--- a/ui/src/pages/Calculator/components/WorkerInput/styles.tsx
+++ b/ui/src/pages/Calculator/components/WorkerInput/styles.tsx
@@ -1,6 +1,0 @@
-import styled from "styled-components";
-
-export const Container = styled.div`
-    display: flex;
-    flex-direction: column;
-`;


### PR DESCRIPTION
# What

Added common input component that has theme styling
- Can provide any of the theme's color palettes

Replaced all usages of native input element with new component (Worker Input)

# Why

To provide styling to the worker input such that it matches the rest of the site's theme
- Previously, the element did not react to theme mode updates

Added it as a common component to:
- Allow re-use w/o needing to re-style
- Allow for more granular functionality (clear all input etc.) to be added without needing to test that specifically through each usage