### PR TITLE
feat(api): 167 query distinct item names

### DIFF
--- a/api/scripts/deploy.sh
+++ b/api/scripts/deploy.sh
@@ -80,12 +80,12 @@ echo "Run post-build scripts..."
 cd $dist_dir && npx lerna exec --scope="@colony-survival-calculator/*-function" -- bash -c 'cd . && test -f post-build.sh && ./post-build.sh || true'
 
 if [ $dryrun ]; then
-    echo "Dry run deployment of UI for environment: $environment..."
+    echo "Dry run deployment of API for environment: $environment..."
     terraform -chdir="$infra_dir" plan -var-file="$infra_dir/$environment.tfvars"
 elif [ $teardown ]; then
-    echo "Tearing down UI for environment: $environment..."
+    echo "Tearing down API for environment: $environment..."
     terraform -chdir="$infra_dir" apply -var-file="$infra_dir/$environment.tfvars" -destroy
 else
-    echo "Deploying UI for environment: $environment..."
+    echo "Deploying API for environment: $environment..."
     terraform -chdir="$infra_dir" apply -auto-approve -var-file="$infra_dir/$environment.tfvars"
 fi

--- a/api/src/functions/query-distinct-item-names/__tests__/handler.test.ts
+++ b/api/src/functions/query-distinct-item-names/__tests__/handler.test.ts
@@ -1,0 +1,45 @@
+import type { AppSyncResolverEvent } from "aws-lambda";
+import { mock } from "jest-mock-extended";
+
+import { handler } from "../handler";
+import { queryDistinctItemNames } from "../domain/query-distinct-item-names";
+
+jest.mock("../domain/query-distinct-item-names", () => ({
+    queryDistinctItemNames: jest.fn(),
+}));
+
+const mockQueryDistinctItemNames = queryDistinctItemNames as jest.Mock;
+
+const validEvent = mock<AppSyncResolverEvent<never>>();
+
+beforeEach(() => {
+    mockQueryDistinctItemNames.mockReset();
+});
+
+test("calls the domain to fetch all distinct item names", async () => {
+    await handler(validEvent);
+
+    expect(mockQueryDistinctItemNames).toHaveBeenCalledTimes(1);
+});
+
+test.each([
+    ["nothing", []],
+    ["multiple item names", ["test item 1", "test item 2"]],
+])(
+    "returns provided distinct item names given %s returned",
+    async (_: string, expected: string[]) => {
+        mockQueryDistinctItemNames.mockResolvedValue(expected);
+
+        const actual = await handler(validEvent);
+
+        expect(actual).toEqual(expect.arrayContaining(expected));
+    }
+);
+
+test("throws an error if any unhandled exceptions occur while querying distinct item names", async () => {
+    const expectedError = new Error("test error");
+    mockQueryDistinctItemNames.mockRejectedValue(expectedError);
+
+    expect.assertions(1);
+    await expect(handler(validEvent)).rejects.toThrowError(expectedError);
+});

