### PR TITLE
feat(api): 162 worker name items schema

### DIFF
--- a/api/src/functions/add-item/adapters/__tests__/store-item.test.ts
+++ b/api/src/functions/add-item/adapters/__tests__/store-item.test.ts
@@ -99,6 +99,7 @@ describe.each([
                 requirements: [{ name: "test", amount: 1 }],
                 minimumTool: Tools.none,
                 maximumTool: Tools.steel,
+                creator: "Test Creator 1",
             }),
         ],
     ],
@@ -112,6 +113,7 @@ describe.each([
                 requirements: [{ name: "test", amount: 1 }],
                 minimumTool: Tools.copper,
                 maximumTool: Tools.bronze,
+                creator: "Test Creator 1",
             }),
             createItem({
                 name: "test item 2",
@@ -120,6 +122,7 @@ describe.each([
                 requirements: [{ name: "world", amount: 3 }],
                 minimumTool: Tools.none,
                 maximumTool: Tools.steel,
+                creator: "Test Creator 2",
             }),
         ],
     ],

--- a/api/src/functions/add-item/domain/__tests__/__snapshots__/add-item.test.ts.snap
+++ b/api/src/functions/add-item/domain/__tests__/__snapshots__/add-item.test.ts.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`handles invalid input (schema validation) given a non JSON array throws a validation error 1`] = `"Validation Error: [{"instancePath":"","schemaPath":"#/type","keyword":"type","params":{"type":"array"},"message":"must be array"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with a invalid creator name throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/creator","schemaPath":"#/items/properties/creator/type","keyword":"type","params":{"type":"string"},"message":"must be string"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with a missing creator name throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0","schemaPath":"#/items/required","keyword":"required","params":{"missingProperty":"creator"},"message":"must have required property 'creator'"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with a missing maximum tool throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0","schemaPath":"#/items/required","keyword":"required","params":{"missingProperty":"maximumTool"},"message":"must have required property 'maximumTool'"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with a missing minimum tool throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0","schemaPath":"#/items/required","keyword":"required","params":{"missingProperty":"minimumTool"},"message":"must have required property 'minimumTool'"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with a missing name throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0","schemaPath":"#/items/required","keyword":"required","params":{"missingProperty":"name"},"message":"must have required property 'name'"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with a non-object requirement throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/requires/0","schemaPath":"#/items/properties/requires/items/type","keyword":"type","params":{"type":"object"},"message":"must be object"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with a requirement that has a non-numeric requirement amount throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/requires/0/amount","schemaPath":"#/items/properties/requires/items/properties/amount/type","keyword":"type","params":{"type":"number"},"message":"must be number"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with a requirement that is missing a name throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/requires/0","schemaPath":"#/items/properties/requires/items/required","keyword":"required","params":{"missingProperty":"name"},"message":"must have required property 'name'"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with a requirement that is missing requirement amount throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/requires/0","schemaPath":"#/items/properties/requires/items/required","keyword":"required","params":{"missingProperty":"amount"},"message":"must have required property 'amount'"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with an optional output that has a non-numeric output amount throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/optionalOutputs/0/amount","schemaPath":"#/items/properties/optionalOutputs/items/properties/amount/type","keyword":"type","params":{"type":"number"},"message":"must be number"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with an optional output that has a non-numeric output likelihood throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/optionalOutputs/0/likelihood","schemaPath":"#/items/properties/optionalOutputs/items/properties/likelihood/type","keyword":"type","params":{"type":"number"},"message":"must be number"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with an optional output that has an output amount less than one throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/optionalOutputs/0/amount","schemaPath":"#/items/properties/optionalOutputs/items/properties/amount/minimum","keyword":"minimum","params":{"comparison":">=","limit":1},"message":"must be >= 1"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with an optional output that has output likelihood equal to zero throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/optionalOutputs/0/likelihood","schemaPath":"#/items/properties/optionalOutputs/items/properties/likelihood/exclusiveMinimum","keyword":"exclusiveMinimum","params":{"comparison":">","limit":0},"message":"must be > 0"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with an optional output that has output likelihood greater than one throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/optionalOutputs/0/likelihood","schemaPath":"#/items/properties/optionalOutputs/items/properties/likelihood/maximum","keyword":"maximum","params":{"comparison":"<=","limit":1},"message":"must be <= 1"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with an optional output that has output likelihood less than zero throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/optionalOutputs/0/likelihood","schemaPath":"#/items/properties/optionalOutputs/items/properties/likelihood/exclusiveMinimum","keyword":"exclusiveMinimum","params":{"comparison":">","limit":0},"message":"must be > 0"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with an optional output that is missing a name throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/optionalOutputs/0","schemaPath":"#/items/properties/optionalOutputs/items/required","keyword":"required","params":{"missingProperty":"name"},"message":"must have required property 'name'"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with an optional output that is missing an output amount throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/optionalOutputs/0","schemaPath":"#/items/properties/optionalOutputs/items/required","keyword":"required","params":{"missingProperty":"amount"},"message":"must have required property 'amount'"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with an optional output that is missing an output likelihood throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/optionalOutputs/0","schemaPath":"#/items/properties/optionalOutputs/items/required","keyword":"required","params":{"missingProperty":"likelihood"},"message":"must have required property 'likelihood'"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with an unknown maximum tool throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/maximumTool","schemaPath":"#/definitions/tools/enum","keyword":"enum","params":{"allowedValues":["none","stone","copper","iron","bronze","steel"]},"message":"must be equal to one of the allowed values"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with an unknown minimum tool throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/minimumTool","schemaPath":"#/definitions/tools/enum","keyword":"enum","params":{"allowedValues":["none","stone","copper","iron","bronze","steel"]},"message":"must be equal to one of the allowed values"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with farm size that has a non-numeric height throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/size/height","schemaPath":"#/items/properties/size/properties/height/type","keyword":"type","params":{"type":"number"},"message":"must be number"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with farm size that has a non-numeric width throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/size/width","schemaPath":"#/items/properties/size/properties/width/type","keyword":"type","params":{"type":"number"},"message":"must be number"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with farm size that is missing a height throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/size","schemaPath":"#/items/properties/size/required","keyword":"required","params":{"missingProperty":"height"},"message":"must have required property 'height'"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with farm size that is missing a width throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/size","schemaPath":"#/items/properties/size/required","keyword":"required","params":{"missingProperty":"width"},"message":"must have required property 'width'"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with missing creation time throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0","schemaPath":"#/items/required","keyword":"required","params":{"missingProperty":"createTime"},"message":"must have required property 'createTime'"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with missing output amount throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0","schemaPath":"#/items/required","keyword":"required","params":{"missingProperty":"output"},"message":"must have required property 'output'"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with missing requirements array throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0","schemaPath":"#/items/required","keyword":"required","params":{"missingProperty":"requires"},"message":"must have required property 'requires'"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with negative creation time throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/createTime","schemaPath":"#/items/properties/createTime/minimum","keyword":"minimum","params":{"comparison":">=","limit":0},"message":"must be >= 0"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with negative output amount throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/output","schemaPath":"#/items/properties/output/minimum","keyword":"minimum","params":{"comparison":">=","limit":1},"message":"must be >= 1"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with non-array requirements throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/requires","schemaPath":"#/items/properties/requires/type","keyword":"type","params":{"type":"array"},"message":"must be array"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with non-numeric creation time throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/createTime","schemaPath":"#/items/properties/createTime/type","keyword":"type","params":{"type":"number"},"message":"must be number"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with non-numeric output amount throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/output","schemaPath":"#/items/properties/output/type","keyword":"type","params":{"type":"number"},"message":"must be number"}]"`;
+
+exports[`handles invalid input (schema validation) given an item with non-object farm size throws a validation error 1`] = `"Validation Error: [{"instancePath":"/0/size","schemaPath":"#/items/properties/size/type","keyword":"type","params":{"type":"object"},"message":"must be object"}]"`;
+
+exports[`handles invalid input (schema validation) given invalid JSON throws a validation error 1`] = `"Validation Error: Unexpected token i in JSON at position 2"`;

