### PR TITLE
feat: update UI to request optimal details

### DIFF
--- a/api/src/json/items.json
+++ b/api/src/json/items.json
@@ -63,6 +63,20 @@
         "creator": "Woodcutter"
     },
     {
+        "name": "Planks",
+        "createTime": 50,
+        "output": 4,
+        "requires": [
+            {
+                "name": "Log",
+                "amount": 1
+            }
+        ],
+        "minimumTool": "none",
+        "maximumTool": "stone",
+        "creator": "Tinkerer"
+    },
+    {
         "name": "Clay",
         "createTime": 20,
         "output": 1,

--- a/ui/src/pages/Calculator/Calculator.tsx
+++ b/ui/src/pages/Calculator/Calculator.tsx
@@ -30,6 +30,12 @@ const GET_ITEM_DETAILS_QUERY = gql(`
 `);
 
 function Calculator() {
+    const [workers, setWorkers] = useState<number>();
+    const [selectedTool, setSelectedTool] = useState<Tools>(Tools.None);
+    const [selectedOutputUnit, setSelectedOutputUnit] = useState<OutputUnit>(
+        OutputUnit.Minutes
+    );
+
     const {
         loading: itemNamesLoading,
         data: itemNameData,
@@ -39,15 +45,14 @@ function Calculator() {
     const { data: itemDetailsData, error: itemDetailsError } = useQuery(
         GET_ITEM_DETAILS_QUERY,
         {
-            variables: { filters: { name: selectedItem } },
+            variables: {
+                filters: {
+                    name: selectedItem,
+                    optimal: { maxAvailableTool: selectedTool },
+                },
+            },
             skip: !selectedItem,
         }
-    );
-
-    const [workers, setWorkers] = useState<number>();
-    const [selectedTool, setSelectedTool] = useState<Tools>();
-    const [selectedOutputUnit, setSelectedOutputUnit] = useState<OutputUnit>(
-        OutputUnit.Minutes
     );
 
     if (itemNamesLoading) {

--- a/ui/src/pages/Calculator/__tests__/Calculator-item-selection.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-item-selection.test.tsx
@@ -261,7 +261,7 @@ test("requests item details on the first option in the item name list without se
     const { matchedRequestDetails } = await expectedRequest;
 
     expect(matchedRequestDetails.variables).toEqual({
-        filters: { name: items[0].name },
+        filters: { name: items[0].name, optimal: { maxAvailableTool: "NONE" } },
     });
 });
 
@@ -272,7 +272,12 @@ test("requests item details for newly selected item if selection is changed", as
         "POST",
         expectedGraphQLAPIURL,
         expectedItemDetailsQueryName,
-        { filters: { name: expectedItemName } }
+        {
+            filters: {
+                name: expectedItemName,
+                optimal: { maxAvailableTool: "NONE" },
+            },
+        }
     );
 
     render(<Calculator />, expectedGraphQLAPIURL);
@@ -283,7 +288,10 @@ test("requests item details for newly selected item if selection is changed", as
     const { matchedRequestDetails } = await expectedRequest;
 
     expect(matchedRequestDetails.variables).toEqual({
-        filters: { name: expectedItemName },
+        filters: {
+            name: expectedItemName,
+            optimal: { maxAvailableTool: "NONE" },
+        },
     });
 });
 

--- a/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
@@ -99,6 +99,7 @@ test("queries optimal output if item and workers inputted with default unit sele
         name: item.name,
         workers: expectedWorkers,
         unit: OutputUnit.Minutes,
+        maxAvailableTool: "NONE",
     });
 });
 
@@ -123,6 +124,7 @@ test("queries optimal output if item and workers inputted with non-default unit 
         name: item.name,
         workers: expectedWorkers,
         unit: OutputUnit.GameDays,
+        maxAvailableTool: "NONE",
     });
 });
 

--- a/ui/src/pages/Calculator/__tests__/Calculator-requirements.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-requirements.test.tsx
@@ -101,6 +101,7 @@ test("queries requirements if item and workers inputted", async () => {
     expect(matchedRequestDetails.variables).toEqual({
         name: itemWithSingleRequirement.name,
         workers: expectedWorkers,
+        maxAvailableTool: "NONE",
     });
 });
 

--- a/ui/src/pages/Calculator/__tests__/Calculator-tool-selection.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-tool-selection.test.tsx
@@ -177,6 +177,59 @@ test("queries requirements again if tool is changed after first query", async ()
     await expect(expectedRequest).resolves.not.toThrow();
 });
 
+test("queries item details with provided tool if non default selected", async () => {
+    const expectedTool = Tools.Steel;
+    const expectedWorkers = 5;
+    const expectedRequest = waitForRequest(
+        server,
+        "POST",
+        expectedGraphQLAPIURL,
+        expectedItemDetailsQueryName,
+        {
+            filters: {
+                name: item.name,
+                optimal: { maxAvailableTool: expectedTool },
+            },
+        }
+    );
+
+    render(<Calculator />, expectedGraphQLAPIURL);
+    await selectTool(expectedTool);
+    await selectItemAndWorkers({
+        itemName: item.name,
+        workers: expectedWorkers,
+    });
+
+    await expect(expectedRequest).resolves.not.toThrow();
+});
+
+test("queries item details again if tool is changed after first query", async () => {
+    const expectedTool = Tools.Copper;
+    const expectedWorkers = 5;
+    const expectedRequest = waitForRequest(
+        server,
+        "POST",
+        expectedGraphQLAPIURL,
+        expectedItemDetailsQueryName,
+        {
+            filters: {
+                name: item.name,
+                optimal: { maxAvailableTool: expectedTool },
+            },
+        }
+    );
+
+    render(<Calculator />, expectedGraphQLAPIURL);
+    await selectTool(Tools.Steel);
+    await selectItemAndWorkers({
+        itemName: item.name,
+        workers: expectedWorkers,
+    });
+    await selectTool(expectedTool);
+
+    await expect(expectedRequest).resolves.not.toThrow();
+});
+
 afterAll(() => {
     server.close();
 });


### PR DESCRIPTION
# What

Updated calculator page to request item details using optimal filter
- Ensures that only the details related to optimal recipe are returned

Updated item seed file to include example of item w/ multiple creators

# Why

Enables the UI to work with items that have one or more creators
- Will always use most optimal recipe (for details, optimal output, and requirements)
- Requirements and optimal output resolvers support using optimal recipe by default, however, the item details resolver needs to be provided an optimal output filter to only return a single element