### PR TITLE
fix(api): fix farm based create times

### DIFF
--- a/api/src/json/items.json
+++ b/api/src/json/items.json
@@ -22,7 +22,7 @@
     },
     {
         "name": "Wheat",
-        "createTime": 1440,
+        "createTime": 870,
         "output": 100,
         "requires": [],
         "minimumTool": "none",
@@ -34,7 +34,7 @@
     },
     {
         "name": "Log",
-        "createTime": 720,
+        "createTime": 435,
         "output": 44,
         "requires": [],
         "minimumTool": "none",


### PR DESCRIPTION
# What

Updated static item list to use working time instead of total game time for farmed items

# Why

Using total game time instead of working time meant that the optimal output calculations were way off for any farmed item.
- Wheat was being output as approx. 30 per day when it should be 50 per day.

All other items optimal output work based on the amount of time a worker spends creating it - Therefore, these items should be consistent 