--- a/api/src/functions/add-item/domain/__tests__/add-item.test.ts
+++ b/api/src/functions/add-item/domain/__tests__/add-item.test.ts
@@ -69,6 +69,7 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -81,6 +82,7 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -94,6 +96,7 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -107,6 +110,7 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -119,6 +123,7 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -132,6 +137,7 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -145,6 +151,7 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -157,6 +164,7 @@ describe.each([
                 output: 1,
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -170,6 +178,7 @@ describe.each([
                 requires: "test",
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -183,6 +192,7 @@ describe.each([
                 requires: ["test"],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -196,6 +206,7 @@ describe.each([
                 requires: [{ amount: 1 }],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -209,6 +220,7 @@ describe.each([
                 requires: [{ name: "wibble" }],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
             {
                 name: "wibble",
@@ -217,6 +229,7 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -230,6 +243,7 @@ describe.each([
                 requires: [{ name: "wibble", amount: "test" }],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
             {
                 name: "wibble",
@@ -238,6 +252,7 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -252,6 +267,7 @@ describe.each([
                 size: "wibble",
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -268,6 +284,7 @@ describe.each([
                 },
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -285,6 +302,7 @@ describe.each([
                 },
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -301,6 +319,7 @@ describe.each([
                 },
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -318,6 +337,7 @@ describe.each([
                 },
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -334,6 +354,7 @@ describe.each([
                     height: 1,
                 },
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -351,6 +372,7 @@ describe.each([
                 },
                 minimumTool: "unknown",
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -367,6 +389,7 @@ describe.each([
                     height: 1,
                 },
                 minimumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -384,6 +407,7 @@ describe.each([
                 },
                 minimumTool: Tools.none,
                 maximumTool: "unknown",
+                creator: "test creator",
             },
         ]),
     ],
@@ -397,7 +421,8 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
-                optionalOutput: [
+                creator: "test creator",
+                optionalOutputs: [
                     {
                         amount: 1,
                         likelihood: 0.5,
@@ -411,6 +436,7 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -424,7 +450,8 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
-                optionalOutput: [
+                creator: "test creator",
+                optionalOutputs: [
                     {
                         name: "wibble",
                         likelihood: 0.5,
@@ -438,6 +465,7 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -451,7 +479,8 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
-                optionalOutput: [
+                creator: "test creator",
+                optionalOutputs: [
                     {
                         name: "wibble",
                         amount: "test",
@@ -466,6 +495,7 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -479,7 +509,8 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
-                optionalOutput: [
+                creator: "test creator",
+                optionalOutputs: [
                     {
                         name: "wibble",
                         amount: 0,
@@ -494,6 +525,7 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -507,7 +539,8 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
-                optionalOutput: [
+                creator: "test creator",
+                optionalOutputs: [
                     {
                         name: "wibble",
                         amount: 5,
@@ -521,6 +554,7 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -534,7 +568,8 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
-                optionalOutput: [
+                creator: "test creator",
+                optionalOutputs: [
                     {
                         name: "wibble",
                         amount: 2,
@@ -549,6 +584,7 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -562,7 +598,8 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
-                optionalOutput: [
+                creator: "test creator",
+                optionalOutputs: [
                     {
                         name: "wibble",
                         amount: 2,
@@ -577,6 +614,7 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -590,7 +628,8 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
-                optionalOutput: [
+                creator: "test creator",
+                optionalOutputs: [
                     {
                         name: "wibble",
                         amount: 2,
@@ -605,6 +644,7 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
             },
         ]),
     ],
@@ -618,7 +658,8 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
-                optionalOutput: [
+                creator: "test creator",
+                optionalOutputs: [
                     {
                         name: "wibble",
                         amount: 2,
@@ -633,6 +674,34 @@ describe.each([
                 requires: [],
                 minimumTool: Tools.none,
                 maximumTool: Tools.none,
+                creator: "test creator",
+            },
+        ]),
+    ],
+    [
+        "an item with a missing creator name",
+        JSON.stringify([
+            {
+                name: "test",
+                createTime: 2,
+                output: 1,
+                requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
+            },
+        ]),
+    ],
+    [
+        "an item with a invalid creator name",
+        JSON.stringify([
+            {
+                name: "test",
+                createTime: 2,
+                output: 1,
+                requires: [],
+                minimumTool: Tools.none,
+                maximumTool: Tools.none,
+                creator: 1,
             },
         ]),
     ],
@@ -650,12 +719,8 @@ describe.each([
         });
 
         test("throws a validation error", async () => {
-            const expectedError = "Validation Error:";
-
             expect.assertions(1);
-            await expect(addItem(input)).rejects.toEqual(
-                expect.stringContaining(expectedError)
-            );
+            await expect(addItem(input)).rejects.toMatchSnapshot();
         });
     }
 );

--- a/api/src/json/items.json
+++ b/api/src/json/items.json
@@ -5,7 +5,8 @@
         "output": 1,
         "requires": [],
         "minimumTool": "none",
-        "maximumTool": "none"
+        "maximumTool": "none",
+        "creator": "Berry farmer"
     },
     {
         "name": "Berry Meal",
@@ -18,7 +19,8 @@
             }
         ],
         "minimumTool": "none",
-        "maximumTool": "none"
+        "maximumTool": "none",
+        "creator": "Berry farmer"
     },
     {
         "name": "Wheat",
@@ -27,6 +29,7 @@
         "requires": [],
         "minimumTool": "none",
         "maximumTool": "none",
+        "creator": "Wheat farmer",
         "size": {
             "width": 10,
             "height": 10
@@ -39,6 +42,7 @@
         "requires": [],
         "minimumTool": "none",
         "maximumTool": "none",
+        "creator": "Forester",
         "size": {
             "width": 3,
             "height": 33
@@ -55,7 +59,8 @@
             }
         ],
         "minimumTool": "none",
-        "maximumTool": "steel"
+        "maximumTool": "steel",
+        "creator": "Woodcutter"
     },
     {
         "name": "Clay",
@@ -63,7 +68,8 @@
         "output": 1,
         "requires": [],
         "minimumTool": "none",
-        "maximumTool": "steel"
+        "maximumTool": "steel",
+        "creator": "Miner"
     },
     {
         "name": "Empty Pot",
@@ -80,7 +86,8 @@
             }
         ],
         "minimumTool": "none",
-        "maximumTool": "copper"
+        "maximumTool": "copper",
+        "creator": "Potter"
     },
     {
         "name": "Pot of Flour",
@@ -97,7 +104,8 @@
             }
         ],
         "minimumTool": "none",
-        "maximumTool": "none"
+        "maximumTool": "none",
+        "creator": "Grinder"
     },
     {
         "name": "Firewood",
@@ -110,7 +118,8 @@
             }
         ],
         "minimumTool": "none",
-        "maximumTool": "steel"
+        "maximumTool": "steel",
+        "creator": "Woodcutter"
     },
     {
         "name": "Pot of Water",
@@ -123,7 +132,8 @@
             }
         ],
         "minimumTool": "none",
-        "maximumTool": "none"
+        "maximumTool": "none",
+        "creator": "Water gatherer"
     },
     {
         "name": "Bread",
@@ -145,6 +155,7 @@
         ],
         "minimumTool": "none",
         "maximumTool": "steel",
+        "creator": "Cook",
         "optionalOutputs": [
             {
                 "name": "Empty Pot",

--- a/api/src/json/schemas/items.json
+++ b/api/src/json/schemas/items.json
@@ -50,6 +50,10 @@
             "maximumTool": {
                 "$ref": "#/definitions/tools"
             },
+            "creator": {
+                "description": "The name of the individual that produces this item",
+                "type": "string"
+            },
             "optionalOutputs": {
                 "description": "Optional outputs that can be created at the same time as this item",
                 "type": "array",
@@ -102,7 +106,8 @@
             "output",
             "requires",
             "minimumTool",
-            "maximumTool"
+            "maximumTool",
+            "creator"
         ],
         "additionalProperties": false
     },

--- a/api/test/item-utils.ts
+++ b/api/test/item-utils.ts
@@ -36,6 +36,7 @@ function createItem({
     requirements,
     minimumTool = Tools.none,
     maximumTool = Tools.none,
+    creator = `${name}-creator`,
     optionalOutputs,
     width,
     height,
@@ -46,6 +47,7 @@ function createItem({
     requirements: Requirements;
     minimumTool?: Tools;
     maximumTool?: Tools;
+    creator?: string;
     optionalOutputs?: OptionalOutput[];
     width?: number;
     height?: number;
@@ -54,6 +56,7 @@ function createItem({
         name,
         createTime,
         output,
+        creator,
         requires: requirements,
         ...(width && height ? { size: { width, height } } : {}),
         minimumTool,


### PR DESCRIPTION
Resolves #162 

# What

Updated items schema to include required `creator` property on each item
Updated static list of items to include their creator names

Includes updates to use snapshot testing on add item validation errors

# Why

Enables future work to allow more than one creator to create a single item
- Requirements query could be updated to allow the user to specify available creators such that we can only provide requirements for the available creators
- Enables requirements query to return creator name 
- etc.

Add item validation error snapshot testing:
- Previously, the optional output tests were failing because the property name was incorrect, i.e. the test was failing for the wrong reason
- Using snapshot testing allows the test to remain simple (no duplication) but enables the test message to be checked for a specific error rather than generic