### PR TITLE
feat: 168 query multi creator items

### DIFF
--- a/api/src/functions/query-item/adapters/__tests__/mongodb-query-item.test.ts
+++ b/api/src/functions/query-item/adapters/__tests__/mongodb-query-item.test.ts
@@ -36,6 +36,26 @@ async function clearItemsCollection() {
     }
 }
 
+function createItemWithNumberOfRecipes(
+    itemName: string,
+    amount: number
+): Items {
+    const items: Items = [];
+    for (let i = 0; i < amount; i++) {
+        items.push(
+            createItem({
+                name: itemName,
+                createTime: 1,
+                output: 1,
+                requirements: [],
+                creator: `${itemName}-creator-${i + 1}`,
+            })
+        );
+    }
+
+    return items;
+}
+
 beforeEach(async () => {
     process.env["DATABASE_NAME"] = databaseName;
     process.env["ITEM_COLLECTION_NAME"] = itemCollectionName;
@@ -66,96 +86,185 @@ test.each([
     }
 );
 
-test("returns an empty array if no items are stored in the items collection", async () => {
-    const { queryItem } = await import("../mongodb-query-item");
+describe("field queries", () => {
+    test("returns an empty array if no items are stored in the items collection", async () => {
+        const { queryItemByField } = await import("../mongodb-query-item");
 
-    const actual = await queryItem();
+        const actual = await queryItemByField();
 
-    expect(actual).toEqual([]);
-});
-
-test.each([
-    [
-        "a single item",
-        [
-            createItem({
-                name: "test item 1",
-                createTime: 2,
-                output: 3,
-                requirements: [{ name: "test", amount: 1 }],
-            }),
-        ],
-    ],
-    [
-        "multiple items",
-        [
-            createItem({
-                name: "test item 1",
-                createTime: 2,
-                output: 3,
-                requirements: [{ name: "test", amount: 1 }],
-            }),
-            createItem({
-                name: "test item 2",
-                createTime: 1,
-                output: 4,
-                requirements: [{ name: "world", amount: 3 }],
-            }),
-        ],
-    ],
-])(
-    "returns an array with all stored items given a %s is stored in the item collection",
-    async (_: string, expected: Items) => {
-        await storeItems(expected);
-        const { queryItem } = await import("../mongodb-query-item");
-
-        const actual = await queryItem();
-
-        expect(actual).toHaveLength(expected.length);
-        expect(actual).toEqual(expect.arrayContaining(expected));
-    }
-);
-
-test("returns only the specified item given an item name provided and multiple items in collection", async () => {
-    const expectedItemName = "expected test item 1";
-    const expected = createItem({
-        name: expectedItemName,
-        createTime: 2,
-        output: 3,
-        requirements: [{ name: "test", amount: 1 }],
+        expect(actual).toEqual([]);
     });
-    const stored = [
-        createItem({
+
+    test.each([
+        [
+            "a single item",
+            [
+                createItem({
+                    name: "test item 1",
+                    createTime: 2,
+                    output: 3,
+                    requirements: [{ name: "test", amount: 1 }],
+                }),
+            ],
+        ],
+        [
+            "multiple items",
+            [
+                createItem({
+                    name: "test item 1",
+                    createTime: 2,
+                    output: 3,
+                    requirements: [{ name: "test", amount: 1 }],
+                }),
+                createItem({
+                    name: "test item 2",
+                    createTime: 1,
+                    output: 4,
+                    requirements: [{ name: "world", amount: 3 }],
+                }),
+            ],
+        ],
+    ])(
+        "returns an array with all stored items given a %s is stored in the item collection",
+        async (_: string, expected: Items) => {
+            await storeItems(expected);
+            const { queryItemByField } = await import("../mongodb-query-item");
+
+            const actual = await queryItemByField();
+
+            expect(actual).toHaveLength(expected.length);
+            expect(actual).toEqual(expect.arrayContaining(expected));
+        }
+    );
+
+    test("returns only the specified item given an item name provided and multiple items in collection", async () => {
+        const expectedItemName = "expected test item 1";
+        const expected = createItem({
+            name: expectedItemName,
+            createTime: 2,
+            output: 3,
+            requirements: [{ name: "test", amount: 1 }],
+        });
+        const stored = [
+            createItem({
+                name: "another item",
+                createTime: 3,
+                output: 5,
+                requirements: [],
+            }),
+            expected,
+        ];
+        await storeItems(stored);
+        const { queryItemByField } = await import("../mongodb-query-item");
+
+        const actual = await queryItemByField(expectedItemName);
+
+        expect(actual).toHaveLength(1);
+        expect(actual[0]).toEqual(expected);
+    });
+
+    test("returns no items if no stored items match the provided item name in collection", async () => {
+        const stored = createItem({
             name: "another item",
             createTime: 3,
             output: 5,
             requirements: [],
-        }),
-        expected,
-    ];
-    await storeItems(stored);
-    const { queryItem } = await import("../mongodb-query-item");
+        });
+        const expectedItemName = "expected test item 1";
+        await storeItems([stored]);
+        const { queryItemByField } = await import("../mongodb-query-item");
 
-    const actual = await queryItem(expectedItemName);
+        const actual = await queryItemByField(expectedItemName);
 
-    expect(actual).toHaveLength(1);
-    expect(actual[0]).toEqual(expected);
+        expect(actual).toHaveLength(0);
+    });
 });
 
-test("returns no items if no stored items match the provided item name in collection", async () => {
-    const stored = createItem({
-        name: "another item",
-        createTime: 3,
-        output: 5,
-        requirements: [],
+describe("creator count queries", () => {
+    test("returns an empty array if no items are stored in the items collection", async () => {
+        const { queryItemByCreatorCount } = await import(
+            "../mongodb-query-item"
+        );
+
+        const actual = await queryItemByCreatorCount(2);
+
+        expect(actual).toEqual([]);
     });
-    const expectedItemName = "expected test item 1";
-    await storeItems([stored]);
-    const { queryItem } = await import("../mongodb-query-item");
 
-    const actual = await queryItem(expectedItemName);
+    test("returns only items with more than two creators if minimum of two specified", async () => {
+        const expected = createItemWithNumberOfRecipes(
+            "expected item w/ two recipes",
+            2
+        );
+        const stored = [
+            createItem({
+                name: "another item",
+                createTime: 3,
+                output: 5,
+                requirements: [],
+            }),
+            ...expected,
+        ];
+        await storeItems(stored);
+        const { queryItemByCreatorCount } = await import(
+            "../mongodb-query-item"
+        );
 
-    expect(actual).toHaveLength(0);
+        const actual = await queryItemByCreatorCount(2);
+
+        expect(actual).toHaveLength(expected.length);
+        expect(actual).toEqual(expect.arrayContaining(expected));
+    });
+
+    test("returns only items with more than three creators if minimum of three specified", async () => {
+        const expected = createItemWithNumberOfRecipes(
+            "expected item w/ 3 recipes",
+            3
+        );
+        const stored = [
+            ...createItemWithNumberOfRecipes("item w/ 2 recipes", 2),
+            ...expected,
+        ];
+        await storeItems(stored);
+        const { queryItemByCreatorCount } = await import(
+            "../mongodb-query-item"
+        );
+
+        const actual = await queryItemByCreatorCount(3);
+
+        expect(actual).toHaveLength(expected.length);
+        expect(actual).toEqual(expect.arrayContaining(expected));
+    });
+
+    test("returns only items with specified name given multiple items with minimum creator requirement", async () => {
+        const expectedItemName = "expected item w/ 3 recipes";
+        const expected = createItemWithNumberOfRecipes(expectedItemName, 3);
+        const stored = [
+            ...createItemWithNumberOfRecipes("another item w/ 3 recipes", 3),
+            ...expected,
+        ];
+        await storeItems(stored);
+        const { queryItemByCreatorCount } = await import(
+            "../mongodb-query-item"
+        );
+
+        const actual = await queryItemByCreatorCount(3, expectedItemName);
+
+        expect(actual).toHaveLength(expected.length);
+        expect(actual).toEqual(expect.arrayContaining(expected));
+    });
+
+    test("returns no items if no item matches the specified name given items with minimum creator requirement", async () => {
+        const stored = createItemWithNumberOfRecipes("item w/ 3 recipes", 3);
+        await storeItems(stored);
+        const { queryItemByCreatorCount } = await import(
+            "../mongodb-query-item"
+        );
+
+        const actual = await queryItemByCreatorCount(3, "unknown");
+
+        expect(actual).toHaveLength(0);
+    });
 });
 
 afterAll(async () => {

--- a/api/src/functions/query-item/domain/__tests__/query-item.test.ts
+++ b/api/src/functions/query-item/domain/__tests__/query-item.test.ts
@@ -2,6 +2,7 @@ import { queryItem as mongoDBQueryItem } from "../../adapters/mongodb-query-item
 import { queryItem } from "../query-item";
 import type { Items } from "../../../../types";
 import { createItem } from "../../../../../test";
+import { QueryFilters } from "../../interfaces/query-item-primary-port";
 
 jest.mock("../../adapters/mongodb-query-item", () => ({
     queryItem: jest.fn(),
@@ -17,13 +18,25 @@ beforeEach(() => {
     consoleErrorSpy.mockClear();
 });
 
+const expectedItemName = "expected item name";
+
 test.each([
-    ["all items", "no item name provided", undefined],
-    ["a specific item", "an item name provided", "expected item name"],
+    ["all items", "no filters provided", undefined, undefined],
+    [
+        "a specific item",
+        "an item name provided",
+        { name: expectedItemName },
+        expectedItemName,
+    ],
 ])(
     "calls the secondary adapter to fetch %s given %s",
-    async (_: string, __: string, expected?: string) => {
-        await queryItem(expected);
+    async (
+        _: string,
+        __: string,
+        filters: QueryFilters | undefined,
+        expected: string | undefined
+    ) => {
+        await queryItem(filters);
 
         expect(mockMongoDBQueryItem).toHaveBeenCalledTimes(1);
         expect(mockMongoDBQueryItem).toHaveBeenCalledWith(expected);

--- a/api/src/functions/query-item/domain/__tests__/query-item.test.ts
+++ b/api/src/functions/query-item/domain/__tests__/query-item.test.ts
@@ -1,118 +1,218 @@
-import { queryItem as mongoDBQueryItem } from "../../adapters/mongodb-query-item";
+import {
+    queryItemByField,
+    queryItemByCreatorCount,
+} from "../../adapters/mongodb-query-item";
 import { queryItem } from "../query-item";
 import type { Items } from "../../../../types";
 import { createItem } from "../../../../../test";
 import { QueryFilters } from "../../interfaces/query-item-primary-port";
 
 jest.mock("../../adapters/mongodb-query-item", () => ({
-    queryItem: jest.fn(),
+    queryItemByField: jest.fn(),
+    queryItemByCreatorCount: jest.fn(),
 }));
 
-const mockMongoDBQueryItem = mongoDBQueryItem as jest.Mock;
+const mockQueryItemByField = queryItemByField as jest.Mock;
+const mockQueryItemByCreatorCount = queryItemByCreatorCount as jest.Mock;
 const consoleErrorSpy = jest
     .spyOn(console, "error")
     .mockImplementation(() => undefined);
 
 beforeEach(() => {
-    mockMongoDBQueryItem.mockReset();
+    mockQueryItemByField.mockReset();
+    mockQueryItemByCreatorCount.mockReset();
     consoleErrorSpy.mockClear();
 });
 
 const expectedItemName = "expected item name";
+const expectedMinimumCreators = 1;
 
-test.each([
-    ["all items", "no filters provided", undefined, undefined],
-    [
-        "a specific item",
-        "an item name provided",
-        { name: expectedItemName },
-        expectedItemName,
-    ],
-])(
-    "calls the secondary adapter to fetch %s given %s",
-    async (
-        _: string,
-        __: string,
-        filters: QueryFilters | undefined,
-        expected: string | undefined
-    ) => {
-        await queryItem(filters);
-
-        expect(mockMongoDBQueryItem).toHaveBeenCalledTimes(1);
-        expect(mockMongoDBQueryItem).toHaveBeenCalledWith(expected);
-    }
-);
-
-test.each([
-    ["none received", []],
-    [
-        "multiple received w/ no farm sizes",
+describe("field queries", () => {
+    test.each([
+        ["all items", "no field filters provided", undefined, undefined],
         [
-            createItem({
-                name: "test 1",
-                createTime: 1,
-                output: 3,
-                requirements: [],
-            }),
-            createItem({
-                name: "test 2",
-                createTime: 4,
-                output: 6,
-                requirements: [],
-            }),
+            "a specific item",
+            "an item name provided",
+            { name: expectedItemName },
+            expectedItemName,
         ],
-    ],
-    [
-        "multiple received w/ farm sizes",
+    ])(
+        "queries the database via fields to fetch %s given %s",
+        async (
+            _: string,
+            __: string,
+            filters: QueryFilters | undefined,
+            expected: string | undefined
+        ) => {
+            await queryItem(filters);
+
+            expect(mockQueryItemByField).toHaveBeenCalledTimes(1);
+            expect(mockQueryItemByField).toHaveBeenCalledWith(expected);
+        }
+    );
+
+    test.each([
+        ["none received", []],
         [
-            createItem({
-                name: "test 1",
-                createTime: 1,
-                output: 3,
-                requirements: [],
-                width: 1,
-                height: 2,
-            }),
-            createItem({
-                name: "test 2",
-                createTime: 4,
-                output: 6,
-                requirements: [],
-                width: 3,
-                height: 4,
-            }),
+            "multiple received w/ no farm sizes",
+            [
+                createItem({
+                    name: "test 1",
+                    createTime: 1,
+                    output: 3,
+                    requirements: [],
+                }),
+                createItem({
+                    name: "test 2",
+                    createTime: 4,
+                    output: 6,
+                    requirements: [],
+                }),
+            ],
         ],
-    ],
-])(
-    "returns all items retrieved from domain given %s",
-    async (_: string, received: Items) => {
-        mockMongoDBQueryItem.mockResolvedValue(received);
+        [
+            "multiple received w/ farm sizes",
+            [
+                createItem({
+                    name: "test 1",
+                    createTime: 1,
+                    output: 3,
+                    requirements: [],
+                    width: 1,
+                    height: 2,
+                }),
+                createItem({
+                    name: "test 2",
+                    createTime: 4,
+                    output: 6,
+                    requirements: [],
+                    width: 3,
+                    height: 4,
+                }),
+            ],
+        ],
+    ])(
+        "returns all items retrieved by field query given %s",
+        async (_: string, received: Items) => {
+            mockQueryItemByField.mockResolvedValue(received);
 
-        const actual = await queryItem();
+            const actual = await queryItem();
 
-        expect(actual).toHaveLength(received.length);
-        expect(actual).toEqual(expect.arrayContaining(received));
-    }
-);
+            expect(actual).toHaveLength(received.length);
+            expect(actual).toEqual(expect.arrayContaining(received));
+        }
+    );
 
-test("throws an error if an exception occurs while fetching item details", async () => {
-    const expectedError = new Error("test error");
-    mockMongoDBQueryItem.mockRejectedValue(expectedError);
+    test("throws an error if an exception occurs while fetching item details by field", async () => {
+        const expectedError = new Error("test error");
+        mockQueryItemByField.mockRejectedValue(expectedError);
 
-    expect.assertions(1);
-    await expect(queryItem()).rejects.toThrow(expectedError);
+        expect.assertions(1);
+        await expect(queryItem()).rejects.toThrow(expectedError);
+    });
+
+    test("logs an error message to console if an exception occurs while fetching item details by field", async () => {
+        const expectedError = new Error("test error");
+        mockQueryItemByField.mockRejectedValue(expectedError);
+
+        try {
+            await queryItem();
+        } catch {
+            // Ignore
+        }
+
+        expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(expectedError);
+    });
 });
 
-test("logs an error message to console if an exception occurs while fetching item details", async () => {
-    const expectedError = new Error("test error");
-    mockMongoDBQueryItem.mockRejectedValue(expectedError);
+describe("creator count queries", () => {
+    test.each([
+        [
+            "a minimum creator count filter is provided",
+            { minimumCreators: expectedMinimumCreators },
+            expectedMinimumCreators,
+            undefined,
+        ],
+        [
+            "a minimum creator count filter is provided w/ an item name",
+            {
+                minimumCreators: expectedMinimumCreators,
+                name: expectedItemName,
+            },
+            expectedMinimumCreators,
+            expectedItemName,
+        ],
+    ])(
+        "queries the database via creator count given %s",
+        async (
+            _: string,
+            filters: QueryFilters | undefined,
+            expectedMinimumCreators: number,
+            expectedItemName: string | undefined
+        ) => {
+            await queryItem(filters);
 
-    try {
-        await queryItem();
-    } catch {
-        // Ignore
-    }
+            expect(mockQueryItemByCreatorCount).toHaveBeenCalledTimes(1);
+            expect(mockQueryItemByCreatorCount).toHaveBeenCalledWith(
+                expectedMinimumCreators,
+                expectedItemName
+            );
+        }
+    );
 
-    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
-    expect(consoleErrorSpy).toHaveBeenCalledWith(expectedError);
+    test.each([
+        ["none received", []],
+        [
+            "multiple received",
+            [
+                createItem({
+                    name: "test 1",
+                    createTime: 1,
+                    output: 3,
+                    requirements: [],
+                }),
+                createItem({
+                    name: "test 1",
+                    createTime: 5,
+                    output: 7,
+                    requirements: [],
+                }),
+            ],
+        ],
+    ])(
+        "returns all items retrieved given %s",
+        async (_: string, received: Items) => {
+            mockQueryItemByCreatorCount.mockResolvedValue(received);
+
+            const actual = await queryItem({ minimumCreators: 1 });
+
+            expect(actual).toHaveLength(received.length);
+            expect(actual).toEqual(expect.arrayContaining(received));
+        }
+    );
+
+    test("throws an error if an exception occurs while fetching item details", async () => {
+        const expectedError = new Error("test error");
+        mockQueryItemByCreatorCount.mockRejectedValue(expectedError);
+
+        expect.assertions(1);
+        await expect(queryItem({ minimumCreators: 1 })).rejects.toThrow(
+            expectedError
+        );
+    });
+
+    test("logs an error message to console if an exception occurs while fetching item details", async () => {
+        const expectedError = new Error("test error");
+        mockQueryItemByCreatorCount.mockRejectedValue(expectedError);
+
+        try {
+            await queryItem({ minimumCreators: 1 });
+        } catch {
+            // Ignore
+        }
+
+        expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(expectedError);
+    });
 });

--- a/api/src/functions/query-item/domain/query-item.ts
+++ b/api/src/functions/query-item/domain/query-item.ts
@@ -1,9 +1,14 @@
 import { queryItem as mongoDBQueryItem } from "../adapters/mongodb-query-item";
-import type { QueryItemPrimaryPort } from "../interfaces/query-item-primary-port";
+import type {
+    QueryFilters,
+    QueryItemPrimaryPort,
+} from "../interfaces/query-item-primary-port";
 
-const queryItem: QueryItemPrimaryPort = async (name?: string) => {
+const queryItem: QueryItemPrimaryPort = async (
+    filters: QueryFilters | undefined
+) => {
     try {
-        return await mongoDBQueryItem(name);
+        return await mongoDBQueryItem(filters?.name);
     } catch (ex) {
         console.error(ex);
         throw ex;

--- a/api/src/functions/query-item/domain/query-item.ts
+++ b/api/src/functions/query-item/domain/query-item.ts
@@ -1,4 +1,7 @@
-import { queryItem as mongoDBQueryItem } from "../adapters/mongodb-query-item";
+import {
+    queryItemByCreatorCount,
+    queryItemByField,
+} from "../adapters/mongodb-query-item";
 import type {
     QueryFilters,
     QueryItemPrimaryPort,
@@ -8,7 +11,14 @@ const queryItem: QueryItemPrimaryPort = async (
     filters: QueryFilters | undefined
 ) => {
     try {
-        return await mongoDBQueryItem(filters?.name);
+        if (filters?.minimumCreators) {
+            return await queryItemByCreatorCount(
+                filters.minimumCreators,
+                filters.name
+            );
+        }
+
+        return await queryItemByField(filters?.name);
     } catch (ex) {
         console.error(ex);
         throw ex;

--- a/api/src/functions/query-item/handler.ts
+++ b/api/src/functions/query-item/handler.ts
@@ -1,10 +1,19 @@
 import type { Item, QueryItemArgs } from "../../graphql/schema";
 import type { GraphQLEventHandler } from "../../interfaces/GraphQLEventHandler";
 import { queryItem } from "./domain/query-item";
+import { QueryFilters } from "./interfaces/query-item-primary-port";
 
 const handler: GraphQLEventHandler<QueryItemArgs, Item[]> = async (event) => {
+    const filters: QueryFilters | undefined = event.arguments.filters
+        ? {
+              name: event.arguments.filters.name ?? undefined,
+              minimumCreators:
+                  event.arguments.filters.minimumCreators ?? undefined,
+          }
+        : undefined;
+
     try {
-        return await queryItem(event.arguments.filters?.name ?? undefined);
+        return await queryItem(filters);
     } catch {
         throw new Error(
             "An error occurred while fetching item details, please try again."

--- a/api/src/functions/query-item/handler.ts
+++ b/api/src/functions/query-item/handler.ts
@@ -4,7 +4,7 @@ import { queryItem } from "./domain/query-item";
 
 const handler: GraphQLEventHandler<QueryItemArgs, Item[]> = async (event) => {
     try {
-        return await queryItem(event.arguments.name ?? undefined);
+        return await queryItem(event.arguments.filters?.name ?? undefined);
     } catch {
         throw new Error(
             "An error occurred while fetching item details, please try again."

--- a/api/src/functions/query-item/interfaces/query-item-primary-port.ts
+++ b/api/src/functions/query-item/interfaces/query-item-primary-port.ts
@@ -1,7 +1,12 @@
 import type { Items } from "../../../types";
 
+type QueryFilters = {
+    name?: string | undefined;
+    minimumCreators?: number | undefined;
+};
+
 interface QueryItemPrimaryPort {
-    (name?: string): Promise<Items>;
+    (filters?: QueryFilters): Promise<Items>;
 }
 
-export type { QueryItemPrimaryPort };
+export type { QueryItemPrimaryPort, QueryFilters };

--- a/api/src/functions/query-item/interfaces/query-item-secondary-port.ts
+++ b/api/src/functions/query-item/interfaces/query-item-secondary-port.ts
@@ -1,7 +1,14 @@
 import type { Items } from "../../../types";
 
-interface QueryItemSecondaryPort {
+interface QueryItemByFieldSecondaryPort {
     (name?: string): Promise<Items>;
 }
 
-export type { QueryItemSecondaryPort };
+interface QueryItemByCreatorCountSecondaryPort {
+    (minimumCreators: number, name?: string): Promise<Items>;
+}
+
+export type {
+    QueryItemByFieldSecondaryPort,
+    QueryItemByCreatorCountSecondaryPort,
+};

--- a/api/src/graphql/schema.graphql
+++ b/api/src/graphql/schema.graphql
@@ -29,9 +29,13 @@ enum Tools {
     STEEL
 }
 
+input ItemsFilters {
+    name: ID
+}
+
 type Query {
     distinctItemNames: [String!]!
-    item(name: ID): [Item!]!
+    item(filters: ItemsFilters): [Item!]!
     requirement(
         name: ID!
         workers: Int!

--- a/api/src/graphql/schema.graphql
+++ b/api/src/graphql/schema.graphql
@@ -31,6 +31,7 @@ enum Tools {
 
 input ItemsFilters {
     name: ID
+    minimumCreators: Int
 }
 
 type Query {

--- a/api/src/graphql/schema.graphql
+++ b/api/src/graphql/schema.graphql
@@ -7,6 +7,7 @@ type Item {
     name: ID!
     createTime: Float!
     output: Int!
+    creator: String!
     size: FarmSize
 }
 

--- a/ui/src/pages/Calculator/Calculator.tsx
+++ b/ui/src/pages/Calculator/Calculator.tsx
@@ -19,8 +19,8 @@ const GET_ITEM_NAMES_QUERY = gql(`
 `);
 
 const GET_ITEM_DETAILS_QUERY = gql(`
-    query GetItemDetails($name: ID!) {
-        item(name: $name) {
+    query GetItemDetails($filters: ItemsFilters!) {
+        item(filters: $filters) {
             size {
                 width
                 height
@@ -39,7 +39,7 @@ function Calculator() {
     const { data: itemDetailsData, error: itemDetailsError } = useQuery(
         GET_ITEM_DETAILS_QUERY,
         {
-            variables: { name: selectedItem ?? "" },
+            variables: { filters: { name: selectedItem } },
             skip: !selectedItem,
         }
     );

--- a/ui/src/pages/Calculator/__tests__/Calculator-item-selection.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-item-selection.test.tsx
@@ -260,7 +260,9 @@ test("requests item details on the first option in the item name list without se
     await screen.findByRole("combobox", { name: expectedItemSelectLabel });
     const { matchedRequestDetails } = await expectedRequest;
 
-    expect(matchedRequestDetails.variables).toEqual({ name: items[0].name });
+    expect(matchedRequestDetails.variables).toEqual({
+        filters: { name: items[0].name },
+    });
 });
 
 test("requests item details for newly selected item if selection is changed", async () => {
@@ -270,7 +272,7 @@ test("requests item details for newly selected item if selection is changed", as
         "POST",
         expectedGraphQLAPIURL,
         expectedItemDetailsQueryName,
-        { name: expectedItemName }
+        { filters: { name: expectedItemName } }
     );
 
     render(<Calculator />, expectedGraphQLAPIURL);
@@ -281,7 +283,7 @@ test("requests item details for newly selected item if selection is changed", as
     const { matchedRequestDetails } = await expectedRequest;
 
     expect(matchedRequestDetails.variables).toEqual({
-        name: expectedItemName,
+        filters: { name: expectedItemName },
     });
 });
 

--- a/ui/src/pages/Calculator/__tests__/Calculator.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator.test.tsx
@@ -32,7 +32,8 @@ const server = setupServer(
         );
     }),
     graphql.query(expectedItemDetailsQueryName, (req, res, ctx) => {
-        const { name } = req.variables;
+        const { filters } = req.variables;
+        const { name } = filters;
         if (name === itemWithFarmSize.name) {
             return res(ctx.data({ item: [expectedFarmSizeDetails] }));
         }


### PR DESCRIPTION
Resolves #168 

# What

Updated query item resolver to allow providing a set of filters:
- Item name - Returns all recipes that produce a given item
- Minimum creator count: Returns all recipes that have a certain number of creators
- These filters can be combined for more granular filtering

Updated query item schema to allow querying of creator name field
Updated UI to provide the new filters object rather than primitive name string (only name currently provided in object)

# Why

Enables future work to allow the user of the application to select which creator they currently use to create a given item. This will be used to fetch accurate optimal output and requirements (factoring in the specific creator used) 