### PR TITLE
feat(api): output query optimal recipe support

### DIFF
--- a/api/src/functions/query-output/domain/output-calculator.ts
+++ b/api/src/functions/query-output/domain/output-calculator.ts
@@ -59,7 +59,7 @@ function getMaxOutput(
     unit: OutputUnit,
     maxAvailableTool: Tools
 ): number {
-    let currentMaximum = 0;
+    let maximumOutputPerSecond = 0;
     for (const item of items) {
         const toolModifier = getMaxToolModifier(
             item.maximumTool,
@@ -67,16 +67,14 @@ function getMaxOutput(
         );
 
         const outputPerSecond = item.output / (item.createTime / toolModifier);
-        const outputPerWorker =
-            OutputUnitSecondMappings[unit] * outputPerSecond;
-        const totalOutput = outputPerWorker * workers;
-
-        if (currentMaximum < totalOutput) {
-            currentMaximum = totalOutput;
+        if (maximumOutputPerSecond < outputPerSecond) {
+            maximumOutputPerSecond = outputPerSecond;
         }
     }
 
-    return currentMaximum;
+    const outputPerWorker =
+        OutputUnitSecondMappings[unit] * maximumOutputPerSecond;
+    return outputPerWorker * workers;
 }
 
 const calculateOutput: QueryOutputPrimaryPort = async (

--- a/api/src/functions/query-requirements/domain/__tests__/query-requirements.test.ts
+++ b/api/src/functions/query-requirements/domain/__tests__/query-requirements.test.ts
@@ -725,7 +725,7 @@ describe("multiple recipe handling", () => {
         expect(actual[0]?.workers).toBeCloseTo(7.5);
     });
 
-    test("throws an error if an item cannot be created by any recipe", async () => {
+    test("throws an error if an item cannot be created by any recipe w/ provided tools", async () => {
         const requiredItem = createItem({
             name: "required item",
             createTime: 3,


### PR DESCRIPTION
# What

Updated output query resolver to handle items that can be created by multiple creators
- Will return the absolute maximum output given the provided tool

# Why

It is possible for an item to be created by more than one creator - Previously, this resolver would simply error. This constitutes the final API side change to support items w/ multiple creators
- All revolvers now return optimal output by default or can be requested to return only details related to optimal output recipes