### PR TITLE
fix: prevent duplicate item creation

### DIFF
--- a/api/src/functions/add-item/domain/__tests__/add-item.test.ts
+++ b/api/src/functions/add-item/domain/__tests__/add-item.test.ts
@@ -827,6 +827,57 @@ describe.each([
     });
 });
 
+describe("duplicate item and creator name combination handling", () => {
+    const itemName = "test item";
+    const creatorName = "test creator";
+    const items: Items = [
+        createItem({
+            name: itemName,
+            createTime: 2,
+            output: 1,
+            requirements: [],
+            creator: creatorName,
+        }),
+        createItem({
+            name: itemName,
+            createTime: 4,
+            output: 2,
+            requirements: [],
+            creator: "different creator",
+        }),
+        createItem({
+            name: itemName,
+            createTime: 4,
+            output: 2,
+            requirements: [],
+            creator: creatorName,
+        }),
+        createItem({
+            name: "another item",
+            createTime: 1,
+            output: 3,
+            requirements: [],
+        }),
+    ];
+    const input = JSON.stringify(items);
+    const expectedError = `Items provided with same name: ${itemName} and creator: ${creatorName}`;
+
+    test("does not store any items in database", async () => {
+        try {
+            await addItem(input);
+        } catch {
+            // Ignore
+        }
+
+        expect(storeItem).not.toHaveBeenCalled();
+    });
+
+    test("throws a validation error", async () => {
+        expect.assertions(1);
+        await expect(addItem(input)).rejects.toThrowError(expectedError);
+    });
+});
+
 describe.each([
     ["a single item", [validItem]],
     ["multiple items", validItems],

--- a/api/src/functions/add-item/domain/add-item.ts
+++ b/api/src/functions/add-item/domain/add-item.ts
@@ -69,11 +69,28 @@ function validateTools(items: Items): void {
     }
 }
 
+function validateCreators(items: Items): void {
+    const itemMap = new Map<string, Set<string>>();
+    for (const item of items) {
+        const creatorSet = itemMap.get(item.name);
+        if (!creatorSet) {
+            itemMap.set(item.name, new Set([item.creator]));
+        } else if (creatorSet.has(item.creator)) {
+            throw new Error(
+                `Items provided with same name: ${item.name} and creator: ${item.creator}`
+            );
+        } else {
+            creatorSet.add(item.creator);
+        }
+    }
+}
+
 const addItem: AddItemPrimaryPort = async (items) => {
     const parsedItems = parseItems(items);
     validateRequirements(parsedItems);
     validateOptionalOutputs(parsedItems);
     validateTools(parsedItems);
+    validateCreators(parsedItems);
 
     try {
         return await storeItem(parsedItems);


### PR DESCRIPTION
# What

Updated the add item resolver validation to prevent an two items from being added where they have the same name and creator

# Why

Prevents duplication of item recipes - An item can be created by more than one creator, but it cannot be created multiple ways by the same creator