--- a/api/src/functions/query-distinct-item-names/adapters/__tests__/mongodb-distinct-item-name-adapter.test.ts
+++ b/api/src/functions/query-distinct-item-names/adapters/__tests__/mongodb-distinct-item-name-adapter.test.ts
@@ -1,0 +1,164 @@
+import type { MongoMemoryServer } from "mongodb-memory-server";
+import { MongoClient } from "mongodb";
+
+import { createItem, createMemoryServer } from "../../../../../test/index";
+
+const databaseName = "TestDatabase";
+const itemCollectionName = "Items";
+
+let mongoDBMemoryServer: MongoMemoryServer;
+
+jest.mock("@colony-survival-calculator/mongodb-client", async () => {
+    mongoDBMemoryServer = await createMemoryServer(databaseName);
+    return MongoClient.connect(mongoDBMemoryServer.getUri());
+});
+
+import mockClient from "@colony-survival-calculator/mongodb-client";
+import { Items } from "../../../../types";
+
+async function storeItems(items: Items) {
+    const { storeItem } = await import("../../../add-item/adapters/store-item");
+    await storeItem(items);
+}
+
+async function clearItemsCollection() {
+    const client = await mockClient;
+    const db = client.db(databaseName);
+
+    const existingCollections = await db.listCollections().toArray();
+    const collectionExists =
+        existingCollections.find(
+            (collection) => collection.name == itemCollectionName
+        ) !== undefined;
+    if (collectionExists) {
+        const itemsCollection = db.collection(itemCollectionName);
+        await itemsCollection.drop();
+    }
+}
+
+beforeEach(async () => {
+    process.env["DATABASE_NAME"] = databaseName;
+    process.env["ITEM_COLLECTION_NAME"] = itemCollectionName;
+
+    await clearItemsCollection();
+});
+
+test.each([
+    [
+        "database name",
+        "DATABASE_NAME",
+        "Misconfigured: Database name not provided",
+    ],
+    [
+        "item collection name",
+        "ITEM_COLLECTION_NAME",
+        "Misconfigured: Item collection name not provided",
+    ],
+])(
+    "throws an error if %s configuration not provided",
+    async (_: string, key: string, expectedError: string) => {
+        delete process.env[key];
+
+        expect.assertions(1);
+        await expect(async () => {
+            await import("../mongodb-distinct-item-name-adapter");
+        }).rejects.toThrow(expectedError);
+    }
+);
+
+test("returns an empty array if no items are stored in the items collection", async () => {
+    const { queryDistinctItemNames } = await import(
+        "../mongodb-distinct-item-name-adapter"
+    );
+
+    const actual = await queryDistinctItemNames();
+
+    expect(actual).toEqual([]);
+});
+
+test.each([
+    [
+        "a single item name",
+        "one item",
+        [
+            createItem({
+                name: "test item 1",
+                createTime: 5,
+                output: 3,
+                requirements: [],
+            }),
+        ],
+        ["test item 1"],
+    ],
+    [
+        "all item names",
+        "multiple none duplicate items",
+        [
+            createItem({
+                name: "test item 1",
+                createTime: 5,
+                output: 3,
+                requirements: [],
+            }),
+            createItem({
+                name: "test item 2",
+                createTime: 5,
+                output: 3,
+                requirements: [],
+            }),
+        ],
+        ["test item 1", "test item 2"],
+    ],
+    [
+        "distinct item names",
+        "multiple duplicate items",
+        [
+            createItem({
+                name: "test item 1",
+                createTime: 5,
+                output: 3,
+                requirements: [],
+                creator: "test creator 1",
+            }),
+            createItem({
+                name: "test item 1",
+                createTime: 5,
+                output: 3,
+                requirements: [],
+                creator: "test creator 2",
+            }),
+            createItem({
+                name: "test item 2",
+                createTime: 5,
+                output: 3,
+                requirements: [],
+                creator: "test creator 1",
+            }),
+            createItem({
+                name: "test item 2",
+                createTime: 5,
+                output: 3,
+                requirements: [],
+                creator: "test creator 2",
+            }),
+        ],
+        ["test item 1", "test item 2"],
+    ],
+])(
+    "returns %s given %s stored in the database",
+    async (_: string, __: string, items: Items, expected: string[]) => {
+        await storeItems(items);
+        const { queryDistinctItemNames } = await import(
+            "../mongodb-distinct-item-name-adapter"
+        );
+
+        const actual = await queryDistinctItemNames();
+
+        expect(actual).toEqual(expect.arrayContaining(expected));
+    }
+);
+
+afterAll(async () => {
+    (await mockClient).close(true);
+    await mongoDBMemoryServer.stop();
+});

--- a/api/src/functions/query-distinct-item-names/adapters/mongodb-distinct-item-name-adapter.ts
+++ b/api/src/functions/query-distinct-item-names/adapters/mongodb-distinct-item-name-adapter.ts
@@ -1,0 +1,7 @@
+import { ItemDatabasePort } from "../interfaces/item-database-port";
+
+const queryDistinctItemNames: ItemDatabasePort = async () => {
+    return [];
+};
+
+export { queryDistinctItemNames };

--- a/api/src/functions/query-distinct-item-names/adapters/mongodb-distinct-item-name-adapter.ts
+++ b/api/src/functions/query-distinct-item-names/adapters/mongodb-distinct-item-name-adapter.ts
@@ -1,7 +1,22 @@
+import client from "@colony-survival-calculator/mongodb-client";
+
 import { ItemDatabasePort } from "../interfaces/item-database-port";
 
+const databaseName = process.env["DATABASE_NAME"];
+if (!databaseName) {
+    throw new Error("Misconfigured: Database name not provided");
+}
+
+const itemCollectionName = process.env["ITEM_COLLECTION_NAME"];
+if (!itemCollectionName) {
+    throw new Error("Misconfigured: Item collection name not provided");
+}
+
 const queryDistinctItemNames: ItemDatabasePort = async () => {
-    return [];
+    const db = (await client).db(databaseName);
+    const collection = db.collection(itemCollectionName);
+
+    return collection.distinct("name");
 };
 
 export { queryDistinctItemNames };

