### PR TITLE
feat(ui): 159 worker sorting

### DIFF
--- a/ui/src/pages/Calculator/components/Requirements/Requirements.tsx
+++ b/ui/src/pages/Calculator/components/Requirements/Requirements.tsx
@@ -1,6 +1,13 @@
 import React, { MouseEventHandler, useEffect, useState } from "react";
 import { useLazyQuery } from "@apollo/client";
 import { useDebounce } from "use-debounce";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+    IconDefinition,
+    faSort,
+    faSortAsc,
+    faSortDesc,
+} from "@fortawesome/free-solid-svg-icons";
 
 import {
     RequirementsTable,
@@ -21,12 +28,19 @@ type RequirementsProps = {
     maxAvailableTool?: Tools;
 };
 
-const sortDirectionMap: { [key in ValidSortDirections]: ValidSortDirections } =
-    {
-        none: "descending",
-        descending: "ascending",
-        ascending: "none",
-    };
+const sortDirectionOrderMap: {
+    [key in ValidSortDirections]: ValidSortDirections;
+} = {
+    none: "descending",
+    descending: "ascending",
+    ascending: "none",
+};
+
+const sortDirectionIconMap: { [key in ValidSortDirections]: IconDefinition } = {
+    none: faSort,
+    descending: faSortDesc,
+    ascending: faSortAsc,
+};
 
 const GET_ITEM_REQUIREMENTS = gql(`
     query GetItemRequirements($name: ID!, $workers: Int!, $maxAvailableTool: Tools) {
@@ -52,7 +66,7 @@ function Requirements({
 
     const changeWorkerSortDirection: MouseEventHandler = (event) => {
         event.stopPropagation();
-        setWorkerSortDirection(sortDirectionMap[workerSortDirection]);
+        setWorkerSortDirection(sortDirectionOrderMap[workerSortDirection]);
     };
 
     useEffect(() => {
@@ -89,8 +103,13 @@ function Requirements({
                             text-align="end"
                             aria-sort={workerSortDirection}
                             onClick={changeWorkerSortDirection}
+                            tabIndex={0}
                         >
                             <button>Workers</button>
+                            <FontAwesomeIcon
+                                icon={sortDirectionIconMap[workerSortDirection]}
+                                aria-hidden="true"
+                            />
                         </SortableHeader>
                     </tr>
                 </thead>

--- a/ui/src/pages/Calculator/components/Requirements/Requirements.tsx
+++ b/ui/src/pages/Calculator/components/Requirements/Requirements.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { MouseEventHandler, useEffect, useState } from "react";
 import { useLazyQuery } from "@apollo/client";
 import { useDebounce } from "use-debounce";
 
@@ -6,19 +6,27 @@ import {
     RequirementsTable,
     TextColumnHeader,
     TextColumnCell,
-    NumberColumnHeader,
     NumberColumnCell,
     Header,
+    SortableHeader,
 } from "./styles";
 import { gql } from "../../../../graphql/__generated__";
 import { Tools } from "../../../../graphql/__generated__/graphql";
 import { DEFAULT_DEBOUNCE } from "../../utils";
 
+type ValidSortDirections = "none" | "ascending" | "descending";
 type RequirementsProps = {
     selectedItemName: string;
     workers: number;
     maxAvailableTool?: Tools;
 };
+
+const sortDirectionMap: { [key in ValidSortDirections]: ValidSortDirections } =
+    {
+        none: "descending",
+        descending: "ascending",
+        ascending: "none",
+    };
 
 const GET_ITEM_REQUIREMENTS = gql(`
     query GetItemRequirements($name: ID!, $workers: Int!, $maxAvailableTool: Tools) {
@@ -37,7 +45,15 @@ function Requirements({
     const [getItemRequirements, { loading, data, error }] = useLazyQuery(
         GET_ITEM_REQUIREMENTS
     );
+    const [workerSortDirection, setWorkerSortDirection] =
+        useState<ValidSortDirections>("none");
+
     const [debouncedWorkers] = useDebounce(workers, DEFAULT_DEBOUNCE);
+
+    const changeWorkerSortDirection: MouseEventHandler = (event) => {
+        event.stopPropagation();
+        setWorkerSortDirection(sortDirectionMap[workerSortDirection]);
+    };
 
     useEffect(() => {
         getItemRequirements({
@@ -69,7 +85,13 @@ function Requirements({
                 <thead>
                     <tr>
                         <TextColumnHeader>Item</TextColumnHeader>
-                        <NumberColumnHeader>Workers</NumberColumnHeader>
+                        <SortableHeader
+                            text-align="end"
+                            aria-sort={workerSortDirection}
+                            onClick={changeWorkerSortDirection}
+                        >
+                            <button>Workers</button>
+                        </SortableHeader>
                     </tr>
                 </thead>
                 <tbody>

--- a/ui/src/pages/Calculator/components/Requirements/Requirements.tsx
+++ b/ui/src/pages/Calculator/components/Requirements/Requirements.tsx
@@ -100,7 +100,7 @@ function Requirements({
                     <tr>
                         <TextColumnHeader>Item</TextColumnHeader>
                         <SortableHeader
-                            text-align="end"
+                            item-alignment="end"
                             aria-sort={workerSortDirection}
                             onClick={changeWorkerSortDirection}
                             tabIndex={0}

--- a/ui/src/pages/Calculator/components/Requirements/Requirements.tsx
+++ b/ui/src/pages/Calculator/components/Requirements/Requirements.tsx
@@ -18,7 +18,7 @@ import {
     SortableHeader,
 } from "./styles";
 import { gql } from "../../../../graphql/__generated__";
-import { Tools } from "../../../../graphql/__generated__/graphql";
+import { Requirement, Tools } from "../../../../graphql/__generated__/graphql";
 import { DEFAULT_DEBOUNCE } from "../../utils";
 
 type ValidSortDirections = "none" | "ascending" | "descending";
@@ -50,6 +50,21 @@ const GET_ITEM_REQUIREMENTS = gql(`
         }
     }
 `);
+
+function sortByWorkers(
+    requirements: Readonly<Requirement[]>,
+    order: ValidSortDirections
+): Requirement[] {
+    const reference = [...requirements];
+    switch (order) {
+        case "descending":
+            return reference.sort((a, b) => b.workers - a.workers);
+        case "ascending":
+            return reference.sort((a, b) => a.workers - b.workers);
+        default:
+            return reference;
+    }
+}
 
 function Requirements({
     selectedItemName,
@@ -92,6 +107,8 @@ function Requirements({
         return <></>;
     }
 
+    const sortedWorkers = sortByWorkers(data.requirement, workerSortDirection);
+
     return (
         <>
             <Header>Requirements:</Header>
@@ -114,7 +131,7 @@ function Requirements({
                     </tr>
                 </thead>
                 <tbody>
-                    {data.requirement.map((requirement) => (
+                    {sortedWorkers.map((requirement) => (
                         <tr key={requirement.name}>
                             <TextColumnCell>{requirement.name}</TextColumnCell>
                             <NumberColumnCell>

--- a/ui/src/pages/Calculator/components/Requirements/styles.ts
+++ b/ui/src/pages/Calculator/components/Requirements/styles.ts
@@ -29,18 +29,27 @@ export const TextColumnHeader = styled.th`
 `;
 
 type SortableHeaderProps = {
-    "text-align": "start" | "end";
+    "item-alignment": "start" | "end";
 };
 
 export const SortableHeader = styled.th<SortableHeaderProps>`
-    ${({ "text-align": textAlign }) => css`
-        text-align: ${textAlign};
+    display: flex;
+
+    ${({ "item-alignment": itemAlignment, theme }) => css`
+        justify-content: ${itemAlignment};
+        align-items: center;
+
+        button {
+            color: ${theme.color.surface.on_main};
+        }
     `}
 
     button {
         border: none;
         background: none;
-        margin-right: 0.2rem;
+        margin-right: 0.5rem;
+        font-weight: bold;
+        padding: 0;
     }
 `;
 

--- a/ui/src/pages/Calculator/components/Requirements/styles.ts
+++ b/ui/src/pages/Calculator/components/Requirements/styles.ts
@@ -40,6 +40,7 @@ export const SortableHeader = styled.th<SortableHeaderProps>`
     button {
         border: none;
         background: none;
+        margin-right: 0.2rem;
     }
 `;
 

--- a/ui/src/pages/Calculator/components/Requirements/styles.ts
+++ b/ui/src/pages/Calculator/components/Requirements/styles.ts
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 export const Header = styled.h2`
     margin-bottom: 0rem;
@@ -28,8 +28,19 @@ export const TextColumnHeader = styled.th`
     text-align: start;
 `;
 
-export const NumberColumnHeader = styled.th`
-    text-align: end;
+type SortableHeaderProps = {
+    "text-align": "start" | "end";
+};
+
+export const SortableHeader = styled.th<SortableHeaderProps>`
+    ${({ "text-align": textAlign }) => css`
+        text-align: ${textAlign};
+    `}
+
+    button {
+        border: none;
+        background: none;
+    }
 `;
 
 export const TextColumnCell = styled.td`


### PR DESCRIPTION
Resolves #159 

# What

Updated requirements table to allow requirements to be sorted by the number of workers required
- Displays sort indicator on worker column header

# Why

To enable user's to see which are the most/least demanding requirements easily