### PR TITLE
feat(api): support requirements creator overrides

### DIFF
--- a/api/src/functions/query-requirements/adapters/__tests__/mongodb-requirements-adapter.test.ts
+++ b/api/src/functions/query-requirements/adapters/__tests__/mongodb-requirements-adapter.test.ts
@@ -307,6 +307,42 @@ test.each([
     }
 );
 
+test("removes duplicate items w/ same creator when input item has multiple creators that require the same item", async () => {
+    const requiredItemName = "required item 1";
+    const expected = [
+        createItem({
+            name: requiredItemName,
+            createTime: 4,
+            output: 2,
+            requirements: [],
+        }),
+        createItem({
+            name: validItemName,
+            createTime: 1,
+            output: 8,
+            requirements: [{ name: requiredItemName, amount: 4 }],
+            creator: "test creator 1",
+        }),
+        createItem({
+            name: validItemName,
+            createTime: 2,
+            output: 4,
+            requirements: [{ name: requiredItemName, amount: 2 }],
+            creator: "test creator 2",
+        }),
+    ];
+    await storeItems(JSON.parse(JSON.stringify(expected)));
+
+    const { queryRequirements } = await import(
+        "../mongodb-requirements-adapter"
+    );
+
+    const actual = await queryRequirements(validItemName);
+
+    expect(actual).toHaveLength(expected.length);
+    expect(actual).toEqual(expect.arrayContaining(expected));
+});
+
 afterAll(async () => {
     (await mockClient).close(true);
     await mongoDBMemoryServer.stop();

--- a/api/src/functions/query-requirements/adapters/mongodb-requirements-adapter.ts
+++ b/api/src/functions/query-requirements/adapters/mongodb-requirements-adapter.ts
@@ -44,6 +44,24 @@ const queryRequirements: RequirementsDatabasePort = async (name: string) => {
             },
         },
         {
+            $group: {
+                _id: {
+                    name: "$name",
+                    creator: "$creator",
+                },
+                unique: {
+                    $addToSet: "$$ROOT",
+                },
+            },
+        },
+        {
+            $replaceRoot: {
+                newRoot: {
+                    $arrayElemAt: ["$unique", 0],
+                },
+            },
+        },
+        {
             $sort: {
                 depth: 1,
             },

--- a/api/src/functions/query-requirements/domain/__tests__/query-requirements.test.ts
+++ b/api/src/functions/query-requirements/domain/__tests__/query-requirements.test.ts
@@ -763,6 +763,50 @@ describe("multiple recipe handling", () => {
         expect(actual[0]?.workers).toBeCloseTo(7.5);
     });
 
+    test("does not return any required items if the required item was related to a sub optimal recipe", async () => {
+        const moreOptimalRequiredItem = createItem({
+            name: "required item",
+            createTime: 3,
+            output: 4,
+            requirements: [],
+        });
+        const lessOptimalRequiredItem = createItem({
+            name: "another required item",
+            createTime: 3,
+            output: 4,
+            requirements: [],
+        });
+        const lessOptimalItemRecipe = createItem({
+            name: validItemName,
+            createTime: 2,
+            output: 3,
+            requirements: [{ name: lessOptimalRequiredItem.name, amount: 4 }],
+            creator: "creator 1",
+        });
+        const moreOptimalItemRecipe = createItem({
+            name: validItemName,
+            createTime: 1,
+            output: 6,
+            requirements: [{ name: moreOptimalRequiredItem.name, amount: 4 }],
+            creator: "creator 2",
+        });
+        mockMongoDBQueryRequirements.mockResolvedValue([
+            lessOptimalItemRecipe,
+            moreOptimalItemRecipe,
+            moreOptimalRequiredItem,
+            lessOptimalRequiredItem,
+        ]);
+
+        const actual = await queryRequirements({
+            name: validItemName,
+            workers: validWorkers,
+        });
+
+        expect(actual).toHaveLength(1);
+        expect(actual[0]?.name).toEqual(moreOptimalRequiredItem.name);
+        expect(actual[0]?.workers).toBeCloseTo(15);
+    });
+
     test("throws an error if an item cannot be created by any recipe w/ provided tools", async () => {
         const requiredItem = createItem({
             name: "required item",
@@ -799,5 +843,321 @@ describe("multiple recipe handling", () => {
         await expect(
             queryRequirements({ name: validItemName, workers: validWorkers })
         ).rejects.toThrow(expectedError);
+    });
+});
+
+describe("creator override handling", () => {
+    test("overrides more optimal recipe when given applicable item override", async () => {
+        const overrideCreator = "override creator";
+        const requiredItem = createItem({
+            name: "required item",
+            createTime: 3,
+            output: 4,
+            requirements: [],
+        });
+        const lessOptimalItemRecipe = createItem({
+            name: validItemName,
+            createTime: 2,
+            output: 3,
+            requirements: [{ name: requiredItem.name, amount: 4 }],
+            creator: overrideCreator,
+        });
+        const moreOptimalItemRecipe = createItem({
+            name: validItemName,
+            createTime: 1,
+            output: 3,
+            requirements: [{ name: requiredItem.name, amount: 4 }],
+            creator: "creator 2",
+        });
+        mockMongoDBQueryRequirements.mockResolvedValue([
+            lessOptimalItemRecipe,
+            moreOptimalItemRecipe,
+            requiredItem,
+        ]);
+
+        const actual = await queryRequirements({
+            name: validItemName,
+            workers: validWorkers,
+            creatorOverrides: [
+                { itemName: validItemName, creator: overrideCreator },
+            ],
+        });
+
+        expect(actual).toHaveLength(1);
+        expect(actual[0]?.name).toEqual(requiredItem.name);
+        expect(actual[0]?.workers).toBeCloseTo(7.5);
+    });
+
+    test("favours less optimal requirement recipe given applicable requirement override", async () => {
+        const requiredItemName = "required item";
+        const overrideCreator = "override creator";
+        const moreOptimalRequirementRecipe = createItem({
+            name: requiredItemName,
+            createTime: 1,
+            output: 4,
+            requirements: [],
+        });
+        const lessOptimalRequirementRecipe = createItem({
+            name: requiredItemName,
+            createTime: 3,
+            output: 4,
+            requirements: [],
+            creator: overrideCreator,
+        });
+        const recipe = createItem({
+            name: validItemName,
+            createTime: 1,
+            output: 3,
+            requirements: [{ name: requiredItemName, amount: 4 }],
+            creator: "creator 2",
+        });
+        mockMongoDBQueryRequirements.mockResolvedValue([
+            recipe,
+            moreOptimalRequirementRecipe,
+            lessOptimalRequirementRecipe,
+        ]);
+
+        const actual = await queryRequirements({
+            name: validItemName,
+            workers: validWorkers,
+            creatorOverrides: [
+                { itemName: requiredItemName, creator: overrideCreator },
+            ],
+        });
+
+        expect(actual).toHaveLength(1);
+        expect(actual[0]?.name).toEqual(requiredItemName);
+        expect(actual[0]?.workers).toBeCloseTo(15);
+    });
+
+    test("throws an error if provided more than one override for a single item", async () => {
+        const overrideCreator = "override creator";
+        const requiredItem = createItem({
+            name: "required item",
+            createTime: 3,
+            output: 4,
+            requirements: [],
+        });
+        const recipe = createItem({
+            name: validItemName,
+            createTime: 1,
+            output: 3,
+            requirements: [{ name: requiredItem.name, amount: 4 }],
+            creator: overrideCreator,
+        });
+        mockMongoDBQueryRequirements.mockResolvedValue([recipe, requiredItem]);
+        const expectedError = `Invalid input: More than one creator override provided for: ${validItemName}`;
+
+        expect.assertions(1);
+        await expect(
+            queryRequirements({
+                name: validItemName,
+                workers: validWorkers,
+                creatorOverrides: [
+                    { itemName: validItemName, creator: overrideCreator },
+                    { itemName: validItemName, creator: "another creator" },
+                ],
+            })
+        ).rejects.toThrow(expectedError);
+    });
+
+    test("ignores any provided override that is irrelevant to calculating requirements", async () => {
+        const requiredItem = createItem({
+            name: "required item",
+            createTime: 3,
+            output: 4,
+            requirements: [],
+        });
+        const lessOptimalItemRecipe = createItem({
+            name: validItemName,
+            createTime: 2,
+            output: 3,
+            requirements: [{ name: requiredItem.name, amount: 4 }],
+        });
+        const moreOptimalItemRecipe = createItem({
+            name: validItemName,
+            createTime: 1,
+            output: 3,
+            requirements: [{ name: requiredItem.name, amount: 4 }],
+            creator: "creator 2",
+        });
+        mockMongoDBQueryRequirements.mockResolvedValue([
+            lessOptimalItemRecipe,
+            moreOptimalItemRecipe,
+            requiredItem,
+        ]);
+
+        const actual = await queryRequirements({
+            name: validItemName,
+            workers: validWorkers,
+            creatorOverrides: [
+                { itemName: "another item", creator: "another item creator" },
+            ],
+        });
+
+        expect(actual).toHaveLength(1);
+        expect(actual[0]?.name).toEqual(requiredItem.name);
+        expect(actual[0]?.workers).toBeCloseTo(15);
+    });
+
+    test("does not return any requirement that relates to a recipe that was removed by an override", async () => {
+        const override = "test override creator";
+        const requiredItem = createItem({
+            name: "required item",
+            createTime: 3,
+            output: 4,
+            requirements: [],
+        });
+        const overriddenRequirement = createItem({
+            name: "overridden item requirement",
+            createTime: 2,
+            output: 1,
+            requirements: [],
+        });
+        const removedItemRecipe = createItem({
+            name: validItemName,
+            createTime: 2,
+            output: 3,
+            requirements: [{ name: overriddenRequirement.name, amount: 4 }],
+        });
+        const usedRecipe = createItem({
+            name: validItemName,
+            createTime: 1,
+            output: 3,
+            requirements: [{ name: requiredItem.name, amount: 4 }],
+            creator: override,
+        });
+        mockMongoDBQueryRequirements.mockResolvedValue([
+            usedRecipe,
+            removedItemRecipe,
+            overriddenRequirement,
+            requiredItem,
+        ]);
+
+        const actual = await queryRequirements({
+            name: validItemName,
+            workers: validWorkers,
+            creatorOverrides: [{ itemName: validItemName, creator: override }],
+        });
+
+        expect(actual).toHaveLength(1);
+        expect(actual[0]?.name).toEqual(requiredItem.name);
+        expect(actual[0]?.workers).toBeCloseTo(15);
+    });
+
+    test("throws an error if the provided override would result in no recipe being known for a given item (root override)", async () => {
+        const override = "another creator";
+        const requiredItem = createItem({
+            name: "required item",
+            createTime: 3,
+            output: 4,
+            requirements: [],
+        });
+        const recipe = createItem({
+            name: validItemName,
+            createTime: 1,
+            output: 3,
+            requirements: [{ name: requiredItem.name, amount: 4 }],
+            creator: "test creator",
+        });
+        mockMongoDBQueryRequirements.mockResolvedValue([recipe, requiredItem]);
+        const expectedError =
+            "Invalid input, item is not creatable with current overrides";
+
+        expect.assertions(1);
+        await expect(
+            queryRequirements({
+                name: validItemName,
+                workers: validWorkers,
+                creatorOverrides: [
+                    { itemName: validItemName, creator: override },
+                ],
+            })
+        ).rejects.toThrow(expectedError);
+    });
+
+    test("throws an error if the provided override would result in no recipe being known for a given item (requirement override)", async () => {
+        const override = "another creator";
+        const requiredItem = createItem({
+            name: "required item",
+            createTime: 3,
+            output: 4,
+            requirements: [],
+        });
+        const recipe = createItem({
+            name: validItemName,
+            createTime: 1,
+            output: 3,
+            requirements: [{ name: requiredItem.name, amount: 4 }],
+            creator: "test creator",
+        });
+        mockMongoDBQueryRequirements.mockResolvedValue([recipe, requiredItem]);
+        const expectedError =
+            "Invalid input, item is not creatable with current overrides";
+
+        expect.assertions(1);
+        await expect(
+            queryRequirements({
+                name: validItemName,
+                workers: validWorkers,
+                creatorOverrides: [
+                    { itemName: requiredItem.name, creator: override },
+                ],
+            })
+        ).rejects.toThrow(expectedError);
+    });
+
+    test("does not return any requirement related to optimal but un-creatable recipes if override removes requirement", async () => {
+        const lessOptimalRecipeRequirement = createItem({
+            name: "less optimal item requirement",
+            createTime: 3,
+            output: 4,
+            requirements: [],
+        });
+        const moreOptimalRecipeRequirement = createItem({
+            name: "more optimal required item",
+            createTime: 3,
+            output: 4,
+            requirements: [],
+        });
+        const lessOptimalRecipe = createItem({
+            name: validItemName,
+            createTime: 2,
+            output: 3,
+            requirements: [
+                { name: lessOptimalRecipeRequirement.name, amount: 4 },
+            ],
+            creator: "creator 1",
+        });
+        const moreOptimalRecipe = createItem({
+            name: validItemName,
+            createTime: 1,
+            output: 3,
+            requirements: [
+                { name: moreOptimalRecipeRequirement.name, amount: 4 },
+            ],
+            creator: "creator 2",
+        });
+        mockMongoDBQueryRequirements.mockResolvedValue([
+            moreOptimalRecipe,
+            lessOptimalRecipe,
+            moreOptimalRecipeRequirement,
+            lessOptimalRecipeRequirement,
+        ]);
+
+        const actual = await queryRequirements({
+            name: validItemName,
+            workers: validWorkers,
+            creatorOverrides: [
+                {
+                    itemName: moreOptimalRecipeRequirement.name,
+                    creator: "unknown creator",
+                },
+            ],
+        });
+
+        expect(actual).toHaveLength(1);
+        expect(actual[0]?.name).toEqual(lessOptimalRecipeRequirement.name);
+        expect(actual[0]?.workers).toBeCloseTo(7.5);
     });
 });

--- a/api/src/functions/query-requirements/domain/__tests__/query-requirements.test.ts
+++ b/api/src/functions/query-requirements/domain/__tests__/query-requirements.test.ts
@@ -23,9 +23,9 @@ test("throws an error given an empty string as an item name", async () => {
     );
 
     expect.assertions(1);
-    await expect(queryRequirements("", validWorkers)).rejects.toThrow(
-        expectedError
-    );
+    await expect(
+        queryRequirements({ name: "", workers: validWorkers })
+    ).rejects.toThrow(expectedError);
 });
 
 test.each([
@@ -39,9 +39,9 @@ test.each([
         );
 
         expect.assertions(1);
-        await expect(queryRequirements(validItemName, amount)).rejects.toThrow(
-            expectedError
-        );
+        await expect(
+            queryRequirements({ name: validItemName, workers: amount })
+        ).rejects.toThrow(expectedError);
     }
 );
 
@@ -54,7 +54,7 @@ test("calls the database adapter to get the requirements given valid input", asy
     });
     mockMongoDBQueryRequirements.mockResolvedValue([item]);
 
-    await queryRequirements(validItemName, validWorkers);
+    await queryRequirements({ name: validItemName, workers: validWorkers });
 
     expect(mockMongoDBQueryRequirements).toHaveBeenCalledTimes(1);
     expect(mockMongoDBQueryRequirements).toHaveBeenCalledWith(validItemName);
@@ -66,7 +66,7 @@ test("throws an error if no requirements are returned at all (item does not exis
 
     expect.assertions(1);
     await expect(
-        queryRequirements(validItemName, validWorkers)
+        queryRequirements({ name: validItemName, workers: validWorkers })
     ).rejects.toThrow(expectedError);
 });
 
@@ -82,7 +82,7 @@ test("throws an error if the provided item details are not returned from DB", as
 
     expect.assertions(1);
     await expect(
-        queryRequirements(validItemName, validWorkers)
+        queryRequirements({ name: validItemName, workers: validWorkers })
     ).rejects.toThrow(expectedError);
 });
 
@@ -95,7 +95,10 @@ test("returns an empty array if the provided item has no requirements", async ()
     });
     mockMongoDBQueryRequirements.mockResolvedValue([item]);
 
