### PR TITLE
feat: refactor query requirements as linear program

### DIFF
--- a/api/scripts/deploy.sh
+++ b/api/scripts/deploy.sh
@@ -60,11 +60,12 @@ terraform -chdir="$infra_dir" workspace select $environment
 echo "Building API..."
 npm --prefix $script_parent_dir run build:clean
 
-echo "Copying package definitions..."
+echo "Copying package definitions and post-build scripts..."
 folder_diff=$(( $(echo "$src_dir" | tr -cd '/' | wc -c) + 1 ))
 $script_parent_dir/node_modules/.bin/copyfiles -E -u $folder_diff \
     -e "$src_dir/**/node_modules/**" \
     "$src_dir/**/package*.json" \
+    "$src_dir/**/post-build.sh" \
     $dist_dir
 cp $script_parent_dir/package.json $dist_dir/package.json
 
@@ -74,6 +75,9 @@ cd $dist_dir && npx lerna bootstrap --ci -- --production
 
 echo "Bundle code for deployment..."
 cd $dist_dir && npx lerna exec --scope="@colony-survival-calculator/*-function" -- $script_parent_dir/node_modules/.bin/esbuild handler.js --bundle --platform=node --target=$runtime --outfile=dist/index.js
+
+echo "Run post-build scripts..."
+cd $dist_dir && npx lerna exec --scope="@colony-survival-calculator/*-function" -- bash -c 'cd . && test -f post-build.sh && ./post-build.sh || true'
 
 if [ $dryrun ]; then
     echo "Dry run deployment of UI for environment: $environment..."

--- a/api/src/functions/query-requirements/domain/__tests__/query-requirements.test.ts
+++ b/api/src/functions/query-requirements/domain/__tests__/query-requirements.test.ts
@@ -295,11 +295,9 @@ test("returns combined requirements given item with multiple nested requirements
     const actual = await queryRequirements(validItemName, validWorkers);
 
     expect(actual).toHaveLength(3);
-    expect(actual).toEqual([
-        { name: requiredItem1.name, workers: 7.5 },
-        { name: requiredItem2.name, workers: 30 },
-        { name: requiredItem3.name, workers: 30 },
-    ]);
+    expect(actual).toContainEqual({ name: requiredItem1.name, workers: 7.5 });
+    expect(actual).toContainEqual({ name: requiredItem2.name, workers: 30 });
+    expect(actual).toContainEqual({ name: requiredItem3.name, workers: 30 });
 });
 
 test("throws an error if an unhandled exception occurs while fetching item requirements", async () => {

--- a/api/src/functions/query-requirements/glpk-js-fixed.d.ts
+++ b/api/src/functions/query-requirements/glpk-js-fixed.d.ts
@@ -1,0 +1,87 @@
+// Taken from: https://github.com/jvail/glpk.js/blob/3d2ff55364fd61689f027de9abda179f4e09c7e9/dist/glpk.d.ts
+
+declare module "glpk.js" {
+    export interface LP {
+        name: string;
+        objective: {
+            direction: number;
+            name: string;
+            vars: { name: string; coef: number }[];
+        };
+        subjectTo: {
+            name: string;
+            vars: { name: string; coef: number }[];
+            bnds: { type: number; ub: number; lb: number };
+        }[];
+        bounds?: {
+            name: string;
+            type: number;
+            ub: number;
+            lb: number;
+        }[];
+        binaries?: string[];
+        generals?: string[];
+        options?: Options;
+    }
+
+    export interface Options {
+        mipgap?: number /* set relative mip gap tolerance to mipgap, default 0.0 */;
+        tmlim?: number /* limit solution time to tmlim seconds, default INT_MAX */;
+        msglev?: number /* message level for terminal output, default GLP_MSG_ERR */;
+        presol?: boolean /* use presolver, default true */;
+        cb?: {
+            /* a callback called at each 'each' iteration (only simplex) */
+            call(result: Result);
+            each: number;
+        };
+    }
+
+    export interface Result {
+        name: string;
+        time: number;
+        result: {
+            status: number;
+            z: number;
+            vars: { [key: string]: number };
+            dual?: { [key: string]: number } /* simplex only */;
+        };
+    }
+
+    export interface GLPK {
+        /* direction */
+        readonly GLP_MIN: number /* minimization */;
+        readonly GLP_MAX: number /* maximization */;
+
+        /* type of auxiliary/structural variable: */
+        readonly GLP_FR: number /* free (unbounded) variable */;
+        readonly GLP_LO: number /* variable with lower bound */;
+        readonly GLP_UP: number /* variable with upper bound */;
+        readonly GLP_DB: number /* double-bounded variable */;
+        readonly GLP_FX: number /* fixed variable */;
+
+        /* message level: */
+        readonly GLP_MSG_OFF: number /* no output */;
+        readonly GLP_MSG_ERR: number /* warning and error messages only */;
+        readonly GLP_MSG_ON: number /* normal output */;
+        readonly GLP_MSG_ALL: number /* full output */;
+        readonly GLP_MSG_DBG: number /* debug output */;
+
+        /* solution status: */
+        readonly GLP_UNDEF: number /* solution is undefined */;
+        readonly GLP_FEAS: number /* solution is feasible */;
+        readonly GLP_INFEAS: number /* solution is infeasible */;
+        readonly GLP_NOFEAS: number /* no feasible solution exists */;
+        readonly GLP_OPT: number /* solution is optimal */;
+        readonly GLP_UNBND: number /* solution is unbounded */;
+
+        version: string /* GLPK version */;
+        write(lp: LP): string /* writes problem data in CPLEX LP */;
+        solve(
+            lp: LP,
+            options?: number | Options
+        ): Result /* options is either a glp message level or an options obj */;
+    }
+
+    declare const GLPKConstructor: () => GLPK;
+    export default GLPKConstructor;
+}

--- a/api/src/functions/query-requirements/package-lock.json
+++ b/api/src/functions/query-requirements/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.0.0",
             "dependencies": {
                 "aws4": "1.12.0",
+                "glpk.js": "4.0.1",
                 "mongodb": "5.2.0"
             }
         },
@@ -42,6 +43,14 @@
             "integrity": "sha512-HevkSpDbpUfsrHWmWiAsNavANKYIErV2ePXllp1bwq5CDreAaFVj6RVlZpJnxK4WWDCJ/5jMUpaY6G526q3Hjg==",
             "engines": {
                 "node": ">=14.20.1"
+            }
+        },
+        "node_modules/glpk.js": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/glpk.js/-/glpk.js-4.0.1.tgz",
+            "integrity": "sha512-sxb3UT9IP2NXCocvFoC4I4XcvyVRGTS48hRWWpSAnl8yrsSbKDF58HjR8BUu1YxXHkkZ3kq7ycs7RLvI7l1pYg==",
+            "dependencies": {
+                "pako": "^2.0.4"
             }
         },
         "node_modules/ip": {
@@ -95,6 +104,11 @@
                 "@types/whatwg-url": "^8.2.1",
                 "whatwg-url": "^11.0.0"
             }
