### PR TITLE
feat(api): update requirements query to use recipe w/ highest output in requirements calculation

### DIFF
--- a/api/src/functions/query-requirements/domain/item-utils.ts
+++ b/api/src/functions/query-requirements/domain/item-utils.ts
@@ -1,0 +1,91 @@
+import {
+    ToolModifierValues,
+    getMaxToolModifier,
+    isAvailableToolSufficient,
+} from "../../../common/modifiers";
+import { Item, Items, Tools } from "../../../types";
+
+function calculateCreateTime(
+    item: Pick<Item, "maximumTool" | "createTime">,
+    availableTool: Tools
+) {
+    const toolModifier = getMaxToolModifier(item.maximumTool, availableTool);
+    return item.createTime / toolModifier;
+}
+
+function calculateOutput(
+    item: Pick<Item, "maximumTool" | "createTime" | "output">,
+    maxAvailableTool: Tools
+): number {
+    return item.output / calculateCreateTime(item, maxAvailableTool);
+}
+
+function filterByMinimumTool(items: Items): Items {
+    const itemMap = new Map<string, Item>();
+    for (const item of items) {
+        const currentOptimalItem = itemMap.get(item.name);
+        if (!currentOptimalItem) {
+            itemMap.set(item.name, item);
+            continue;
+        }
+
+        if (
+            ToolModifierValues[item.minimumTool] <
+            ToolModifierValues[currentOptimalItem.minimumTool]
+        ) {
+            itemMap.set(item.name, item);
+        }
+    }
+
+    return Array.from(itemMap.values());
+}
+
+function filterByOptimal(items: Items, maxAvailableTool: Tools): Items {
+    const itemMap = new Map<string, Item>();
+
+    for (const item of items) {
+        if (!isAvailableToolSufficient(item.minimumTool, maxAvailableTool)) {
+            continue;
+        }
+
+        const currentOptimalItem = itemMap.get(item.name);
+        if (!currentOptimalItem) {
+            itemMap.set(item.name, item);
+            continue;
+        }
+
+        const currentOptimalOutput = calculateOutput(
+            currentOptimalItem,
+            maxAvailableTool
+        );
+        const itemOutput = calculateOutput(item, maxAvailableTool);
+
+        if (itemOutput > currentOptimalOutput) {
+            itemMap.set(item.name, item);
+        }
+    }
+
+    return Array.from(itemMap.values());
+}
+
+function getLowestRequiredTool(items: Items): Tools {
+    let currentLowestTool = Tools.none;
+    for (const item of items) {
+        if (
+            ToolModifierValues[item.minimumTool] >
+            ToolModifierValues[currentLowestTool]
+        ) {
+            currentLowestTool = item.minimumTool;
+        }
+    }
+
+    return currentLowestTool;
+}
+
+export {
+    calculateCreateTime,
+    calculateOutput,
+    filterByMinimumTool,
+    filterByOptimal,
+    getLowestRequiredTool,
+};

--- a/api/src/functions/query-requirements/domain/requirements-linear-program.ts
+++ b/api/src/functions/query-requirements/domain/requirements-linear-program.ts
@@ -1,8 +1,8 @@
 import { GLPK, LP } from "glpk.js";
 
 import { Item, Items, OptionalOutput, Tools } from "../../../types";
-import { getMaxToolModifier } from "../../../common/modifiers";
 import { INTERNAL_SERVER_ERROR, UNKNOWN_ITEM_ERROR } from "./errors";
+import { calculateCreateTime } from "./item-utils";
 
 type Constraint = LP["subjectTo"][number];
 type ObjectiveVariable = LP["objective"]["vars"][number];
@@ -13,14 +13,6 @@ type IOItemDetails = {
     demanding: DemandingItemDetails[];
     outputting: OutputDetails[];
 };
-
-function calculateCreateTime(
-    item: Pick<Item, "maximumTool" | "createTime">,
-    availableTool: Tools
-) {
-    const toolModifier = getMaxToolModifier(item.maximumTool, availableTool);
-    return item.createTime / toolModifier;
-}
 
 function convertRequirementsToMap(requirements: Items): Map<string, Item> {
     const requirementMap = new Map<string, Item>();


### PR DESCRIPTION
# What

Updated requirements query resolver's domain logic to always use the recipe w/ highest output in calculations.
- Factors in available tools

Also updated error messaging to return the absolute minimum tool required given multiple items w/ different unmet tool requirements

# Why

Enables the requirements query to handle item's that can be created by more than one creator
- Default behavior
- In the future, this will be updated to allow specifying specific item overrides