-    const actual = await queryRequirements(validItemName, validWorkers);
+    const actual = await queryRequirements({
+        name: validItemName,
+        workers: validWorkers,
+    });
 
     expect(actual).toEqual([]);
 });
@@ -112,7 +115,7 @@ test("throws an error if provided item requires an item that does not exist in d
 
     expect.assertions(1);
     await expect(
-        queryRequirements(validItemName, validWorkers)
+        queryRequirements({ name: validItemName, workers: validWorkers })
     ).rejects.toThrow(expectedError);
 });
 
@@ -131,7 +134,10 @@ test("returns requirement given item with a single requirement and no nested req
     });
     mockMongoDBQueryRequirements.mockResolvedValue([item, requiredItem]);
 
-    const actual = await queryRequirements(validItemName, validWorkers);
+    const actual = await queryRequirements({
+        name: validItemName,
+        workers: validWorkers,
+    });
 
     expect(actual).toHaveLength(1);
     expect(actual[0]?.name).toEqual(requiredItem.name);
@@ -166,7 +172,10 @@ test("returns requirements given item with multiple requirements and no nested r
         requiredItem2,
     ]);
 
-    const actual = await queryRequirements(validItemName, validWorkers);
+    const actual = await queryRequirements({
+        name: validItemName,
+        workers: validWorkers,
+    });
 
     expect(actual).toHaveLength(2);
     expect(actual).toEqual([
@@ -200,7 +209,10 @@ test("returns requirements given item with single nested requirement", async () 
         requiredItem2,
     ]);
 
-    const actual = await queryRequirements(validItemName, validWorkers);
+    const actual = await queryRequirements({
+        name: validItemName,
+        workers: validWorkers,
+    });
 
     expect(actual).toHaveLength(2);
     expect(actual).toEqual([
@@ -244,7 +256,10 @@ test("returns requirements given item with multiple different nested requirement
         requiredItem3,
     ]);
 
-    const actual = await queryRequirements(validItemName, validWorkers);
+    const actual = await queryRequirements({
+        name: validItemName,
+        workers: validWorkers,
+    });
 
     expect(actual).toHaveLength(3);
     expect(actual).toEqual([
@@ -292,7 +307,10 @@ test("returns combined requirements given item with multiple nested requirements
         requiredItem3,
     ]);
 
-    const actual = await queryRequirements(validItemName, validWorkers);
+    const actual = await queryRequirements({
+        name: validItemName,
+        workers: validWorkers,
+    });
 
     expect(actual).toHaveLength(3);
     expect(actual).toContainEqual({ name: requiredItem1.name, workers: 7.5 });
@@ -306,7 +324,7 @@ test("throws an error if an unhandled exception occurs while fetching item requi
 
     expect.assertions(1);
     await expect(
-        queryRequirements(validItemName, validWorkers)
+        queryRequirements({ name: validItemName, workers: validWorkers })
     ).rejects.toThrow(expectedError);
 });
 
@@ -333,7 +351,11 @@ describe("handles tool modifiers", () => {
 
             expect.assertions(1);
             await expect(
-                queryRequirements(validItemName, validWorkers, provided)
+                queryRequirements({
+                    name: validItemName,
+                    workers: validWorkers,
+                    maxAvailableTool: provided,
+                })
             ).rejects.toThrow(expectedError);
         }
     );
@@ -371,7 +393,11 @@ describe("handles tool modifiers", () => {
 
             expect.assertions(1);
             await expect(
-                queryRequirements(validItemName, validWorkers, provided)
+                queryRequirements({
+                    name: validItemName,
+                    workers: validWorkers,
+                    maxAvailableTool: provided,
+                })
             ).rejects.toThrow(expectedError);
         }
     );
@@ -399,7 +425,7 @@ describe("handles tool modifiers", () => {
 
         expect.assertions(1);
         await expect(
-            queryRequirements(validItemName, validWorkers)
+            queryRequirements({ name: validItemName, workers: validWorkers })
         ).rejects.toThrow(expectedError);
     });
 
@@ -435,11 +461,11 @@ describe("handles tool modifiers", () => {
                 requiredItem,
             ]);
 
-            const actual = await queryRequirements(
-                validItemName,
-                validWorkers,
-                provided
-            );
+            const actual = await queryRequirements({
+                name: validItemName,
+                workers: validWorkers,
+                maxAvailableTool: provided,
+            });
             const requirement = actual.find(
                 (value) => value.name === requiredItemName
             ) as RequiredWorkers;
@@ -468,11 +494,11 @@ describe("handles tool modifiers", () => {
         });
         mockMongoDBQueryRequirements.mockResolvedValue([item, requiredItem]);
 
-        const actual = await queryRequirements(
-            validItemName,
-            validWorkers,
-            Tools.steel
-        );
+        const actual = await queryRequirements({
+            name: validItemName,
+            workers: validWorkers,
+            maxAvailableTool: Tools.steel,
+        });
         const requirement = actual.find(
             (value) => value.name === requiredItemName
         ) as RequiredWorkers;
@@ -500,11 +526,11 @@ describe("handles tool modifiers", () => {
         });
         mockMongoDBQueryRequirements.mockResolvedValue([item, requiredItem]);
 
-        const actual = await queryRequirements(
-            validItemName,
-            validWorkers,
-            Tools.steel
-        );
+        const actual = await queryRequirements({
+            name: validItemName,
+            workers: validWorkers,
+            maxAvailableTool: Tools.steel,
+        });
         const requirement = actual.find(
             (value) => value.name === requiredItemName
         ) as RequiredWorkers;
@@ -532,11 +558,11 @@ describe("handles tool modifiers", () => {
         });
         mockMongoDBQueryRequirements.mockResolvedValue([item, requiredItem]);
 
-        const actual = await queryRequirements(
-            validItemName,
-            validWorkers,
-            Tools.steel
-        );
+        const actual = await queryRequirements({
+            name: validItemName,
+            workers: validWorkers,
+            maxAvailableTool: Tools.steel,
+        });
         const requirement = actual.find(
             (value) => value.name === requiredItemName
         ) as RequiredWorkers;
@@ -564,7 +590,10 @@ describe("optional output requirement impact", () => {
         });
         mockMongoDBQueryRequirements.mockResolvedValue([item, requiredItem1]);
 
-        const actual = await queryRequirements(validItemName, validWorkers);
+        const actual = await queryRequirements({
+            name: validItemName,
+            workers: validWorkers,
+        });
 
         expect(actual).toHaveLength(1);
         expect(actual[0]?.name).toEqual(requiredItem1.name);
@@ -599,7 +628,10 @@ describe("optional output requirement impact", () => {
             requiredItem2,
         ]);
 
-        const actual = await queryRequirements(validItemName, validWorkers);
+        const actual = await queryRequirements({
+            name: validItemName,
+            workers: validWorkers,
+        });
 
         expect(actual).toHaveLength(2);
         expect(actual).toContainEqual({
@@ -641,7 +673,10 @@ describe("multiple recipe handling", () => {
             requiredItem,
         ]);
 
-        const actual = await queryRequirements(validItemName, validWorkers);
+        const actual = await queryRequirements({
+            name: validItemName,
+            workers: validWorkers,
+        });
 
         expect(actual).toHaveLength(1);
         expect(actual[0]?.name).toEqual(requiredItem.name);
@@ -677,11 +712,11 @@ describe("multiple recipe handling", () => {
             requiredItem,
         ]);
 
-        const actual = await queryRequirements(
-            validItemName,
-            validWorkers,
-            Tools.steel
-        );
+        const actual = await queryRequirements({
+            name: validItemName,
+            workers: validWorkers,
+            maxAvailableTool: Tools.steel,
+        });
 
         expect(actual).toHaveLength(1);
         expect(actual[0]?.name).toEqual(requiredItem.name);
@@ -718,7 +753,10 @@ describe("multiple recipe handling", () => {
             requiredItem,
         ]);
 
-        const actual = await queryRequirements(validItemName, validWorkers);
+        const actual = await queryRequirements({
+            name: validItemName,
+            workers: validWorkers,
+        });
 
         expect(actual).toHaveLength(1);
         expect(actual[0]?.name).toEqual(requiredItem.name);
@@ -759,7 +797,7 @@ describe("multiple recipe handling", () => {
 
         expect.assertions(1);
         await expect(
-            queryRequirements(validItemName, validWorkers)
+            queryRequirements({ name: validItemName, workers: validWorkers })
         ).rejects.toThrow(expectedError);
     });
 });

--- a/api/src/functions/query-requirements/domain/errors.ts
+++ b/api/src/functions/query-requirements/domain/errors.ts
@@ -5,6 +5,10 @@ const INVALID_WORKERS_ERROR =
 const UNKNOWN_ITEM_ERROR = "Unknown item provided";
 const TOOL_LEVEL_ERROR_PREFIX =
     "Unable to create item with available tools, minimum tool is:";
+const MULTIPLE_OVERRIDE_ERROR_PREFIX =
+    "Invalid input: More than one creator override provided for:";
+const INVALID_OVERRIDE_ITEM_NOT_CREATABLE_ERROR =
+    "Invalid input, item is not creatable with current overrides";
 const INTERNAL_SERVER_ERROR = "Internal server error";
 
 export {
@@ -12,5 +16,7 @@ export {
     INVALID_WORKERS_ERROR,
     UNKNOWN_ITEM_ERROR,
     TOOL_LEVEL_ERROR_PREFIX,
+    MULTIPLE_OVERRIDE_ERROR_PREFIX,
+    INVALID_OVERRIDE_ITEM_NOT_CREATABLE_ERROR,
     INTERNAL_SERVER_ERROR,
 };

--- a/api/src/functions/query-requirements/domain/item-utils.ts
+++ b/api/src/functions/query-requirements/domain/item-utils.ts
@@ -1,9 +1,15 @@
+import { Graph } from "graph-data-structure";
+
 import {
     ToolModifierValues,
     getMaxToolModifier,
     isAvailableToolSufficient,
 } from "../../../common/modifiers";
 import { Item, Items, Tools } from "../../../types";
+import { CreatorOverride } from "../interfaces/query-requirements-primary-port";
+import { INTERNAL_SERVER_ERROR } from "./errors";
+
+const ROOT_GRAPH_KEY = "root";
 
 function calculateCreateTime(
     item: Pick<Item, "maximumTool" | "createTime">,
@@ -82,10 +88,146 @@ function getLowestRequiredTool(items: Items): Tools {
     return currentLowestTool;
 }
 
+function groupItemsByName(items: Items): Map<string, Items> {
+    const itemRecipes = new Map<string, Items>();
+    for (const item of items) {
+        const recipes = itemRecipes.get(item.name) ?? [];
+        itemRecipes.set(item.name, [...recipes, item]);
+    }
+
+    return itemRecipes;
+}
+
+function getUniqueItemKey(item: Pick<Item, "name" | "creator">): string {
+    return `${item.name}#${item.creator}`;
+}
+
+function splitItems(
+    items: Items,
+    predicate: (item: Item) => boolean
+): [Items, Items] {
+    const matching: Items = [];
+    const nonMatching: Items = [];
+    for (const item of items) {
+        if (predicate(item)) {
+            matching.push(item);
+        } else {
+            nonMatching.push(item);
+        }
+    }
+
+    return [matching, nonMatching];
+}
+
+function createItemGraph(
+    items: Items,
+    recipesMap: Map<string, Items>,
+    rootItemName?: string
+) {
+    const graph = Graph();
+    for (const item of items) {
+        const itemRecipeKey = getUniqueItemKey(item);
+        graph.addNode(itemRecipeKey);
+
+        if (rootItemName === item.name) {
+            graph.addNode(ROOT_GRAPH_KEY);
+            graph.addEdge(ROOT_GRAPH_KEY, itemRecipeKey);
+        }
+
+        for (const requirement of item.requires) {
+            const recipes = recipesMap.get(requirement.name);
+            if (!recipes) {
+                throw new Error(INTERNAL_SERVER_ERROR);
+            }
+
+            for (const recipe of recipes) {
+                const requirementRecipeKey = getUniqueItemKey(recipe);
+                graph.addNode(requirementRecipeKey);
+                graph.addEdge(itemRecipeKey, requirementRecipeKey);
+                graph.addEdge(requirementRecipeKey, itemRecipeKey);
+            }
+        }
+    }
+
+    return graph;
+}
+
+function filterByCreatorOverrides(
+    rootItemName: string,
+    items: Items,
+    overrides: CreatorOverride[]
+): Items {
+    const itemMap = new Map<string, Item>(
+        items.map((item) => [getUniqueItemKey(item), item])
+    );
+    const recipesMap = groupItemsByName(items);
+    const graph = createItemGraph(items, recipesMap, rootItemName);
+
+    const removeUncreatableNodes = (current: string) => {
+        const item = itemMap.get(current);
+        if (!item) {
+            throw new Error(INTERNAL_SERVER_ERROR);
+        }
+
+        const adjacent = graph.adjacent(current);
+        const adjacentItems = new Set(
+            adjacent.map((node) => node.split("#")[0] as string)
+        );
+        const creatable = item.requires.every(({ name }) =>
+            adjacentItems.has(name)
+        );
+        if (!creatable) {
+            graph.removeNode(current);
+            adjacent.map((node) => removeUncreatableNodes(node));
+        }
+    };
+
+    for (const { itemName, creator } of overrides) {
+        const [, recipesToIgnore] = splitItems(
+            recipesMap.get(itemName) ?? [],
+            (item) => item.creator === creator
+        );
+
+        for (const ignore of recipesToIgnore) {
+            const ignoreKey = getUniqueItemKey(ignore);
+            const adjacent = graph.adjacent(ignoreKey);
+            graph.removeNode(ignoreKey);
+            adjacent.map((node) => removeUncreatableNodes(node));
+        }
+    }
+
+    const creatableItemSet = new Set<string>(
+        graph.depthFirstSearch([ROOT_GRAPH_KEY], false)
+    );
+
+    return items.filter((item) => creatableItemSet.has(getUniqueItemKey(item)));
+}
+
+function canCreateItem(name: string, items: Items): boolean {
+    const recipesMap = groupItemsByName(items);
+
+    const canCreateItem = (name: string): boolean => {
+        const recipes = recipesMap.get(name);
+        if (!recipes || recipes.length === 0) {
+            return false;
+        }
+
+        return recipes.some((recipe) => {
+            return recipe.requires.every((requirement) =>
+                canCreateItem(requirement.name)
+            );
+        });
+    };
+
+    return canCreateItem(name);
+}
+
 export {
     calculateCreateTime,
     calculateOutput,
+    canCreateItem,
     filterByMinimumTool,
     filterByOptimal,
+    filterByCreatorOverrides,
     getLowestRequiredTool,
 };

--- a/api/src/functions/query-requirements/domain/query-requirements.ts
+++ b/api/src/functions/query-requirements/domain/query-requirements.ts
@@ -45,11 +45,11 @@ function mapResults(
     return requiredWorkers;
 }
 
-const queryRequirements: QueryRequirementsPrimaryPort = async (
-    name: string,
-    workers: number,
-    maxAvailableTool: Tools = Tools.none
-) => {
+const queryRequirements: QueryRequirementsPrimaryPort = async ({
+    name,
+    workers,
+    maxAvailableTool = Tools.none,
+}) => {
     if (name === "") {
         throw new Error(INVALID_ITEM_NAME_ERROR);
     }

--- a/api/src/functions/query-requirements/domain/query-requirements.ts
+++ b/api/src/functions/query-requirements/domain/query-requirements.ts
@@ -1,6 +1,9 @@
 import GLPK, { Result } from "glpk.js";
 
-import type { QueryRequirementsPrimaryPort } from "../interfaces/query-requirements-primary-port";
+import type {
+    CreatorOverride,
+    QueryRequirementsPrimaryPort,
+} from "../interfaces/query-requirements-primary-port";
 import { queryRequirements as queryRequirementsDB } from "../adapters/mongodb-requirements-adapter";
 import { Items, Tools } from "../../../types";
 import { isAvailableToolSufficient } from "../../../common/modifiers";
@@ -9,11 +12,15 @@ import { createRequirementsLinearProgram } from "./requirements-linear-program";
 import {
     INTERNAL_SERVER_ERROR,
     INVALID_ITEM_NAME_ERROR,
+    INVALID_OVERRIDE_ITEM_NOT_CREATABLE_ERROR,
     INVALID_WORKERS_ERROR,
+    MULTIPLE_OVERRIDE_ERROR_PREFIX,
     TOOL_LEVEL_ERROR_PREFIX,
     UNKNOWN_ITEM_ERROR,
 } from "./errors";
 import {
+    canCreateItem,
+    filterByCreatorOverrides,
     filterByMinimumTool,
     filterByOptimal,
     getLowestRequiredTool,
@@ -22,6 +29,42 @@ import {
 const glpk = GLPK();
 
 type ResultVariables = Result["result"]["vars"];
+
+function findMultipleOverrides(
+    overrides?: CreatorOverride[]
+): string | undefined {
+    if (!overrides) {
+        return undefined;
+    }
+
+    const knownOverrides = new Set<string>();
+    for (const override of overrides) {
+        if (knownOverrides.has(override.itemName)) {
+            return override.itemName;
+        }
+
+        knownOverrides.add(override.itemName);
+    }
+
+    return undefined;
+}
+
+function getOverriddenRequirements(
+    inputItemName: string,
+    items: Items,
+    overrides?: CreatorOverride[]
+) {
+    if (!overrides) {
+        return items;
+    }
+
+    const filtered = filterByCreatorOverrides(inputItemName, items, overrides);
+    if (canCreateItem(inputItemName, filtered)) {
+        return filtered;
+    }
+
+    throw new Error(INVALID_OVERRIDE_ITEM_NOT_CREATABLE_ERROR);
+}
 
 async function getRequiredItemDetails(name: string): Promise<Items> {
     try {
@@ -37,7 +80,7 @@ function mapResults(
 ): RequiredWorkers[] {
     const requiredWorkers: RequiredWorkers[] = [];
     for (const [itemName, workers] of Object.entries(results)) {
-        if (itemName != inputItemName) {
+        if (itemName != inputItemName && workers !== 0) {
             requiredWorkers.push({ name: itemName, workers });
         }
     }
@@ -49,6 +92,7 @@ const queryRequirements: QueryRequirementsPrimaryPort = async ({
     name,
     workers,
     maxAvailableTool = Tools.none,
+    creatorOverrides,
 }) => {
     if (name === "") {
         throw new Error(INVALID_ITEM_NAME_ERROR);
@@ -58,19 +102,36 @@ const queryRequirements: QueryRequirementsPrimaryPort = async ({
         throw new Error(INVALID_WORKERS_ERROR);
     }
 
+    const multipleOverride = findMultipleOverrides(creatorOverrides);
+    if (multipleOverride) {
+        throw new Error(
+            `${MULTIPLE_OVERRIDE_ERROR_PREFIX} ${multipleOverride}`
+        );
+    }
+
     const requirements = await getRequiredItemDetails(name);
     if (requirements.length == 0) {
         throw new Error(UNKNOWN_ITEM_ERROR);
     }
 
+    const overriddenRequirements = getOverriddenRequirements(
+        name,
+        requirements,
+        creatorOverrides
+    );
+
     const lowestToolRequired = getLowestRequiredTool(
-        filterByMinimumTool(requirements)
+        filterByMinimumTool(overriddenRequirements)
     );
     if (!isAvailableToolSufficient(lowestToolRequired, maxAvailableTool)) {
         throw new Error(`${TOOL_LEVEL_ERROR_PREFIX} ${lowestToolRequired}`);
     }
 
-    const optimalRequirements = filterByOptimal(requirements, maxAvailableTool);
+    const optimalRequirements = filterByOptimal(
+        overriddenRequirements,
+        maxAvailableTool
+    );
+
     const program = createRequirementsLinearProgram(
         glpk,
         name,

--- a/api/src/functions/query-requirements/handler.ts
+++ b/api/src/functions/query-requirements/handler.ts
@@ -10,12 +10,14 @@ const handler: GraphQLEventHandler<
     const { name, workers, maxAvailableTool, creatorOverrides } =
         event.arguments;
 
-    return await queryRequirements(
+    return await queryRequirements({
         name,
         workers,
-        maxAvailableTool ? ToolSchemaMap[maxAvailableTool] : undefined,
-        creatorOverrides ?? undefined
-    );
+        ...(maxAvailableTool
+            ? { maxAvailableTool: ToolSchemaMap[maxAvailableTool] }
+            : {}),
+        ...(creatorOverrides ? { creatorOverrides } : {}),
+    });
 };
 
 export { handler };

--- a/api/src/functions/query-requirements/handler.ts
+++ b/api/src/functions/query-requirements/handler.ts
@@ -7,12 +7,14 @@ const handler: GraphQLEventHandler<
     QueryRequirementArgs,
     Requirement[]
 > = async (event) => {
-    const { name, workers, maxAvailableTool } = event.arguments;
+    const { name, workers, maxAvailableTool, creatorOverrides } =
+        event.arguments;
 
     return await queryRequirements(
         name,
         workers,
-        maxAvailableTool ? ToolSchemaMap[maxAvailableTool] : undefined
+        maxAvailableTool ? ToolSchemaMap[maxAvailableTool] : undefined,
+        creatorOverrides ?? undefined
     );
 };
 

--- a/api/src/functions/query-requirements/interfaces/query-requirements-primary-port.ts
+++ b/api/src/functions/query-requirements/interfaces/query-requirements-primary-port.ts
@@ -1,14 +1,22 @@
 import { Tools } from "../../../types";
 
+type CreatorOverride = {
+    itemName: string;
+    creator: string;
+};
+
 type RequiredWorkers = {
     name: string;
     workers: number;
 };
 
 interface QueryRequirementsPrimaryPort {
-    (name: string, workers: number, maxAvailableTool?: Tools): Promise<
-        RequiredWorkers[]
-    >;
+    (
+        name: string,
+        workers: number,
+        maxAvailableTool?: Tools,
+        creatorOverrides?: CreatorOverride[]
+    ): Promise<RequiredWorkers[]>;
 }
 
 export type { RequiredWorkers, QueryRequirementsPrimaryPort };

--- a/api/src/functions/query-requirements/interfaces/query-requirements-primary-port.ts
+++ b/api/src/functions/query-requirements/interfaces/query-requirements-primary-port.ts
@@ -11,12 +11,12 @@ type RequiredWorkers = {
 };
 
 interface QueryRequirementsPrimaryPort {
-    (
-        name: string,
-        workers: number,
-        maxAvailableTool?: Tools,
-        creatorOverrides?: CreatorOverride[]
-    ): Promise<RequiredWorkers[]>;
+    (input: {
+        name: string;
+        workers: number;
+        maxAvailableTool?: Tools;
+        creatorOverrides?: CreatorOverride[];
+    }): Promise<RequiredWorkers[]>;
 }
 
 export type { RequiredWorkers, QueryRequirementsPrimaryPort };

--- a/api/src/functions/query-requirements/interfaces/query-requirements-primary-port.ts
+++ b/api/src/functions/query-requirements/interfaces/query-requirements-primary-port.ts
@@ -19,4 +19,4 @@ interface QueryRequirementsPrimaryPort {
     }): Promise<RequiredWorkers[]>;
 }
 
-export type { RequiredWorkers, QueryRequirementsPrimaryPort };
+export type { CreatorOverride, RequiredWorkers, QueryRequirementsPrimaryPort };

--- a/api/src/functions/query-requirements/package-lock.json
+++ b/api/src/functions/query-requirements/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "aws4": "1.12.0",
                 "glpk.js": "4.0.1",
+                "graph-data-structure": "3.3.0",
                 "mongodb": "5.2.0"
             }
         },
@@ -52,6 +53,11 @@
             "dependencies": {
                 "pako": "^2.0.4"
             }
+        },
+        "node_modules/graph-data-structure": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/graph-data-structure/-/graph-data-structure-3.3.0.tgz",
+            "integrity": "sha512-p5z0GZ3tm85kuB0iXFjLpbL9gNSFeDPPOyINhLQm6mVfHbLaj62LF9uB1tymcsxkHqLWLQSqGA0f/4/OepCdxA=="
         },
         "node_modules/ip": {
             "version": "2.0.0",
@@ -230,6 +236,11 @@
             "requires": {
                 "pako": "^2.0.4"
             }
+        },
+        "graph-data-structure": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/graph-data-structure/-/graph-data-structure-3.3.0.tgz",
+            "integrity": "sha512-p5z0GZ3tm85kuB0iXFjLpbL9gNSFeDPPOyINhLQm6mVfHbLaj62LF9uB1tymcsxkHqLWLQSqGA0f/4/OepCdxA=="
         },
         "ip": {
             "version": "2.0.0",

--- a/api/src/functions/query-requirements/package.json
+++ b/api/src/functions/query-requirements/package.json
@@ -6,6 +6,7 @@
         "@colony-survival-calculator/mongodb-client": "0.0.0",
         "aws4": "1.12.0",
         "glpk.js": "4.0.1",
+        "graph-data-structure": "3.3.0",
         "mongodb": "5.2.0"
     }
 }

--- a/api/src/graphql/schema.graphql
+++ b/api/src/graphql/schema.graphql
@@ -13,6 +13,11 @@ type Item {
     size: FarmSize
 }
 
+input CreatorOverride {
+    itemName: String!
+    creator: String!
+}
+
 type Requirement {
     name: ID!
     workers: Float!
@@ -50,6 +55,7 @@ type Query {
         name: ID!
         workers: Int!
         maxAvailableTool: Tools
+        creatorOverrides: [CreatorOverride!]
     ): [Requirement!]!
     output(
         name: ID!


### PR DESCRIPTION
# What

Updated requirement query to allow provision of any array of creator overrides
- If an applicable creator override is provided then that creator's recipe will be used regardless of whether the recipe is optimal
- Otherwise, if the override is not applicable - The optimal recipe will still be used

# Why

Enables specific creators to be factored into requirements calculation rather than just simply the optimal recipe