### PR TITLE
feat(ui): update calculator to fetch distinct item names using distinct query

### DIFF
--- a/ui/src/pages/Calculator/Calculator.tsx
+++ b/ui/src/pages/Calculator/Calculator.tsx
@@ -14,9 +14,7 @@ import ToolSelector from "./components/ToolSelector";
 
 const GET_ITEM_NAMES_QUERY = gql(`
     query GetItemNames {
-        item {
-            name
-        }
+        distinctItemNames
     }
 `);
 
@@ -60,8 +58,8 @@ function Calculator() {
         );
     }
 
-    if (!selectedItem && itemNameData?.item[0]) {
-        setSelectedItem(itemNameData.item[0].name);
+    if (!selectedItem && itemNameData?.distinctItemNames[0]) {
+        setSelectedItem(itemNameData.distinctItemNames[0]);
     }
 
     const networkError = itemNameError || itemDetailsError;
@@ -69,10 +67,11 @@ function Calculator() {
     return (
         <CalculatorContainer>
             <CalculatorHeader>Desired output:</CalculatorHeader>
-            {itemNameData?.item && itemNameData.item.length > 0 ? (
+            {itemNameData?.distinctItemNames &&
+            itemNameData.distinctItemNames.length > 0 ? (
                 <>
                     <ItemSelector
-                        items={itemNameData.item}
+                        items={itemNameData.distinctItemNames}
                         onItemChange={setSelectedItem}
                     />
                     <WorkerInput onWorkerChange={setWorkers} />
@@ -106,7 +105,8 @@ function Calculator() {
                     ) : null}
                 </>
             </ErrorBoundary>
-            {itemNameData?.item && itemNameData.item.length < 1 ? (
+            {itemNameData?.distinctItemNames &&
+            itemNameData.distinctItemNames.length < 1 ? (
                 <span role="alert">Unable to fetch known items</span>
             ) : null}
             {networkError ? (

--- a/ui/src/pages/Calculator/__tests__/Calculator-item-selection.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-item-selection.test.tsx
@@ -30,7 +30,9 @@ const items: ItemName[] = [{ name: "Item 1" }, { name: "Item 2" }];
 
 const server = setupServer(
     graphql.query(expectedItemNameQueryName, (_, res, ctx) => {
-        return res(ctx.data({ item: items }));
+        return res(
+            ctx.data({ distinctItemNames: items.map((item) => item.name) })
+        );
     }),
     graphql.query(expectedItemDetailsQueryName, (_, res, ctx) => {
         return res(ctx.data({ item: [] }));
@@ -52,7 +54,9 @@ beforeEach(() => {
     server.events.removeAllListeners();
     server.use(
         graphql.query(expectedItemNameQueryName, (_, res, ctx) => {
-            return res(ctx.data({ item: items }));
+            return res(
+                ctx.data({ distinctItemNames: items.map((item) => item.name) })
+            );
         })
     );
 });
@@ -144,7 +148,7 @@ describe("given no item names returned", () => {
     beforeEach(() => {
         server.use(
             graphql.query(expectedItemNameQueryName, (_, res, ctx) => {
-                return res(ctx.data({ item: [] }));
+                return res(ctx.data({ distinctItemNames: [] }));
             })
         );
     });

--- a/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
@@ -31,7 +31,7 @@ const item: ItemName = { name: "Item 1" };
 
 const server = setupServer(
     graphql.query(expectedItemNameQueryName, (_, res, ctx) => {
-        return res(ctx.data({ item: [item] }));
+        return res(ctx.data({ distinctItemNames: [item.name] }));
     }),
     graphql.query(expectedItemDetailsQueryName, (req, res, ctx) => {
         return res(ctx.data({ item: [] }));

--- a/ui/src/pages/Calculator/__tests__/Calculator-requirements.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-requirements.test.tsx
@@ -58,7 +58,9 @@ const expectedOutputText = `Optimal output: ${expectedOutput} per minute`;
 
 const server = setupServer(
     graphql.query(expectedItemNameQueryName, (_, res, ctx) => {
-        return res(ctx.data({ item: items }));
+        return res(
+            ctx.data({ distinctItemNames: items.map((item) => item.name) })
+        );
     }),
     graphql.query(expectedItemDetailsQueryName, (req, res, ctx) => {
         return res(ctx.data({ item: [] }));

--- a/ui/src/pages/Calculator/__tests__/Calculator-tool-selection.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-tool-selection.test.tsx
@@ -24,7 +24,7 @@ const item: ItemName = { name: "Item 1" };
 
 const server = setupServer(
     graphql.query(expectedItemNameQueryName, (_, res, ctx) => {
-        return res(ctx.data({ item: [item] }));
+        return res(ctx.data({ distinctItemNames: [item.name] }));
     }),
     graphql.query(expectedItemDetailsQueryName, (_, res, ctx) => {
         return res(ctx.data({ item: [] }));

--- a/ui/src/pages/Calculator/__tests__/Calculator.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator.test.tsx
@@ -27,7 +27,9 @@ const items = [itemWithFarmSize, itemWithoutFarmSize];
 
 const server = setupServer(
     graphql.query(expectedItemNameQueryName, (_, res, ctx) => {
-        return res(ctx.data({ item: items }));
+        return res(
+            ctx.data({ distinctItemNames: items.map((item) => item.name) })
+        );
     }),
     graphql.query(expectedItemDetailsQueryName, (req, res, ctx) => {
         const { name } = req.variables;

--- a/ui/src/pages/Calculator/components/ItemSelector/ItemSelector.tsx
+++ b/ui/src/pages/Calculator/components/ItemSelector/ItemSelector.tsx
@@ -1,25 +1,22 @@
 import React from "react";
 
-import { Item } from "../../../../graphql/__generated__/graphql";
 import { Selector } from "../../../../common/components";
 
-type ItemName = Pick<Item, "name">;
-
 type ItemSelectorProps = {
-    items: ItemName[];
+    items: string[];
     onItemChange: (item: string) => void;
 };
 
 function ItemSelector({ items, onItemChange }: ItemSelectorProps) {
-    const handleItemChange = (selectedItem?: ItemName) => {
-        if (selectedItem) onItemChange(selectedItem.name);
+    const handleItemChange = (selectedItem?: string) => {
+        if (selectedItem) onItemChange(selectedItem);
     };
 
     return (
         <Selector
             items={items}
-            itemToKey={(item) => item.name}
-            itemToDisplayText={(item) => item.name}
+            itemToKey={(item) => item}
+            itemToDisplayText={(item) => item}
             labelText="Item:"
             defaultSelectedItem={items[0]}
             onSelectedItemChange={handleItemChange}

--- a/ui/src/routes/__tests__/router.test.tsx
+++ b/ui/src/routes/__tests__/router.test.tsx
@@ -25,7 +25,7 @@ const item: ItemName = { name: "Item 1" };
 
 const server = setupServer(
     graphql.query(expectedItemNameQueryName, (_, res, ctx) => {
-        return res(ctx.data({ item: [item] }));
+        return res(ctx.data({ distinctItemNames: [item.name] }));
     }),
     graphql.query(expectedItemDetailsQueryName, (req, res, ctx) => {
         return res(ctx.data({ item: [] }));


### PR DESCRIPTION
# What

Updated Calculator component to query item names using `distinctItemNames` field rather than `item`

# Why

It is now possible for multiple creators to create a single item. Using the `distinctItemNames` field provides the same functionality as before, but ensures the UI does not display duplicate entries for items with multiple creators 