+        },
+        "node_modules/pako": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+            "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
         },
         "node_modules/punycode": {
             "version": "2.3.0",
@@ -209,6 +223,14 @@
             "resolved": "https://registry.npmjs.org/bson/-/bson-5.2.0.tgz",
             "integrity": "sha512-HevkSpDbpUfsrHWmWiAsNavANKYIErV2ePXllp1bwq5CDreAaFVj6RVlZpJnxK4WWDCJ/5jMUpaY6G526q3Hjg=="
         },
+        "glpk.js": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/glpk.js/-/glpk.js-4.0.1.tgz",
+            "integrity": "sha512-sxb3UT9IP2NXCocvFoC4I4XcvyVRGTS48hRWWpSAnl8yrsSbKDF58HjR8BUu1YxXHkkZ3kq7ycs7RLvI7l1pYg==",
+            "requires": {
+                "pako": "^2.0.4"
+            }
+        },
         "ip": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
@@ -239,6 +261,11 @@
                 "@types/whatwg-url": "^8.2.1",
                 "whatwg-url": "^11.0.0"
             }
+        },
+        "pako": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+            "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
         },
         "punycode": {
             "version": "2.3.0",

--- a/api/src/functions/query-requirements/package.json
+++ b/api/src/functions/query-requirements/package.json
@@ -5,6 +5,7 @@
     "dependencies": {
         "@colony-survival-calculator/mongodb-client": "0.0.0",
         "aws4": "1.12.0",
+        "glpk.js": "4.0.1",
         "mongodb": "5.2.0"
     }
 }

--- a/api/src/functions/query-requirements/post-build.sh
+++ b/api/src/functions/query-requirements/post-build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+script_dir=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
+
+cp $script_dir/node_modules/glpk.js/dist/glpk.wasm $script_dir/dist/glpk.wasm


### PR DESCRIPTION
# What

Updated query requirements lambda to use linear programming to solve requirements calculation
Updated API deploy script to allow for a post-build script to be run for each lambda
- Enables copying required files to dist folder before zip and deployment
- In the case of the query requirements lambda this is necessary to copy `glpk.wasm`

# Why

Linear programming: 
- Should scale better with larger numbers of constraints (useful if we start to consider larger recipes)
- Now should be easier to add additional constraints such as individual item demand constraints (rather than overall) and optional outputs that produce items that are needed in the recipe
- Also was just generally quite an interesting problem to solve with LP

Deploy script updates:
- `glpk.wasm` is required for `glpk.js` to run, therefore needed to copy that file as part of deployment
- Did consider using esbuild for this, however, encountered issues with loading using plugins