### PR TITLE
feat: fetch specific creator optimal output

### DIFF
--- a/api/src/functions/query-output/adapters/__tests__/mongodb-output-adapter.ts
+++ b/api/src/functions/query-output/adapters/__tests__/mongodb-output-adapter.ts
@@ -72,7 +72,7 @@ test.each([
 test("returns an empty array if no items are stored in the items collection", async () => {
     const { queryOutputDetails } = await import("../mongodb-output-adapter");
 
-    const actual = await queryOutputDetails(validItemName);
+    const actual = await queryOutputDetails({ name: validItemName });
 
     expect(actual).toEqual([]);
 });
@@ -162,7 +162,7 @@ test.each([
             "../mongodb-output-adapter"
         );
 
-        const actual = await queryOutputDetails(validItemName);
+        const actual = await queryOutputDetails({ name: validItemName });
 
         expect(actual).toHaveLength(expected.length);
         expect(actual).toEqual(expect.arrayContaining(expected));

--- a/api/src/functions/query-output/adapters/mongodb-output-adapter.ts
+++ b/api/src/functions/query-output/adapters/mongodb-output-adapter.ts
@@ -16,12 +16,15 @@ if (!itemCollectionName) {
     throw new Error("Misconfigured: Item collection name not provided");
 }
 
-const queryOutputDetails: OutputDatabasePort = async ({ name }) => {
+const queryOutputDetails: OutputDatabasePort = async ({ name, creator }) => {
     const db = (await client).db(databaseName);
     const collection = db.collection(itemCollectionName);
 
     return collection
-        .find<Item>({ name })
+        .find<Item>({
+            ...(name ? { name } : {}),
+            ...(creator ? { creator } : {}),
+        })
         .project<ItemOutputDetails>({
             _id: 0,
             createTime: 1,

--- a/api/src/functions/query-output/adapters/mongodb-output-adapter.ts
+++ b/api/src/functions/query-output/adapters/mongodb-output-adapter.ts
@@ -16,7 +16,7 @@ if (!itemCollectionName) {
     throw new Error("Misconfigured: Item collection name not provided");
 }
 
-const queryOutputDetails: OutputDatabasePort = async (name) => {
+const queryOutputDetails: OutputDatabasePort = async ({ name }) => {
     const db = (await client).db(databaseName);
     const collection = db.collection(itemCollectionName);
 

--- a/api/src/functions/query-output/domain/__tests__/output-calculator.test.ts
+++ b/api/src/functions/query-output/domain/__tests__/output-calculator.test.ts
@@ -78,7 +78,28 @@ test("calls the database adapter to get the output details for the provided item
     });
 
     expect(mockQueryOutputDetails).toHaveBeenCalledTimes(1);
-    expect(mockQueryOutputDetails).toHaveBeenCalledWith(validItemName);
+    expect(mockQueryOutputDetails).toHaveBeenCalledWith({
+        name: validItemName,
+    });
+});
+
+test("provides the creator name to database adapter if provided", async () => {
+    const expectedCreatorName = "test creator";
+    const details = createItemOutputDetails(2, 3);
+    mockQueryOutputDetails.mockResolvedValue([details]);
+
+    await calculateOutput({
+        name: validItemName,
+        workers: validWorkers,
+        unit: OutputUnit.MINUTES,
+        creator: expectedCreatorName,
+    });
+
+    expect(mockQueryOutputDetails).toHaveBeenCalledTimes(1);
+    expect(mockQueryOutputDetails).toHaveBeenCalledWith({
+        name: validItemName,
+        creator: expectedCreatorName,
+    });
 });
 
 test("throws an error if no item output details are returned from DB", async () => {

--- a/api/src/functions/query-output/domain/__tests__/output-calculator.test.ts
+++ b/api/src/functions/query-output/domain/__tests__/output-calculator.test.ts
@@ -38,7 +38,11 @@ test("throws an error given an empty string as an item name", async () => {
 
     expect.assertions(1);
     await expect(
-        calculateOutput("", validWorkers, OutputUnit.MINUTES)
+        calculateOutput({
+            name: "",
+            workers: validWorkers,
+            unit: OutputUnit.MINUTES,
+        })
     ).rejects.toThrow(expectedError);
 });
 
@@ -54,7 +58,11 @@ test.each([
 
         expect.assertions(1);
         await expect(
-            calculateOutput(validItemName, amount, OutputUnit.MINUTES)
+            calculateOutput({
+                name: validItemName,
+                workers: amount,
+                unit: OutputUnit.MINUTES,
+            })
         ).rejects.toThrow(expectedError);
     }
 );
@@ -63,7 +71,11 @@ test("calls the database adapter to get the output details for the provided item
     const details = createItemOutputDetails(2, 3);
     mockQueryOutputDetails.mockResolvedValue([details]);
 
-    await calculateOutput(validItemName, validWorkers, OutputUnit.MINUTES);
+    await calculateOutput({
+        name: validItemName,
+        workers: validWorkers,
+        unit: OutputUnit.MINUTES,
+    });
 
     expect(mockQueryOutputDetails).toHaveBeenCalledTimes(1);
     expect(mockQueryOutputDetails).toHaveBeenCalledWith(validItemName);
@@ -75,7 +87,11 @@ test("throws an error if no item output details are returned from DB", async () 
 
     expect.assertions(1);
     await expect(
-        calculateOutput(validItemName, validWorkers, OutputUnit.MINUTES)
+        calculateOutput({
+            name: validItemName,
+            workers: validWorkers,
+            unit: OutputUnit.MINUTES,
+        })
     ).rejects.toThrow(expectedError);
 });
 
@@ -85,7 +101,11 @@ test("throws an error if an unhandled exception occurs while fetching item requi
 
     expect.assertions(1);
     await expect(
-        calculateOutput(validItemName, validWorkers, OutputUnit.MINUTES)
+        calculateOutput({
+            name: validItemName,
+            workers: validWorkers,
+            unit: OutputUnit.MINUTES,
+        })
     ).rejects.toThrow(expectedError);
 });
 
@@ -105,7 +125,11 @@ test.each([
         const details = createItemOutputDetails(createTime, amount);
         mockQueryOutputDetails.mockResolvedValue([details]);
 
-        const actual = await calculateOutput(validItemName, validWorkers, unit);
+        const actual = await calculateOutput({
+            name: validItemName,
+            workers: validWorkers,
+            unit,
+        });
 
         expect(actual).toBeCloseTo(expected);
     }
@@ -129,12 +153,12 @@ describe("handles tool modifiers", () => {
 
             expect.assertions(1);
             await expect(
-                calculateOutput(
-                    validItemName,
-                    validWorkers,
-                    OutputUnit.MINUTES,
-                    provided
-                )
+                calculateOutput({
+                    name: validItemName,
+                    workers: validWorkers,
+                    unit: OutputUnit.MINUTES,
+                    maxAvailableTool: provided,
+                })
             ).rejects.toThrow(expectedError);
         }
     );
@@ -157,12 +181,12 @@ describe("handles tool modifiers", () => {
             );
             mockQueryOutputDetails.mockResolvedValue([details]);
 
-            const actual = await calculateOutput(
-                validItemName,
-                validWorkers,
-                OutputUnit.MINUTES,
-                provided
-            );
+            const actual = await calculateOutput({
+                name: validItemName,
+                workers: validWorkers,
+                unit: OutputUnit.MINUTES,
+                maxAvailableTool: provided,
+            });
 
             expect(actual).toBeCloseTo(expected);
         }
@@ -173,12 +197,12 @@ describe("handles tool modifiers", () => {
         const details = createItemOutputDetails(2, 3, Tools.none, Tools.copper);
         mockQueryOutputDetails.mockResolvedValue([details]);
 
-        const actual = await calculateOutput(
-            validItemName,
-            validWorkers,
-            OutputUnit.MINUTES,
-            Tools.steel
-        );
+        const actual = await calculateOutput({
+            name: validItemName,
+            workers: validWorkers,
+            unit: OutputUnit.MINUTES,
+            maxAvailableTool: Tools.steel,
+        });
 
         expect(actual).toBeCloseTo(expected);
     });
@@ -193,12 +217,12 @@ describe("multiple recipe handling", () => {
         ];
         mockQueryOutputDetails.mockResolvedValue(recipes);
 
-        const actual = await calculateOutput(
-            validItemName,
-            validWorkers,
-            OutputUnit.MINUTES,
-            Tools.steel
-        );
+        const actual = await calculateOutput({
+            name: validItemName,
+            workers: validWorkers,
+            unit: OutputUnit.MINUTES,
+            maxAvailableTool: Tools.steel,
+        });
 
         expect(actual).toBeCloseTo(expected);
     });
@@ -211,12 +235,12 @@ describe("multiple recipe handling", () => {
         ];
         mockQueryOutputDetails.mockResolvedValue(recipes);
 
-        const actual = await calculateOutput(
-            validItemName,
-            validWorkers,
-            OutputUnit.MINUTES,
-            Tools.steel
-        );
+        const actual = await calculateOutput({
+            name: validItemName,
+            workers: validWorkers,
+            unit: OutputUnit.MINUTES,
+            maxAvailableTool: Tools.steel,
+        });
 
         expect(actual).toBeCloseTo(expected);
     });
@@ -229,12 +253,12 @@ describe("multiple recipe handling", () => {
         ];
         mockQueryOutputDetails.mockResolvedValue(recipes);
 
-        const actual = await calculateOutput(
-            validItemName,
-            validWorkers,
-            OutputUnit.MINUTES,
-            Tools.none
-        );
+        const actual = await calculateOutput({
+            name: validItemName,
+            workers: validWorkers,
+            unit: OutputUnit.MINUTES,
+            maxAvailableTool: Tools.none,
+        });
 
         expect(actual).toBeCloseTo(expected);
     });
@@ -249,12 +273,12 @@ describe("multiple recipe handling", () => {
 
         expect.assertions(1);
         await expect(
-            calculateOutput(
-                validItemName,
-                validWorkers,
-                OutputUnit.MINUTES,
-                Tools.none
-            )
+            calculateOutput({
+                name: validItemName,
+                workers: validWorkers,
+                unit: OutputUnit.MINUTES,
+                maxAvailableTool: Tools.none,
+            })
         ).rejects.toThrow(expectedError);
     });
 });

--- a/api/src/functions/query-output/domain/output-calculator.ts
+++ b/api/src/functions/query-output/domain/output-calculator.ts
@@ -77,12 +77,12 @@ function getMaxOutput(
     return outputPerWorker * workers;
 }
 
-const calculateOutput: QueryOutputPrimaryPort = async (
+const calculateOutput: QueryOutputPrimaryPort = async ({
     name,
     workers,
     unit,
-    maxAvailableTool = Tools.none
-) => {
+    maxAvailableTool = Tools.none,
+}) => {
     if (name === "") {
         throw new Error(INVALID_ITEM_NAME_ERROR);
     }

--- a/api/src/functions/query-output/domain/output-calculator.ts
+++ b/api/src/functions/query-output/domain/output-calculator.ts
@@ -22,10 +22,14 @@ const TOOL_LEVEL_ERROR_PREFIX =
 const INTERNAL_SERVER_ERROR = "Internal server error";
 
 async function getItemOutputDetails(
-    name: string
+    name: string,
+    creator?: string
 ): Promise<ItemOutputDetails[]> {
     try {
-        return await queryOutputDetails(name);
+        return await queryOutputDetails({
+            name,
+            ...(creator ? { creator } : {}),
+        });
     } catch {
         throw new Error(INTERNAL_SERVER_ERROR);
     }
@@ -82,6 +86,7 @@ const calculateOutput: QueryOutputPrimaryPort = async ({
     workers,
     unit,
     maxAvailableTool = Tools.none,
+    creator,
 }) => {
     if (name === "") {
         throw new Error(INVALID_ITEM_NAME_ERROR);
@@ -91,7 +96,7 @@ const calculateOutput: QueryOutputPrimaryPort = async ({
         throw new Error(INVALID_WORKERS_ERROR);
     }
 
-    const outputDetails = await getItemOutputDetails(name);
+    const outputDetails = await getItemOutputDetails(name, creator);
     if (outputDetails.length === 0) {
         throw new Error(UNKNOWN_ITEM_ERROR);
     }

--- a/api/src/functions/query-output/handler.ts
+++ b/api/src/functions/query-output/handler.ts
@@ -5,14 +5,17 @@ import { OutputUnit } from "./interfaces/query-output-primary-port";
 import { ToolSchemaMap } from "../../common/modifiers";
 
 const handler: GraphQLEventHandler<QueryOutputArgs, number> = async (event) => {
-    const { name, workers, unit, maxAvailableTool } = event.arguments;
+    const { name, workers, unit, maxAvailableTool, creator } = event.arguments;
 
-    return calculateOutput(
+    return calculateOutput({
         name,
         workers,
-        OutputUnit[unit],
-        maxAvailableTool ? ToolSchemaMap[maxAvailableTool] : undefined
-    );
+        unit: OutputUnit[unit],
+        ...(maxAvailableTool
+            ? { maxAvailableTool: ToolSchemaMap[maxAvailableTool] }
+            : {}),
+        ...(creator ? { creator } : {}),
+    });
 };
 
 export { handler };

--- a/api/src/functions/query-output/interfaces/output-database-port.ts
+++ b/api/src/functions/query-output/interfaces/output-database-port.ts
@@ -6,7 +6,7 @@ type ItemOutputDetails = Pick<
 >;
 
 interface OutputDatabasePort {
-    (name: string): Promise<ItemOutputDetails[]>;
+    (input: { name: string; creator?: string }): Promise<ItemOutputDetails[]>;
 }
 
 export type { ItemOutputDetails, OutputDatabasePort };

--- a/api/src/functions/query-output/interfaces/query-output-primary-port.ts
+++ b/api/src/functions/query-output/interfaces/query-output-primary-port.ts
@@ -6,12 +6,13 @@ enum OutputUnit {
 }
 
 interface QueryOutputPrimaryPort {
-    (
-        name: string,
-        workers: number,
-        unit: OutputUnit,
-        maxAvailableTool?: Tools
-    ): Promise<number>;
+    (input: {
+        name: string;
+        workers: number;
+        unit: OutputUnit;
+        maxAvailableTool?: Tools;
+        creator?: string;
+    }): Promise<number>;
 }
 
 export { OutputUnit, QueryOutputPrimaryPort };

--- a/api/src/graphql/schema.graphql
+++ b/api/src/graphql/schema.graphql
@@ -56,6 +56,7 @@ type Query {
         workers: Int!
         unit: OutputUnit!
         maxAvailableTool: Tools
+        creator: String
     ): Float!
 }
 


### PR DESCRIPTION
# What

Updated `output` query to allow providing a creator name. If provided, it will return the optimal output for a given item using the create time etc for the provided creator if they exist

# Why

Enables fetching specific creator outputs for items that are created by more than one creator
- Previously, the code would only return the optimal output using the best recipe/creator known