### PR TITLE
feat: creator name query support

### DIFF
--- a/api/src/functions/query-item/__tests__/handler.test.ts
+++ b/api/src/functions/query-item/__tests__/handler.test.ts
@@ -16,11 +16,13 @@ const mockQueryItem = queryItem as jest.Mock;
 
 function createFilters(
     itemName?: string,
-    minimumCreators?: number
+    minimumCreators?: number,
+    creator?: string
 ): ItemsFilters {
     return {
         name: itemName ?? null,
         minimumCreators: minimumCreators ?? null,
+        creator: creator ?? null,
     };
 }
 
@@ -37,14 +39,18 @@ function createMockEvent(
 
 const expectedItemName = "test item";
 const expectedMinimumCreators = 2;
+const expectedCreator = "test item creator";
 const mockEventWithoutFilters = createMockEvent();
 const mockEventWithEmptyFilters = createMockEvent(createFilters());
 const mockEventWithItemName = createMockEvent(createFilters(expectedItemName));
 const mockEventWithMinimumCreators = createMockEvent(
     createFilters(undefined, expectedMinimumCreators)
 );
+const mockEventWithCreator = createMockEvent(
+    createFilters(undefined, undefined, expectedCreator)
+);
 const mockEventWithAllFilters = createMockEvent(
-    createFilters(expectedItemName, expectedMinimumCreators)
+    createFilters(expectedItemName, expectedMinimumCreators, expectedCreator)
 );
 
 beforeEach(() => {
@@ -77,10 +83,20 @@ test.each([
         { minimumCreators: expectedMinimumCreators },
     ],
     [
-        "a specific item with a minimum number of creators",
-        "an item name and minimum number of creators specified in filter",
+        "all known items created by a specific creator",
+        "a creator name specified in filter",
+        mockEventWithCreator,
+        { creator: expectedCreator },
+    ],
+    [
+        "a specific item w/ a specific creator that can be produced by a min number of creators",
+        "an item name, creator, and minimum number of creators specified in filter",
         mockEventWithAllFilters,
-        { name: expectedItemName, minimumCreators: expectedMinimumCreators },
+        {
+            name: expectedItemName,
+            minimumCreators: expectedMinimumCreators,
+            creator: expectedCreator,
+        },
     ],
 ])(
     "calls the domain to fetch %s given an event with %s",

--- a/api/src/functions/query-item/adapters/__tests__/mongodb-query-item.test.ts
+++ b/api/src/functions/query-item/adapters/__tests__/mongodb-query-item.test.ts
@@ -163,6 +163,62 @@ describe("field queries", () => {
         expect(actual[0]).toEqual(expected);
     });
 
+    test("returns only items related to specified creator given multiple items from different creators in collection", async () => {
+        const expectedCreator = "test item creator";
+        const expected = createItem({
+            name: "test item",
+            createTime: 2,
+            output: 2,
+            requirements: [],
+            creator: expectedCreator,
+        });
+        const stored = [
+            createItem({
+                name: "another item",
+                createTime: 3,
+                output: 5,
+                requirements: [],
+            }),
+            expected,
+        ];
+        await storeItems(stored);
+        const { queryItemByField } = await import("../mongodb-query-item");
+
+        const actual = await queryItemByField(undefined, expectedCreator);
+
+        expect(actual).toHaveLength(1);
+        expect(actual[0]).toEqual(expected);
+    });
+
+    test("returns only specific item created by specific creator if both item name and creator provided", async () => {
+        const expectedItemName = "test item";
+        const expectedCreator = "test item creator";
+        const expected = createItem({
+            name: expectedItemName,
+            createTime: 2,
+            output: 2,
+            requirements: [],
+            creator: expectedCreator,
+        });
+        const stored = [
+            createItem({
+                name: expectedItemName,
+                createTime: 3,
+                output: 5,
+                requirements: [],
+                creator: "a different creator",
+            }),
+            expected,
+        ];
+        await storeItems(stored);
+        const { queryItemByField } = await import("../mongodb-query-item");
+
+        const actual = await queryItemByField(undefined, expectedCreator);
+
+        expect(actual).toHaveLength(1);
+        expect(actual[0]).toEqual(expected);
+    });
+
     test("returns no items if no stored items match the provided item name in collection", async () => {
         const stored = createItem({
             name: "another item",
@@ -170,11 +226,25 @@ describe("field queries", () => {
             output: 5,
             requirements: [],
         });
-        const expectedItemName = "expected test item 1";
         await storeItems([stored]);
         const { queryItemByField } = await import("../mongodb-query-item");
 
-        const actual = await queryItemByField(expectedItemName);
+        const actual = await queryItemByField("unknown item");
+
+        expect(actual).toHaveLength(0);
+    });
+
+    test("returns no items if no stored items are created by provided creator in collection", async () => {
+        const stored = createItem({
+            name: "another item",
+            createTime: 3,
+            output: 5,
+            requirements: [],
+        });
+        await storeItems([stored]);
+        const { queryItemByField } = await import("../mongodb-query-item");
+
+        const actual = await queryItemByField(undefined, "unknown creator");
 
         expect(actual).toHaveLength(0);
     });

--- a/api/src/functions/query-item/adapters/mongodb-query-item.ts
+++ b/api/src/functions/query-item/adapters/mongodb-query-item.ts
@@ -1,5 +1,5 @@
 import client from "@colony-survival-calculator/mongodb-client";
-import { Document } from "mongodb";
+import { Document, Filter } from "mongodb";
 
 import type { Item } from "../../../types";
 import type {
@@ -17,15 +17,18 @@ if (!itemCollectionName) {
     throw new Error("Misconfigured: Item collection name not provided");
 }
 
-const queryItemByField: QueryItemByFieldSecondaryPort = async (name) => {
+const queryItemByField: QueryItemByFieldSecondaryPort = async (
+    name,
+    creator
+) => {
     const db = (await client).db(databaseName);
     const collection = db.collection<Item>(itemCollectionName);
+    const filter: Filter<Item> = {
+        ...(name ? { name } : {}),
+        ...(creator ? { creator } : {}),
+    };
 
-    if (name) {
-        return collection.find({ name }).toArray();
-    }
-
-    return collection.find().toArray();
+    return collection.find(filter).toArray();
 };
 
 const queryItemByCreatorCount: QueryItemByCreatorCountSecondaryPort = async (

--- a/api/src/functions/query-item/domain/__tests__/query-item.test.ts
+++ b/api/src/functions/query-item/domain/__tests__/query-item.test.ts
@@ -152,7 +152,6 @@ describe("creator count queries", () => {
             { minimumCreators: expectedMinimumCreators },
             expectedMinimumCreators,
             undefined,
-            undefined,
         ],
         [
             "a minimum creator count filter is provided w/ an item name",
@@ -162,17 +161,6 @@ describe("creator count queries", () => {
             },
             expectedMinimumCreators,
             expectedItemName,
-            undefined,
-        ],
-        [
-            "a minimum creator count filter is provided w/ a creator",
-            {
-                minimumCreators: expectedMinimumCreators,
-                creator: expectedCreator,
-            },
-            expectedMinimumCreators,
-            undefined,
-            expectedCreator,
         ],
     ])(
         "queries the database via creator count given %s",
@@ -180,16 +168,14 @@ describe("creator count queries", () => {
             _: string,
             filters: QueryFilters | undefined,
             expectedMinimumCreators: number,
-            expectedItemName: string | undefined,
-            expectedCreator: string | undefined
+            expectedItemName: string | undefined
         ) => {
             await queryItem(filters);
 
             expect(mockQueryItemByCreatorCount).toHaveBeenCalledTimes(1);
             expect(mockQueryItemByCreatorCount).toHaveBeenCalledWith(
                 expectedMinimumCreators,
-                expectedItemName,
-                expectedCreator
+                expectedItemName
             );
         }
     );
@@ -247,5 +233,31 @@ describe("creator count queries", () => {
 
         expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
         expect(consoleErrorSpy).toHaveBeenCalledWith(expectedError);
+    });
+
+    test("throws an error if a minimum creator filter is provided with a creator name filter", async () => {
+        const expectedError = new Error(
+            "Invalid filter combination provided: Cannot filter by minimum creator and creator name"
+        );
+
+        expect.assertions(1);
+        await expect(
+            queryItem({ minimumCreators: 1, creator: "test creator" })
+        ).rejects.toThrow(expectedError);
+    });
+
+    test("logs an error message to console if a minimum creator filter is provided with a creator name filter", async () => {
+        const expectedError = new Error(
+            "Invalid filter combination provided: Cannot filter by minimum creator and creator name"
+        );
+
+        try {
+            await queryItem({ minimumCreators: 1, creator: "test creator" });
+        } catch {
+            // Ignore
+        }
+
+        expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(expectedError.message);
     });
 });

--- a/api/src/functions/query-item/domain/__tests__/query-item.test.ts
+++ b/api/src/functions/query-item/domain/__tests__/query-item.test.ts
@@ -26,15 +26,30 @@ beforeEach(() => {
 
 const expectedItemName = "expected item name";
 const expectedMinimumCreators = 1;
+const expectedCreator = "expected item creator";
 
 describe("field queries", () => {
     test.each([
-        ["all items", "no field filters provided", undefined, undefined],
+        [
+            "all items",
+            "no field filters provided",
+            undefined,
+            undefined,
+            undefined,
+        ],
         [
             "a specific item",
             "an item name provided",
             { name: expectedItemName },
             expectedItemName,
+            undefined,
+        ],
+        [
+            "a specific creator",
+            "a creator provided",
+            { creator: expectedCreator },
+            undefined,
+            expectedCreator,
         ],
     ])(
         "queries the database via fields to fetch %s given %s",
@@ -42,12 +57,16 @@ describe("field queries", () => {
             _: string,
             __: string,
             filters: QueryFilters | undefined,
-            expected: string | undefined
+            expectedItemName: string | undefined,
+            expectedCreator: string | undefined
         ) => {
             await queryItem(filters);
 
             expect(mockQueryItemByField).toHaveBeenCalledTimes(1);
-            expect(mockQueryItemByField).toHaveBeenCalledWith(expected);
+            expect(mockQueryItemByField).toHaveBeenCalledWith(
+                expectedItemName,
+                expectedCreator
+            );
         }
     );
 
@@ -133,6 +152,7 @@ describe("creator count queries", () => {
             { minimumCreators: expectedMinimumCreators },
             expectedMinimumCreators,
             undefined,
+            undefined,
         ],
         [
             "a minimum creator count filter is provided w/ an item name",
@@ -142,6 +162,17 @@ describe("creator count queries", () => {
             },
             expectedMinimumCreators,
             expectedItemName,
+            undefined,
+        ],
+        [
+            "a minimum creator count filter is provided w/ a creator",
+            {
+                minimumCreators: expectedMinimumCreators,
+                creator: expectedCreator,
+            },
+            expectedMinimumCreators,
+            undefined,
+            expectedCreator,
         ],
     ])(
         "queries the database via creator count given %s",
@@ -149,14 +180,16 @@ describe("creator count queries", () => {
             _: string,
             filters: QueryFilters | undefined,
             expectedMinimumCreators: number,
-            expectedItemName: string | undefined
+            expectedItemName: string | undefined,
+            expectedCreator: string | undefined
         ) => {
             await queryItem(filters);
 
             expect(mockQueryItemByCreatorCount).toHaveBeenCalledTimes(1);
             expect(mockQueryItemByCreatorCount).toHaveBeenCalledWith(
                 expectedMinimumCreators,
-                expectedItemName
+                expectedItemName,
+                expectedCreator
             );
         }
     );

--- a/api/src/functions/query-item/domain/query-item.ts
+++ b/api/src/functions/query-item/domain/query-item.ts
@@ -14,11 +14,12 @@ const queryItem: QueryItemPrimaryPort = async (
         if (filters?.minimumCreators) {
             return await queryItemByCreatorCount(
                 filters.minimumCreators,
-                filters.name
+                filters.name,
+                filters.creator
             );
         }
 
-        return await queryItemByField(filters?.name);
+        return await queryItemByField(filters?.name, filters?.creator);
     } catch (ex) {
         console.error(ex);
         throw ex;

--- a/api/src/functions/query-item/domain/query-item.ts
+++ b/api/src/functions/query-item/domain/query-item.ts
@@ -7,15 +7,22 @@ import type {
     QueryItemPrimaryPort,
 } from "../interfaces/query-item-primary-port";
 
+const INVALID_FILTER_ERROR =
+    "Invalid filter combination provided: Cannot filter by minimum creator and creator name";
+
 const queryItem: QueryItemPrimaryPort = async (
     filters: QueryFilters | undefined
 ) => {
+    if (filters?.minimumCreators && filters.creator) {
+        console.error(INVALID_FILTER_ERROR);
+        throw new Error(INVALID_FILTER_ERROR);
+    }
+
     try {
         if (filters?.minimumCreators) {
             return await queryItemByCreatorCount(
                 filters.minimumCreators,
-                filters.name,
-                filters.creator
+                filters.name
             );
         }
 

--- a/api/src/functions/query-item/handler.ts
+++ b/api/src/functions/query-item/handler.ts
@@ -9,6 +9,7 @@ const handler: GraphQLEventHandler<QueryItemArgs, Item[]> = async (event) => {
               name: event.arguments.filters.name ?? undefined,
               minimumCreators:
                   event.arguments.filters.minimumCreators ?? undefined,
+              creator: event.arguments.filters.creator ?? undefined,
           }
         : undefined;
 

--- a/api/src/functions/query-item/interfaces/query-item-primary-port.ts
+++ b/api/src/functions/query-item/interfaces/query-item-primary-port.ts
@@ -3,6 +3,7 @@ import type { Items } from "../../../types";
 type QueryFilters = {
     name?: string | undefined;
     minimumCreators?: number | undefined;
+    creator?: string | undefined;
 };
 
 interface QueryItemPrimaryPort {

--- a/api/src/functions/query-item/interfaces/query-item-secondary-port.ts
+++ b/api/src/functions/query-item/interfaces/query-item-secondary-port.ts
@@ -5,7 +5,7 @@ interface QueryItemByFieldSecondaryPort {
 }
 
 interface QueryItemByCreatorCountSecondaryPort {
-    (minimumCreators: number, name?: string, creator?: string): Promise<Items>;
+    (minimumCreators: number, name?: string): Promise<Items>;
 }
 
 export type {

--- a/api/src/functions/query-item/interfaces/query-item-secondary-port.ts
+++ b/api/src/functions/query-item/interfaces/query-item-secondary-port.ts
@@ -1,11 +1,11 @@
 import type { Items } from "../../../types";
 
 interface QueryItemByFieldSecondaryPort {
-    (name?: string): Promise<Items>;
+    (name?: string, creator?: string): Promise<Items>;
 }
 
 interface QueryItemByCreatorCountSecondaryPort {
-    (minimumCreators: number, name?: string): Promise<Items>;
+    (minimumCreators: number, name?: string, creator?: string): Promise<Items>;
 }
 
 export type {

--- a/api/src/graphql/schema.graphql
+++ b/api/src/graphql/schema.graphql
@@ -33,6 +33,7 @@ enum Tools {
 input ItemsFilters {
     name: ID
     minimumCreators: Int
+    creator: String
 }
 
 type Query {


### PR DESCRIPTION
# What

Updated item query resolver to allow for querying for all items made by a particular creator

# Why

To enable the UI to fetch details related to a specific item's recipe when that item is made by more than one creator