### PR TITLE
feat(api): query optimal item recipe

### DIFF
--- a/api/infra/main.tf
+++ b/api/infra/main.tf
@@ -50,12 +50,6 @@ resource "aws_s3_bucket_public_access_block" "lambda_bucket_public_access_block"
   restrict_public_buckets = true
 }
 
-resource "aws_s3_bucket_acl" "lambda_bucket_acl" {
-  bucket = aws_s3_bucket.api_bucket.id
-
-  acl = "private"
-}
-
 resource "aws_s3_object" "items_json_seed" {
   bucket = aws_s3_bucket.api_bucket.id
 
@@ -180,6 +174,8 @@ resource "aws_lambda_function" "add_item_lambda" {
       MONGO_DB_URI         = mongodbatlas_serverless_instance.main.connection_strings_standard_srv
     }
   }
+
+  depends_on = [mongodbatlas_project_ip_access_list.main]
 }
 
 resource "aws_lambda_permission" "allow_api_bucket_seed_execution" {

--- a/api/src/common/modifiers/index.ts
+++ b/api/src/common/modifiers/index.ts
@@ -19,6 +19,15 @@ const ToolSchemaMap: Record<GraphQLSchemaTools, JSONSchemaTools> = {
     STEEL: JSONSchemaTools.steel,
 };
 
+const GraphQLToolsSchemaMap: Record<JSONSchemaTools, GraphQLSchemaTools> = {
+    [JSONSchemaTools.none]: "NONE",
+    [JSONSchemaTools.stone]: "STONE",
+    [JSONSchemaTools.copper]: "COPPER",
+    [JSONSchemaTools.iron]: "IRON",
+    [JSONSchemaTools.bronze]: "BRONZE",
+    [JSONSchemaTools.steel]: "STEEL",
+};
+
 function isAvailableToolSufficient(
     minimum: JSONSchemaTools,
     available: JSONSchemaTools
@@ -41,6 +50,7 @@ function getMaxToolModifier(
 
 export {
     ToolSchemaMap,
+    GraphQLToolsSchemaMap,
     ToolModifierValues,
     isAvailableToolSufficient,
     getMaxToolModifier,

--- a/api/src/functions/add-item/domain/__tests__/add-item.test.ts
+++ b/api/src/functions/add-item/domain/__tests__/add-item.test.ts
@@ -1,4 +1,4 @@
-import { Items, Tools } from "../../../../types";
+import { Items, Item, Tools } from "../../../../types";
 import { createItem, createOptionalOutput } from "../../../../../test";
 
 import { storeItem } from "../../adapters/store-item";
@@ -10,7 +10,6 @@ jest.mock("../../adapters/store-item", () => ({
 const mockStoreItem = storeItem as jest.Mock;
 
 import { addItem } from "../add-item";
-import { Item } from "../../../../graphql/schema";
 
 const validItem = createItem({
     name: "item name 1",

--- a/api/src/functions/query-item/__tests__/handler.test.ts
+++ b/api/src/functions/query-item/__tests__/handler.test.ts
@@ -3,9 +3,14 @@ import { mock } from "jest-mock-extended";
 
 import { handler } from "../handler";
 import { queryItem } from "../domain/query-item";
-import type { Items } from "../../../types";
+import { Tools as DomainTools, type Items } from "../../../types";
 import { createItem } from "../../../../test";
-import type { ItemsFilters, QueryItemArgs } from "../../../graphql/schema";
+import type {
+    ItemsFilters,
+    OptimalFilter,
+    QueryItemArgs,
+    Tools,
+} from "../../../graphql/schema";
 import { QueryFilters } from "../interfaces/query-item-primary-port";
 
 jest.mock("../domain/query-item", () => ({
@@ -14,15 +19,28 @@ jest.mock("../domain/query-item", () => ({
 
 const mockQueryItem = queryItem as jest.Mock;
 
-function createFilters(
-    itemName?: string,
-    minimumCreators?: number,
-    creator?: string
-): ItemsFilters {
+function createOptimalFilter(maxAvailableTool?: Tools): OptimalFilter {
+    return {
+        maxAvailableTool: maxAvailableTool ?? null,
+    };
+}
+
+function createFilters({
+    itemName,
+    minimumCreators,
+    creator,
+    optimal,
+}: {
+    itemName?: string;
+    minimumCreators?: number;
+    creator?: string;
+    optimal?: OptimalFilter;
+}): ItemsFilters {
     return {
         name: itemName ?? null,
         minimumCreators: minimumCreators ?? null,
         creator: creator ?? null,
+        optimal: optimal ?? null,
     };
 }
 
@@ -41,16 +59,33 @@ const expectedItemName = "test item";
 const expectedMinimumCreators = 2;
 const expectedCreator = "test item creator";
 const mockEventWithoutFilters = createMockEvent();
-const mockEventWithEmptyFilters = createMockEvent(createFilters());
-const mockEventWithItemName = createMockEvent(createFilters(expectedItemName));
+const mockEventWithEmptyFilters = createMockEvent(createFilters({}));
+const mockEventWithItemName = createMockEvent(
+    createFilters({ itemName: expectedItemName })
+);
 const mockEventWithMinimumCreators = createMockEvent(
-    createFilters(undefined, expectedMinimumCreators)
+    createFilters({ minimumCreators: expectedMinimumCreators })
 );
 const mockEventWithCreator = createMockEvent(
-    createFilters(undefined, undefined, expectedCreator)
+    createFilters({ creator: expectedCreator })
+);
+const mockEventWithOptimalFilter = createMockEvent(
+    createFilters({
+        optimal: createOptimalFilter(),
+    })
+);
+const mockEventWithOptimalFilterAndMaxTool = createMockEvent(
+    createFilters({
+        optimal: createOptimalFilter("COPPER"),
+    })
 );
 const mockEventWithAllFilters = createMockEvent(
-    createFilters(expectedItemName, expectedMinimumCreators, expectedCreator)
+    createFilters({
+        itemName: expectedItemName,
+        minimumCreators: expectedMinimumCreators,
+        creator: expectedCreator,
+        optimal: createOptimalFilter("STEEL"),
+    })
 );
 
 beforeEach(() => {
@@ -58,51 +93,51 @@ beforeEach(() => {
 });
 
 test.each([
+    ["no filters specified", mockEventWithoutFilters, undefined],
     [
-        "all known items",
-        "no filters specified",
-        mockEventWithoutFilters,
-        undefined,
-    ],
-    [
-        "all known items",
         "no item name specified in filter",
         mockEventWithEmptyFilters,
         { name: undefined },
     ],
     [
-        "a specific item",
         "an item name specified in filter",
         mockEventWithItemName,
         { name: expectedItemName },
     ],
     [
-        "all known items with a minimum number of creators",
         "a minimum number of creators specified in filter",
         mockEventWithMinimumCreators,
         { minimumCreators: expectedMinimumCreators },
     ],
     [
-        "all known items created by a specific creator",
         "a creator name specified in filter",
         mockEventWithCreator,
         { creator: expectedCreator },
     ],
     [
-        "a specific item w/ a specific creator that can be produced by a min number of creators",
+        "an optimal filter specified w/o max tool",
+        mockEventWithOptimalFilter,
+        { optimal: {} },
+    ],
+    [
+        "an optimal filter specified w/ max tool",
+        mockEventWithOptimalFilterAndMaxTool,
+        { optimal: { maxAvailableTool: DomainTools.copper } },
+    ],
+    [
         "an item name, creator, and minimum number of creators specified in filter",
         mockEventWithAllFilters,
         {
             name: expectedItemName,
             minimumCreators: expectedMinimumCreators,
             creator: expectedCreator,
+            optimal: { maxAvailableTool: DomainTools.steel },
         },
     ],
 ])(
-    "calls the domain to fetch %s given an event with %s",
+    "calls the domain to fetch items given an event with %s",
     async (
         _: string,
-        __: string,
         event: AppSyncResolverEvent<QueryItemArgs>,
         expected: QueryFilters | undefined
     ) => {

--- a/api/src/functions/query-item/__tests__/handler.test.ts
+++ b/api/src/functions/query-item/__tests__/handler.test.ts
@@ -6,6 +6,7 @@ import { queryItem } from "../domain/query-item";
 import { Tools as DomainTools, type Items } from "../../../types";
 import { createItem } from "../../../../test";
 import type {
+    Item,
     ItemsFilters,
     OptimalFilter,
     QueryItemArgs,
@@ -141,6 +142,8 @@ test.each([
         event: AppSyncResolverEvent<QueryItemArgs>,
         expected: QueryFilters | undefined
     ) => {
+        mockQueryItem.mockResolvedValue([]);
+
         await handler(event);
 
         expect(mockQueryItem).toHaveBeenCalledTimes(1);
@@ -149,7 +152,7 @@ test.each([
 );
 
 test.each([
-    ["none received", []],
+    ["none received", [], []],
     [
         "multiple received w/ no farm sizes",
         [
@@ -158,13 +161,39 @@ test.each([
                 createTime: 1,
                 output: 3,
                 requirements: [],
+                creator: "test 1 creator",
+                minimumTool: DomainTools.none,
+                maximumTool: DomainTools.steel,
             }),
             createItem({
                 name: "test 2",
                 createTime: 4,
                 output: 6,
                 requirements: [],
+                creator: "test 2 creator",
+                minimumTool: DomainTools.copper,
+                maximumTool: DomainTools.bronze,
             }),
+        ],
+        [
+            {
+                name: "test 1",
+                createTime: 1,
+                output: 3,
+                requires: [],
+                creator: "test 1 creator",
+                minimumTool: "NONE" as Tools,
+                maximumTool: "STEEL" as Tools,
+            },
+            {
+                name: "test 2",
+                createTime: 4,
+                output: 6,
+                requires: [],
+                creator: "test 2 creator",
+                minimumTool: "COPPER" as Tools,
+                maximumTool: "BRONZE" as Tools,
+            },
         ],
     ],
     [
@@ -177,6 +206,9 @@ test.each([
                 requirements: [],
                 width: 1,
                 height: 2,
+                creator: "test 1 creator",
+                minimumTool: DomainTools.none,
+                maximumTool: DomainTools.steel,
             }),
             createItem({
                 name: "test 2",
@@ -185,18 +217,49 @@ test.each([
                 requirements: [],
                 width: 3,
                 height: 4,
+                creator: "test 2 creator",
+                minimumTool: DomainTools.copper,
+                maximumTool: DomainTools.bronze,
             }),
+        ],
+        [
+            {
+                name: "test 1",
+                createTime: 1,
+                output: 3,
+                requires: [],
+                size: {
+                    width: 1,
+                    height: 2,
+                },
+                creator: "test 1 creator",
+                minimumTool: "NONE" as Tools,
+                maximumTool: "STEEL" as Tools,
+            },
+            {
+                name: "test 2",
+                createTime: 4,
+                output: 6,
+                requires: [],
+                size: {
+                    width: 3,
+                    height: 4,
+                },
+                creator: "test 2 creator",
+                minimumTool: "COPPER" as Tools,
+                maximumTool: "BRONZE" as Tools,
+            },
         ],
     ],
 ])(
     "returns all items retrieved from domain given %s",
-    async (_: string, received: Items) => {
+    async (_: string, received: Items, expected: Item[]) => {
         mockQueryItem.mockResolvedValue(received);
 
         const actual = await handler(mockEventWithoutFilters);
 
         expect(actual).toHaveLength(received.length);
-        expect(actual).toEqual(expect.arrayContaining(received));
+        expect(actual).toEqual(expect.arrayContaining(expected));
     }
 );
 

--- a/api/src/functions/query-item/domain/query-item.ts
+++ b/api/src/functions/query-item/domain/query-item.ts
@@ -1,4 +1,9 @@
 import {
+    getMaxToolModifier,
+    isAvailableToolSufficient,
+} from "../../../common/modifiers";
+import { Item, Items, Tools } from "../../../types";
+import {
     queryItemByCreatorCount,
     queryItemByField,
 } from "../adapters/mongodb-query-item";
@@ -10,6 +15,47 @@ import type {
 const INVALID_FILTER_ERROR =
     "Invalid filter combination provided: Cannot filter by minimum creator and creator name";
 
+function calculateOutput(
+    item: Pick<Item, "maximumTool" | "createTime" | "output">,
+    maxAvailableTool: Tools
+): number {
+    const modifier = getMaxToolModifier(item.maximumTool, maxAvailableTool);
+    return item.output / (item.createTime / modifier);
+}
+
+function filterByOptimal(items: Items, maxAvailableTool?: Tools): Items {
+    const itemMap = new Map<string, Item>();
+    for (const item of items) {
+        if (
+            maxAvailableTool &&
+            !isAvailableToolSufficient(item.minimumTool, maxAvailableTool)
+        ) {
+            continue;
+        }
+
+        const currentOptimalItem = itemMap.get(item.name);
+        if (!currentOptimalItem) {
+            itemMap.set(item.name, item);
+            continue;
+        }
+
+        const currentOptimalOutput = calculateOutput(
+            currentOptimalItem,
+            maxAvailableTool ?? currentOptimalItem.maximumTool
+        );
+        const itemOutput = calculateOutput(
+            item,
+            maxAvailableTool ?? item.maximumTool
+        );
+
+        if (itemOutput > currentOptimalOutput) {
+            itemMap.set(item.name, item);
+        }
+    }
+
+    return Array.from(itemMap.values());
+}
+
 const queryItem: QueryItemPrimaryPort = async (
     filters: QueryFilters | undefined
 ) => {
@@ -19,14 +65,15 @@ const queryItem: QueryItemPrimaryPort = async (
     }
 
     try {
-        if (filters?.minimumCreators) {
-            return await queryItemByCreatorCount(
-                filters.minimumCreators,
-                filters.name
-            );
+        const items = await (filters?.minimumCreators
+            ? queryItemByCreatorCount(filters.minimumCreators, filters.name)
+            : queryItemByField(filters?.name, filters?.creator));
+
+        if (filters?.optimal) {
+            return filterByOptimal(items, filters.optimal.maxAvailableTool);
         }
 
-        return await queryItemByField(filters?.name, filters?.creator);
+        return items;
     } catch (ex) {
         console.error(ex);
         throw ex;

--- a/api/src/functions/query-item/handler.ts
+++ b/api/src/functions/query-item/handler.ts
@@ -1,15 +1,29 @@
+import { ToolSchemaMap } from "../../common/modifiers";
 import type { Item, QueryItemArgs } from "../../graphql/schema";
 import type { GraphQLEventHandler } from "../../interfaces/GraphQLEventHandler";
 import { queryItem } from "./domain/query-item";
-import { QueryFilters } from "./interfaces/query-item-primary-port";
-
+import {
+    OptimalFilter,
+    QueryFilters,
+} from "./interfaces/query-item-primary-port";
 const handler: GraphQLEventHandler<QueryItemArgs, Item[]> = async (event) => {
+    const { name, minimumCreators, creator, optimal } =
+        event.arguments.filters ?? {};
+
+    const optimalFilter: OptimalFilter | undefined = optimal
+        ? {
+              maxAvailableTool: optimal.maxAvailableTool
+                  ? ToolSchemaMap[optimal.maxAvailableTool]
+                  : undefined,
+          }
+        : undefined;
+
     const filters: QueryFilters | undefined = event.arguments.filters
         ? {
-              name: event.arguments.filters.name ?? undefined,
-              minimumCreators:
-                  event.arguments.filters.minimumCreators ?? undefined,
-              creator: event.arguments.filters.creator ?? undefined,
+              name: name ?? undefined,
+              minimumCreators: minimumCreators ?? undefined,
+              creator: creator ?? undefined,
+              optimal: optimalFilter,
           }
         : undefined;
 

--- a/api/src/functions/query-item/handler.ts
+++ b/api/src/functions/query-item/handler.ts
@@ -1,4 +1,4 @@
-import { ToolSchemaMap } from "../../common/modifiers";
+import { GraphQLToolsSchemaMap, ToolSchemaMap } from "../../common/modifiers";
 import type { Item, QueryItemArgs } from "../../graphql/schema";
 import type { GraphQLEventHandler } from "../../interfaces/GraphQLEventHandler";
 import { queryItem } from "./domain/query-item";
@@ -28,8 +28,13 @@ const handler: GraphQLEventHandler<QueryItemArgs, Item[]> = async (event) => {
         : undefined;
 
     try {
-        return await queryItem(filters);
-    } catch {
+        const items = await queryItem(filters);
+        return items.map(({ maximumTool, minimumTool, ...rest }) => ({
+            maximumTool: GraphQLToolsSchemaMap[maximumTool],
+            minimumTool: GraphQLToolsSchemaMap[minimumTool],
+            ...rest,
+        }));
+    } catch (ex) {
         throw new Error(
             "An error occurred while fetching item details, please try again."
         );

--- a/api/src/functions/query-item/interfaces/query-item-primary-port.ts
+++ b/api/src/functions/query-item/interfaces/query-item-primary-port.ts
@@ -1,13 +1,18 @@
-import type { Items } from "../../../types";
+import type { Items, Tools } from "../../../types";
+
+type OptimalFilter = {
+    maxAvailableTool?: Tools | undefined;
+};
 
 type QueryFilters = {
     name?: string | undefined;
     minimumCreators?: number | undefined;
     creator?: string | undefined;
+    optimal?: OptimalFilter | undefined;
 };
 
 interface QueryItemPrimaryPort {
     (filters?: QueryFilters): Promise<Items>;
 }
 
-export type { QueryItemPrimaryPort, QueryFilters };
+export type { QueryItemPrimaryPort, QueryFilters, OptimalFilter };

--- a/api/src/graphql/schema.graphql
+++ b/api/src/graphql/schema.graphql
@@ -8,6 +8,8 @@ type Item {
     createTime: Float!
     output: Int!
     creator: String!
+    minimumTool: Tools!
+    maximumTool: Tools!
     size: FarmSize
 }
 

--- a/api/src/graphql/schema.graphql
+++ b/api/src/graphql/schema.graphql
@@ -30,10 +30,15 @@ enum Tools {
     STEEL
 }
 
+type OptimalFilter {
+    maxAvailableTool: Tools
+}
+
 input ItemsFilters {
     name: ID
     minimumCreators: Int
     creator: String
+    optimal: OptimalFilter
 }
 
 type Query {

--- a/api/src/graphql/schema.graphql
+++ b/api/src/graphql/schema.graphql
@@ -30,7 +30,7 @@ enum Tools {
     STEEL
 }
 
-type OptimalFilter {
+input OptimalFilter {
     maxAvailableTool: Tools
 }
 


### PR DESCRIPTION
# What

Updated Query Item resolver to:
- Allow providing a optimal filter
     - If the optimal filter is provided w/o a max tool specified then the recipes' max tool is used to calculate max output
     - If the optimal filter is provided w/ a max tool specified then that tool will be used to calculate max output of all recipes
     - In the event that the provided max tool cannot meet the minimum requirement of a recipe, then that recipe will not be returned (Regardless of whether it was optimal)
- Return the minimum and maximum tool information for a given item's recipe

Removed redundant ACL configuration from API IaC

# Why

To enable the UI / other consumers to fetch the best recipe for a given item w/o having to know which creator creates the item the fastest