--- a/api/src/functions/query-distinct-item-names/domain/__tests__/query-distinct-item-names.test.ts
+++ b/api/src/functions/query-distinct-item-names/domain/__tests__/query-distinct-item-names.test.ts
@@ -1,0 +1,40 @@
+import { queryDistinctItemNames as dbQueryItemNames } from "../../adapters/mongodb-distinct-item-name-adapter";
+import { queryDistinctItemNames as domain } from "../query-distinct-item-names";
+
+jest.mock("../../adapters/mongodb-distinct-item-name-adapter", () => ({
+    queryDistinctItemNames: jest.fn(),
+}));
+
+const mockQueryDistinctItemNames = dbQueryItemNames as jest.Mock;
+
+beforeEach(() => {
+    mockQueryDistinctItemNames.mockReset();
+});
+
+test("calls the database to fetch all distinct item names", async () => {
+    await domain();
+
+    expect(mockQueryDistinctItemNames).toHaveBeenCalledTimes(1);
+});
+
+test.each([
+    ["nothing", []],
+    ["multiple item names", ["test item 1", "test item 2"]],
+])(
+    "returns provided distinct item names given %s returned from database",
+    async (_: string, expected: string[]) => {
+        mockQueryDistinctItemNames.mockResolvedValue(expected);
+
+        const actual = await domain();
+
+        expect(actual).toEqual(expect.arrayContaining(expected));
+    }
+);
+
+test("throws an error if any unhandled exceptions occur while querying distinct item names from database", async () => {
+    const expectedError = new Error("test error");
+    mockQueryDistinctItemNames.mockRejectedValue(expectedError);
+
+    expect.assertions(1);
+    await expect(domain()).rejects.toThrowError(expectedError);
+});

--- a/api/src/functions/query-distinct-item-names/domain/query-distinct-item-names.ts
+++ b/api/src/functions/query-distinct-item-names/domain/query-distinct-item-names.ts
@@ -1,7 +1,8 @@
 import { QueryDistinctItemNamesPrimaryPort } from "../interfaces/query-distinct-item-names-primary-port";
+import { queryDistinctItemNames as dbQueryItemNames } from "../adapters/mongodb-distinct-item-name-adapter";
 
 const queryDistinctItemNames: QueryDistinctItemNamesPrimaryPort = async () => {
-    return [];
+    return dbQueryItemNames();
 };
 
 export { queryDistinctItemNames };

--- a/api/src/functions/query-distinct-item-names/domain/query-distinct-item-names.ts
+++ b/api/src/functions/query-distinct-item-names/domain/query-distinct-item-names.ts
@@ -1,0 +1,7 @@
+import { QueryDistinctItemNamesPrimaryPort } from "../interfaces/query-distinct-item-names-primary-port";
+
+const queryDistinctItemNames: QueryDistinctItemNamesPrimaryPort = async () => {
+    return [];
+};
+
+export { queryDistinctItemNames };

--- a/api/src/functions/query-distinct-item-names/handler.ts
+++ b/api/src/functions/query-distinct-item-names/handler.ts
@@ -1,0 +1,8 @@
+import { GraphQLEventHandler } from "../../interfaces/GraphQLEventHandler";
+import { queryDistinctItemNames } from "./domain/query-distinct-item-names";
+
+const handler: GraphQLEventHandler<never, string[]> = async () => {
+    return await queryDistinctItemNames();
+};
+
+export { handler };

--- a/api/src/functions/query-distinct-item-names/interfaces/item-database-port.ts
+++ b/api/src/functions/query-distinct-item-names/interfaces/item-database-port.ts
@@ -1,0 +1,5 @@
+interface ItemDatabasePort {
+    (): Promise<string[]>;
+}
+
+export { ItemDatabasePort };

--- a/api/src/functions/query-distinct-item-names/interfaces/query-distinct-item-names-primary-port.ts
+++ b/api/src/functions/query-distinct-item-names/interfaces/query-distinct-item-names-primary-port.ts
@@ -1,0 +1,5 @@
+interface QueryDistinctItemNamesPrimaryPort {
+    (): Promise<string[]>;
+}
+
+export { QueryDistinctItemNamesPrimaryPort };

