### PR TITLE
feat: 150 optional output schema support

### DIFF
--- a/api/src/functions/add-item/domain/__tests__/add-item.test.ts
+++ b/api/src/functions/add-item/domain/__tests__/add-item.test.ts
@@ -373,6 +373,255 @@ describe.each([
             },
         ]),
     ],
+    [
+        "an item with an optional output that is missing a name",
+        JSON.stringify([
+            {
+                name: "test",
+                createTime: 2,
+                output: 1,
+                requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
+                optionalOutput: [
+                    {
+                        amount: 1,
+                        likelihood: 0.5,
+                    },
+                ],
+            },
+            {
+                name: "wibble",
+                createTime: 1,
+                output: 1,
+                requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
+            },
+        ]),
+    ],
+    [
+        "an item with an optional output that is missing an output amount",
+        JSON.stringify([
+            {
+                name: "test",
+                createTime: 2,
+                output: 1,
+                requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
+                optionalOutput: [
+                    {
+                        name: "wibble",
+                        likelihood: 0.5,
+                    },
+                ],
+            },
+            {
+                name: "wibble",
+                createTime: 1,
+                output: 1,
+                requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
+            },
+        ]),
+    ],
+    [
+        "an item with an optional output that has a non-numeric output amount",
+        JSON.stringify([
+            {
+                name: "test",
+                createTime: 2,
+                output: 1,
+                requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
+                optionalOutput: [
+                    {
+                        name: "wibble",
+                        amount: "test",
+                        likelihood: 0.5,
+                    },
+                ],
+            },
+            {
+                name: "wibble",
+                createTime: 1,
+                output: 1,
+                requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
+            },
+        ]),
+    ],
+    [
+        "an item with an optional output that has an output amount less than one",
+        JSON.stringify([
+            {
+                name: "test",
+                createTime: 2,
+                output: 1,
+                requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
+                optionalOutput: [
+                    {
+                        name: "wibble",
+                        amount: 0,
+                        likelihood: 0.5,
+                    },
+                ],
+            },
+            {
+                name: "wibble",
+                createTime: 1,
+                output: 1,
+                requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
+            },
+        ]),
+    ],
+    [
+        "an item with an optional output that is missing an output likelihood",
+        JSON.stringify([
+            {
+                name: "test",
+                createTime: 2,
+                output: 1,
+                requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
+                optionalOutput: [
+                    {
+                        name: "wibble",
+                        amount: 5,
+                    },
+                ],
+            },
+            {
+                name: "wibble",
+                createTime: 1,
+                output: 1,
+                requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
+            },
+        ]),
+    ],
+    [
+        "an item with an optional output that has a non-numeric output likelihood",
+        JSON.stringify([
+            {
+                name: "test",
+                createTime: 2,
+                output: 1,
+                requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
+                optionalOutput: [
+                    {
+                        name: "wibble",
+                        amount: 2,
+                        likelihood: "test",
+                    },
+                ],
+            },
+            {
+                name: "wibble",
+                createTime: 1,
+                output: 1,
+                requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
+            },
+        ]),
+    ],
+    [
+        "an item with an optional output that has output likelihood less than zero",
+        JSON.stringify([
+            {
+                name: "test",
+                createTime: 2,
+                output: 1,
+                requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
+                optionalOutput: [
+                    {
+                        name: "wibble",
+                        amount: 2,
+                        likelihood: -1,
+                    },
+                ],
+            },
+            {
+                name: "wibble",
+                createTime: 1,
+                output: 1,
+                requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
+            },
+        ]),
+    ],
+    [
+        "an item with an optional output that has output likelihood equal to zero",
+        JSON.stringify([
+            {
+                name: "test",
+                createTime: 2,
+                output: 1,
+                requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
+                optionalOutput: [
+                    {
+                        name: "wibble",
+                        amount: 2,
+                        likelihood: 0,
+                    },
+                ],
+            },
+            {
+                name: "wibble",
+                createTime: 1,
+                output: 1,
+                requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
+            },
+        ]),
+    ],
+    [
+        "an item with an optional output that has output likelihood greater than one",
+        JSON.stringify([
+            {
+                name: "test",
+                createTime: 2,
+                output: 1,
+                requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
+                optionalOutput: [
+                    {
+                        name: "wibble",
+                        amount: 2,
+                        likelihood: 2,
+                    },
+                ],
+            },
+            {
+                name: "wibble",
+                createTime: 1,
+                output: 1,
+                requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
+            },
+        ]),
+    ],
 ])(
     "handles invalid input (schema validation) given %s",
     (_: string, input: string) => {

--- a/api/src/functions/add-item/domain/__tests__/add-item.test.ts
+++ b/api/src/functions/add-item/domain/__tests__/add-item.test.ts
@@ -1,5 +1,5 @@
 import { Items, Tools } from "../../../../types";
-import { createItem } from "../../../../../test";
+import { createItem, createOptionalOutput } from "../../../../../test";
 
 import { storeItem } from "../../adapters/store-item";
 
@@ -30,7 +30,21 @@ const validItemWithReqs = createItem({
     minimumTool: Tools.none,
     maximumTool: Tools.none,
 });
-const validItems = [validItem, validItemWithReqs];
+const validItemWithOptionalOutputs = createItem({
+    name: "test item",
+    createTime: 1,
+    output: 1,
+    requirements: [],
+    optionalOutputs: [
+        createOptionalOutput({
+            name: "item name 1",
+            amount: 1,
+            likelihood: 0.5,
+        }),
+    ],
+});
+
+const validItems = [validItem, validItemWithReqs, validItemWithOptionalOutputs];
 
 const errorLogSpy = jest
     .spyOn(console, "error")
@@ -651,6 +665,23 @@ describe.each([
         "unknown item requirements",
         validItemWithReqs,
         "Missing requirement: item name 1 in item name 2",
+    ],
+    [
+        "unknown optional output item",
+        createItem({
+            name: "test item",
+            createTime: 1,
+            output: 1,
+            requirements: [],
+            optionalOutputs: [
+                createOptionalOutput({
+                    name: "test optional item",
+                    amount: 1,
+                    likelihood: 0.5,
+                }),
+            ],
+        }),
+        "Missing optional output: test optional item in test item",
     ],
     [
         "invalid min/max tool combination (none above stone)",

--- a/api/src/functions/add-item/domain/add-item.ts
+++ b/api/src/functions/add-item/domain/add-item.ts
@@ -39,6 +39,23 @@ function validateRequirements(items: Items): void {
     }
 }
 
+function validateOptionalOutputs(items: Items): void {
+    const itemMap = new Set<string>(items.map((item) => item.name));
+    for (const item of items) {
+        if (!item.optionalOutputs) {
+            continue;
+        }
+
+        for (const optionalOutput of item.optionalOutputs) {
+            if (!itemMap.has(optionalOutput.name)) {
+                throw new Error(
+                    `Missing optional output: ${optionalOutput.name} in ${item.name}`
+                );
+            }
+        }
+    }
+}
+
 function validateTools(items: Items): void {
     for (const item of items) {
         ToolModifierValues;
@@ -55,6 +72,7 @@ function validateTools(items: Items): void {
 const addItem: AddItemPrimaryPort = async (items) => {
     const parsedItems = parseItems(items);
     validateRequirements(parsedItems);
+    validateOptionalOutputs(parsedItems);
     validateTools(parsedItems);
 
     try {

--- a/api/src/json/items.json
+++ b/api/src/json/items.json
@@ -144,6 +144,13 @@
             }
         ],
         "minimumTool": "none",
-        "maximumTool": "steel"
+        "maximumTool": "steel",
+        "optionalOutputs": [
+            {
+                "name": "Empty Pot",
+                "amount": 2,
+                "likelihood": 0.95
+            }
+        ]
     }
 ]

--- a/api/src/json/schemas/items.json
+++ b/api/src/json/schemas/items.json
@@ -50,6 +50,33 @@
             "maximumTool": {
                 "$ref": "#/definitions/tools"
             },
+            "optionalOutputs": {
+                "description": "Optional outputs that can be created at the same time as this item",
+                "type": "array",
+                "items": {
+                    "title": "OptionalOutput",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "description": "The name of the optional output item",
+                            "type": "string"
+                        },
+                        "amount": {
+                            "description": "The amount of the optional output produced",
+                            "type": "number",
+                            "minimum": 1
+                        },
+                        "likelihood": {
+                            "description": "The likelihood this optional output item will be produced",
+                            "type": "number",
+                            "exclusiveMinimum": 0,
+                            "maximum": 1
+                        }
+                    },
+                    "required": ["name", "amount", "likelihood"],
+                    "additionalProperties": false
+                }
+            },
             "size": {
                 "description": "Optimal size of crafting area, only provided for farms",
                 "type": "object",

--- a/api/test/item-utils.ts
+++ b/api/test/item-utils.ts
@@ -1,9 +1,27 @@
-import { Item, Requirement, Requirements, Tools } from "../src/types";
+import {
+    Item,
+    OptionalOutput,
+    Requirement,
+    Requirements,
+    Tools,
+} from "../src/types";
 
 function createRequirements(name: string, amount: number): Requirement {
     return {
         name,
         amount,
+    };
+}
+
+function createOptionalOutput(
+    name: string,
+    amount: number,
+    likelihood: number
+): OptionalOutput {
+    return {
+        name,
+        amount,
+        likelihood,
     };
 }
 
@@ -14,6 +32,7 @@ function createItem({
     requirements,
     minimumTool = Tools.none,
     maximumTool = Tools.none,
+    optionalOutputs,
     width,
     height,
 }: {
@@ -23,6 +42,7 @@ function createItem({
     requirements: Requirements;
     minimumTool?: Tools;
     maximumTool?: Tools;
+    optionalOutputs?: OptionalOutput[];
     width?: number;
     height?: number;
 }): Item {
@@ -34,7 +54,8 @@ function createItem({
         ...(width && height ? { size: { width, height } } : {}),
         minimumTool,
         maximumTool,
+        ...(optionalOutputs ? optionalOutputs : {}),
     };
 }
 
-export { createItem, createRequirements };
+export { createItem, createRequirements, createOptionalOutput };

--- a/api/test/item-utils.ts
+++ b/api/test/item-utils.ts
@@ -13,11 +13,15 @@ function createRequirements(name: string, amount: number): Requirement {
     };
 }
 
-function createOptionalOutput(
-    name: string,
-    amount: number,
-    likelihood: number
-): OptionalOutput {
+function createOptionalOutput({
+    name,
+    amount,
+    likelihood,
+}: {
+    name: string;
+    amount: number;
+    likelihood: number;
+}): OptionalOutput {
     return {
         name,
         amount,
@@ -54,7 +58,7 @@ function createItem({
         ...(width && height ? { size: { width, height } } : {}),
         minimumTool,
         maximumTool,
-        ...(optionalOutputs ? optionalOutputs : {}),
+        ...(optionalOutputs ? { optionalOutputs } : {}),
     };
 }
 


### PR DESCRIPTION
Resolves #150 

# What

Updated item's schema to support specifying optional outputs
Updated add item lambda to support validating optional outputs:
- Schema validation
- Item presence validation

# Why

To enable future work to improve the accuracy of requirement estimates