--- a/api/src/functions/query-distinct-item-names/package-lock.json
+++ b/api/src/functions/query-distinct-item-names/package-lock.json
@@ -1,0 +1,182 @@
+{
+    "name": "@colony-survival-calculator/query-distinct-item-names",
+    "version": "0.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@colony-survival-calculator/query-distinct-item-names",
+            "version": "0.0.0",
+            "dependencies": {
+                "aws4": "1.12.0",
+                "mongodb": "5.2.0"
+            }
+        },
+        "node_modules/@types/node": {
+            "version": "20.2.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.1.tgz",
+            "integrity": "sha512-DqJociPbZP1lbZ5SQPk4oag6W7AyaGMO6gSfRwq3PWl4PXTwJpRQJhDq4W0kzrg3w6tJ1SwlvGZ5uKFHY13LIg=="
+        },
+        "node_modules/@types/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+        },
+        "node_modules/@types/whatwg-url": {
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+            "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/webidl-conversions": "*"
+            }
+        },
+        "node_modules/aws4": {
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+            "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
+        },
+        "node_modules/bson": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/bson/-/bson-5.3.0.tgz",
+            "integrity": "sha512-ukmCZMneMlaC5ebPHXIkP8YJzNl5DC41N5MAIvKDqLggdao342t4McltoJBQfQya/nHBWAcSsYRqlXPoQkTJag==",
+            "engines": {
+                "node": ">=14.20.1"
+            }
+        },
+        "node_modules/ip": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+            "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+        },
+        "node_modules/memory-pager": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+            "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+            "optional": true
+        },
+        "node_modules/mongodb": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.2.0.tgz",
+            "integrity": "sha512-nLgo95eP1acvjBcOdrUV3aqpWwHZCZwhYA2opB8StybbtQL/WoE5pk92qUUfjbKOWcGLYJczTqQbfOQhYtrkKg==",
+            "dependencies": {
+                "bson": "^5.2.0",
+                "mongodb-connection-string-url": "^2.6.0",
+                "socks": "^2.7.1"
+            },
+            "engines": {
+                "node": ">=14.20.1"
+            },
+            "optionalDependencies": {
+                "saslprep": "^1.0.3"
+            },
+            "peerDependencies": {
+                "@aws-sdk/credential-providers": "^3.201.0",
+                "mongodb-client-encryption": "^2.3.0",
+                "snappy": "^7.2.2"
+            },
+            "peerDependenciesMeta": {
+                "@aws-sdk/credential-providers": {
+                    "optional": true
+                },
+                "mongodb-client-encryption": {
+                    "optional": true
+                },
+                "snappy": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/mongodb-connection-string-url": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+            "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+            "dependencies": {
+                "@types/whatwg-url": "^8.2.1",
+                "whatwg-url": "^11.0.0"
+            }
+        },
+        "node_modules/punycode": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+            "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/saslprep": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+            "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+            "optional": true,
+            "dependencies": {
+                "sparse-bitfield": "^3.0.3"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/smart-buffer": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+            "engines": {
+                "node": ">= 6.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/socks": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+            "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+            "dependencies": {
+                "ip": "^2.0.0",
+                "smart-buffer": "^4.2.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/sparse-bitfield": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+            "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+            "optional": true,
+            "dependencies": {
+                "memory-pager": "^1.0.2"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+            "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+            "dependencies": {
+                "punycode": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+            "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+            "dependencies": {
+                "tr46": "^3.0.0",
+                "webidl-conversions": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        }
+    }
+}

--- a/api/src/functions/query-distinct-item-names/package-lock.json
+++ b/api/src/functions/query-distinct-item-names/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "@colony-survival-calculator/query-distinct-item-names",
+    "name": "@colony-survival-calculator/query-distinct-item-names-function",
     "version": "0.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "@colony-survival-calculator/query-distinct-item-names",
+            "name": "@colony-survival-calculator/query-distinct-item-names-function",
             "version": "0.0.0",
             "dependencies": {
                 "aws4": "1.12.0",

--- a/api/src/functions/query-distinct-item-names/package.json
+++ b/api/src/functions/query-distinct-item-names/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@colony-survival-calculator/query-distinct-item-names",
+    "name": "@colony-survival-calculator/query-distinct-item-names-function",
     "private": true,
     "version": "0.0.0",
     "dependencies": {

--- a/api/src/functions/query-distinct-item-names/package.json
+++ b/api/src/functions/query-distinct-item-names/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "@colony-survival-calculator/query-distinct-item-names",
+    "private": true,
+    "version": "0.0.0",
+    "dependencies": {
+        "@colony-survival-calculator/mongodb-client": "0.0.0",
+        "aws4": "1.12.0",
+        "mongodb": "5.2.0"
+    }
+}

--- a/api/src/graphql/schema.graphql
+++ b/api/src/graphql/schema.graphql
@@ -30,6 +30,7 @@ enum Tools {
 }
 
 type Query {
+    distinctItemNames: [String!]!
     item(name: ID): [Item!]!
     requirement(
         name: ID!


### PR DESCRIPTION
Resolves #167 

# What

Added `distinctItemNames` query field to GraphQL Schema
Added corresponding app sync resolver to fetch distinct item names from MongoDB

# Why

Currently no items in the database are created by more than one creator, however, it is now possible for items to be added that are. Without this query, the UI would need to be updated to perform the distinct client side.

Adding this query reduces the amount of data sent to the client + reduces the responsibilities of the UI layer
- Just needs to be updated to query this field rather than `item`