### PR TITLE
feat: add creator overrides selector

### DIFF
--- a/api/src/json/items.json
+++ b/api/src/json/items.json
@@ -150,6 +150,20 @@
         "creator": "Water gatherer"
     },
     {
+        "name": "Pot of Water",
+        "createTime": 16,
+        "output": 1,
+        "requires": [
+            {
+                "name": "Empty Pot",
+                "amount": 1
+            }
+        ],
+        "minimumTool": "none",
+        "maximumTool": "none",
+        "creator": "Water pump worker"
+    },
+    {
         "name": "Bread",
         "createTime": 20,
         "output": 1,

--- a/ui/src/common/components/Input/Input.tsx
+++ b/ui/src/common/components/Input/Input.tsx
@@ -16,6 +16,7 @@ type InputProps<Type> = Pick<HTMLAttributes<HTMLInputElement>, "inputMode"> & {
     parseValue: (value: unknown) => Type;
     errorMessage?: string;
     clearIconLabel?: string;
+    defaultValue?: string;
     palette?: ColorPalettes;
     className?: string;
 };
@@ -26,11 +27,12 @@ function Input<Type>({
     parseValue,
     errorMessage,
     clearIconLabel,
+    defaultValue,
     inputMode,
     palette = "secondary",
     className,
 }: InputProps<Type>) {
-    const [value, setValue] = useState<string>("");
+    const [value, setValue] = useState<string>(defaultValue ?? "");
     const [isInvalid, setIsInvalid] = useState<boolean>(false);
     const inputID = useId();
 

--- a/ui/src/common/components/Input/__tests__/Input.test.tsx
+++ b/ui/src/common/components/Input/__tests__/Input.test.tsx
@@ -306,3 +306,22 @@ test("provides undefined to change handler if input is cleared", async () => {
 
     expect(mockOnChangeHandler).toHaveBeenLastCalledWith(undefined);
 });
+
+test("sets the provided value as default if specified", async () => {
+    const expectedDefault = "123";
+
+    render(
+        <Input
+            label={expectedLabelText}
+            parseValue={parseValue}
+            onChange={mockOnChangeHandler}
+            defaultValue={expectedDefault}
+        />
+    );
+
+    expect(
+        await screen.findByLabelText(expectedLabelText, {
+            selector: "input",
+        })
+    ).toHaveValue(expectedDefault);
+});

--- a/ui/src/common/components/Selector/Selector.tsx
+++ b/ui/src/common/components/Selector/Selector.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useSelect, UseSelectProps, UseSelectStateChange } from "downshift";
 import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
 
@@ -44,11 +44,16 @@ function Selector<Item>({
         getToggleButtonProps,
         getMenuProps,
         getItemProps,
+        selectItem,
     } = useSelect({
         items,
         defaultSelectedItem,
         onSelectedItemChange: handleSelectedItemChange,
     });
+
+    useEffect(() => {
+        selectItem(defaultSelectedItem);
+    }, [defaultSelectedItem]);
 
     return (
         <Container palette={palette} className={className}>

--- a/ui/src/common/components/Selector/__tests__/Selector.test.tsx
+++ b/ui/src/common/components/Selector/__tests__/Selector.test.tsx
@@ -4,7 +4,10 @@ import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
 import Selector from "..";
-import { renderWithTestProviders as render } from "../../../../test/utils";
+import {
+    renderWithTestProviders as render,
+    wrapWithTestProviders,
+} from "../../../../test/utils";
 
 type Item = { name: string };
 
@@ -43,7 +46,7 @@ async function clickOption(option: string): Promise<void> {
 const items: Item[] = [createItem("test item 1"), createItem("test item 2")];
 const expectedLabelText = "Label text:";
 
-it("renders a select with the provided label text", async () => {
+test("renders a select with the provided label text", async () => {
     render(
         <Selector
             items={items}
@@ -59,7 +62,7 @@ it("renders a select with the provided label text", async () => {
     ).toBeVisible();
 });
 
-it("does not render any options by default", async () => {
+test("does not render any options by default", async () => {
     render(
         <Selector
             items={items}
@@ -78,7 +81,7 @@ it("does not render any options by default", async () => {
     }
 });
 
-it("shows the provided default value as the default shown item", async () => {
+test("shows the provided default value as the default shown item", async () => {
     const expectedDefaultItem = items[0];
 
     render(
@@ -96,7 +99,7 @@ it("shows the provided default value as the default shown item", async () => {
     ).toHaveTextContent(expectedDefaultItem.name);
 });
 
-it("show each item provided as an option in the select when clicked", async () => {
+test("show each item provided as an option in the select when clicked", async () => {
     render(
         <Selector
             items={items}
@@ -115,7 +118,7 @@ it("show each item provided as an option in the select when clicked", async () =
     }
 });
 
-it("shows the provided default item as selected in the option list by default", async () => {
+test("shows the provided default item as selected in the option list by default", async () => {
     const expectedDefaultItem = items[0];
 
     render(
@@ -137,7 +140,7 @@ it("shows the provided default item as selected in the option list by default", 
     ).toBeVisible();
 });
 
-it("updates the shown item when a different item is selected", async () => {
+test("updates the shown item when a different item is selected", async () => {
     const expectedShownItem = items[1];
 
     render(
@@ -157,7 +160,7 @@ it("updates the shown item when a different item is selected", async () => {
     ).toHaveTextContent(expectedShownItem.name);
 });
 
-it("updates the selected item in the option list after a different item is selected", async () => {
+test("updates the selected item in the option list after a different item is selected", async () => {
     const expectedSelectedItem = items[1];
     const expectedDeselectedItem = items[0];
 
@@ -205,6 +208,37 @@ test("calls the provided on change function when an item is selected", async () 
     await clickSelect(expectedLabelText);
     await clickOption(expectedItem.name);
     await screen.findByText(expectedItem.name);
+
+    expect(mockOnItemChange).toHaveBeenCalledTimes(1);
+    expect(mockOnItemChange).toHaveBeenCalledWith(expectedItem);
+});
+
+test("calls the provided on change function when the default item is changed", async () => {
+    const mockOnItemChange = vi.fn();
+    const expectedItem = items[1];
+    const { rerender } = render(
+        <Selector
+            items={items}
+            labelText={expectedLabelText}
+            defaultSelectedItem={items[0]}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+            onSelectedItemChange={mockOnItemChange}
+        />
+    );
+
+    rerender(
+        wrapWithTestProviders(
+            <Selector
+                items={items}
+                labelText={expectedLabelText}
+                defaultSelectedItem={expectedItem}
+                itemToKey={itemToKey}
+                itemToDisplayText={itemToDisplayText}
+                onSelectedItemChange={mockOnItemChange}
+            />
+        )
+    );
 
     expect(mockOnItemChange).toHaveBeenCalledTimes(1);
     expect(mockOnItemChange).toHaveBeenCalledWith(expectedItem);

--- a/ui/src/common/components/Selector/styles.tsx
+++ b/ui/src/common/components/Selector/styles.tsx
@@ -33,6 +33,7 @@ export const ToggleButton = styled.div<CommonProps>`
     align-items: center;
     padding: 0.5rem;
     border-radius: 0.25rem;
+    cursor: pointer;
 `;
 
 interface ToggleIndicatorIconProps extends FontAwesomeIconProps {
@@ -71,6 +72,7 @@ export const Menu = styled.div<MenuProps>`
     padding: 0.25rem 0rem;
     border-radius: 0.25rem;
     list-style-type: none;
+    cursor: pointer;
 `;
 
 export const Item = styled.li<CommonProps>`

--- a/ui/src/pages/Calculator/Calculator.tsx
+++ b/ui/src/pages/Calculator/Calculator.tsx
@@ -147,6 +147,7 @@ function CalculatorTab({
                             selectedItemName={selectedItem}
                             workers={workers}
                             maxAvailableTool={selectedTool}
+                            creatorOverrides={selectedCreatorOverrides}
                         />
                     ) : null}
                 </>

--- a/ui/src/pages/Calculator/Calculator.tsx
+++ b/ui/src/pages/Calculator/Calculator.tsx
@@ -9,6 +9,7 @@ import ErrorBoundary from "./components/ErrorBoundary";
 import { PageContainer, TabContainer, TabHeader, Tabs } from "./styles";
 import {
     CreatorOverride,
+    ItemsFilters,
     OutputUnit,
     Tools,
 } from "../../graphql/__generated__/graphql";
@@ -37,17 +38,32 @@ const GET_ITEM_DETAILS_QUERY = gql(`
 type StateProp<S> = [S, (value: S) => void];
 
 type CalculatorTabProps = {
-    selectedItem: StateProp<string | undefined>;
-    workers: StateProp<number | undefined>;
-    selectedTool: StateProp<Tools>;
-    selectedOutputUnit: StateProp<OutputUnit>;
+    itemState: StateProp<string | undefined>;
+    workersState: StateProp<number | undefined>;
+    toolState: StateProp<Tools>;
+    outputUnitState: StateProp<OutputUnit>;
+    selectedCreatorOverrides: CreatorOverride[];
 };
 
+function getItemDetailsFilters(
+    item?: string,
+    tool?: Tools,
+    overrides?: CreatorOverride[]
+): ItemsFilters {
+    const creator = overrides
+        ? overrides.find(({ itemName }) => item == itemName)?.creator
+        : undefined;
+    return creator
+        ? { name: item, creator }
+        : { name: item, optimal: { maxAvailableTool: tool } };
+}
+
 function CalculatorTab({
-    selectedItem: [selectedItem, setSelectedItem],
-    workers: [workers, setWorkers],
-    selectedTool: [selectedTool, setSelectedTool],
-    selectedOutputUnit: [selectedOutputUnit, setSelectedOutputUnit],
+    itemState: [selectedItem, setSelectedItem],
+    workersState: [workers, setWorkers],
+    toolState: [selectedTool, setSelectedTool],
+    outputUnitState: [selectedOutputUnit, setSelectedOutputUnit],
+    selectedCreatorOverrides,
 }: CalculatorTabProps) {
     const {
         loading: itemNamesLoading,
@@ -58,10 +74,11 @@ function CalculatorTab({
         GET_ITEM_DETAILS_QUERY,
         {
             variables: {
-                filters: {
-                    name: selectedItem,
-                    optimal: { maxAvailableTool: selectedTool },
-                },
+                filters: getItemDetailsFilters(
+                    selectedItem,
+                    selectedTool,
+                    selectedCreatorOverrides
+                ),
             },
             skip: !selectedItem,
         }
@@ -208,10 +225,11 @@ function Calculator() {
             <TabContainer role="tabpanel">
                 {selectedTab === PageTabs.CALCULATOR ? (
                     <CalculatorTab
-                        selectedItem={selectedItemState}
-                        workers={workersState}
-                        selectedTool={selectedToolState}
-                        selectedOutputUnit={selectedOutputUnitState}
+                        itemState={selectedItemState}
+                        workersState={workersState}
+                        toolState={selectedToolState}
+                        outputUnitState={selectedOutputUnitState}
+                        selectedCreatorOverrides={selectedCreatorOverrides[0]}
                     />
                 ) : null}
                 {selectedTab === PageTabs.SETTINGS ? (

--- a/ui/src/pages/Calculator/Calculator.tsx
+++ b/ui/src/pages/Calculator/Calculator.tsx
@@ -35,17 +35,15 @@ type CalculatorTabProps = {
     selectedItem: StateProp<string | undefined>;
     workers: StateProp<number | undefined>;
     selectedTool: StateProp<Tools>;
+    selectedOutputUnit: StateProp<OutputUnit>;
 };
 
 function CalculatorTab({
     selectedItem: [selectedItem, setSelectedItem],
     workers: [workers, setWorkers],
     selectedTool: [selectedTool, setSelectedTool],
+    selectedOutputUnit: [selectedOutputUnit, setSelectedOutputUnit],
 }: CalculatorTabProps) {
-    const [selectedOutputUnit, setSelectedOutputUnit] = useState<OutputUnit>(
-        OutputUnit.Minutes
-    );
-
     const {
         loading: itemNamesLoading,
         data: itemNameData,
@@ -99,7 +97,10 @@ function CalculatorTab({
                         onToolChange={setSelectedTool}
                         defaultTool={selectedTool}
                     />
-                    <OutputUnitSelector onUnitChange={setSelectedOutputUnit} />
+                    <OutputUnitSelector
+                        onUnitChange={setSelectedOutputUnit}
+                        defaultUnit={selectedOutputUnit}
+                    />
                 </>
             ) : null}
             <ErrorBoundary>
@@ -159,6 +160,7 @@ function Calculator() {
     const selectedItemState = useState<string>();
     const workersState = useState<number>();
     const selectedToolState = useState<Tools>(Tools.None);
+    const selectedOutputUnitState = useState<OutputUnit>(OutputUnit.Minutes);
 
     return (
         <PageContainer>
@@ -186,6 +188,7 @@ function Calculator() {
                         selectedItem={selectedItemState}
                         workers={workersState}
                         selectedTool={selectedToolState}
+                        selectedOutputUnit={selectedOutputUnitState}
                     />
                 ) : null}
                 {selectedTab === PageTabs.SETTINGS ? <SettingsTab /> : null}

--- a/ui/src/pages/Calculator/Calculator.tsx
+++ b/ui/src/pages/Calculator/Calculator.tsx
@@ -11,6 +11,7 @@ import { OutputUnit, Tools } from "../../graphql/__generated__/graphql";
 import OptimalOutput from "./components/OptimalOutput";
 import { gql } from "../../graphql/__generated__";
 import ToolSelector from "./components/ToolSelector";
+import CreatorOverrides from "./components/CreatorOverrides";
 
 const GET_ITEM_NAMES_QUERY = gql(`
     query GetItemNames {
@@ -144,7 +145,12 @@ function CalculatorTab({
 }
 
 function SettingsTab() {
-    return <TabHeader>Overrides:</TabHeader>;
+    return (
+        <>
+            <TabHeader>Overrides:</TabHeader>
+            <CreatorOverrides />
+        </>
+    );
 }
 
 enum PageTabs {

--- a/ui/src/pages/Calculator/Calculator.tsx
+++ b/ui/src/pages/Calculator/Calculator.tsx
@@ -29,18 +29,19 @@ const GET_ITEM_DETAILS_QUERY = gql(`
     }
 `);
 
-type StateProp<S> = ReturnType<typeof useState<S>>;
+type StateProp<S> = [S, (value: S) => void];
 
 type CalculatorTabProps = {
-    selectedItem: StateProp<string>;
-    workers: StateProp<number>;
+    selectedItem: StateProp<string | undefined>;
+    workers: StateProp<number | undefined>;
+    selectedTool: StateProp<Tools>;
 };
 
 function CalculatorTab({
     selectedItem: [selectedItem, setSelectedItem],
     workers: [workers, setWorkers],
+    selectedTool: [selectedTool, setSelectedTool],
 }: CalculatorTabProps) {
-    const [selectedTool, setSelectedTool] = useState<Tools>(Tools.None);
     const [selectedOutputUnit, setSelectedOutputUnit] = useState<OutputUnit>(
         OutputUnit.Minutes
     );
@@ -94,7 +95,10 @@ function CalculatorTab({
                         onWorkerChange={setWorkers}
                         defaultWorkers={workers}
                     />
-                    <ToolSelector onToolChange={setSelectedTool} />
+                    <ToolSelector
+                        onToolChange={setSelectedTool}
+                        defaultTool={selectedTool}
+                    />
                     <OutputUnitSelector onUnitChange={setSelectedOutputUnit} />
                 </>
             ) : null}
@@ -154,6 +158,7 @@ function Calculator() {
 
     const selectedItemState = useState<string>();
     const workersState = useState<number>();
+    const selectedToolState = useState<Tools>(Tools.None);
 
     return (
         <PageContainer>
@@ -180,6 +185,7 @@ function Calculator() {
                     <CalculatorTab
                         selectedItem={selectedItemState}
                         workers={workersState}
+                        selectedTool={selectedToolState}
                     />
                 ) : null}
                 {selectedTab === PageTabs.SETTINGS ? <SettingsTab /> : null}

--- a/ui/src/pages/Calculator/Calculator.tsx
+++ b/ui/src/pages/Calculator/Calculator.tsx
@@ -6,7 +6,7 @@ import WorkerInput from "./components/WorkerInput";
 import OutputUnitSelector from "./components/OutputUnitSelector";
 import Requirements from "./components/Requirements";
 import ErrorBoundary from "./components/ErrorBoundary";
-import { CalculatorContainer, CalculatorHeader } from "./styles";
+import { PageContainer, TabContainer, TabHeader, Tabs } from "./styles";
 import { OutputUnit, Tools } from "../../graphql/__generated__/graphql";
 import OptimalOutput from "./components/OptimalOutput";
 import { gql } from "../../graphql/__generated__";
@@ -29,7 +29,7 @@ const GET_ITEM_DETAILS_QUERY = gql(`
     }
 `);
 
-function Calculator() {
+function CalculatorTab() {
     const [workers, setWorkers] = useState<number>();
     const [selectedTool, setSelectedTool] = useState<Tools>(Tools.None);
     const [selectedOutputUnit, setSelectedOutputUnit] = useState<OutputUnit>(
@@ -57,9 +57,9 @@ function Calculator() {
 
     if (itemNamesLoading) {
         return (
-            <CalculatorContainer>
+            <PageContainer>
                 <span>Loading items...</span>
-            </CalculatorContainer>
+            </PageContainer>
         );
     }
 
@@ -70,8 +70,8 @@ function Calculator() {
     const networkError = itemNameError || itemDetailsError;
 
     return (
-        <CalculatorContainer>
-            <CalculatorHeader>Desired output:</CalculatorHeader>
+        <>
+            <TabHeader>Desired output:</TabHeader>
             {itemNameData?.distinctItemNames &&
             itemNameData.distinctItemNames.length > 0 ? (
                 <>
@@ -120,7 +120,49 @@ function Calculator() {
                     page and try again.
                 </span>
             ) : null}
-        </CalculatorContainer>
+        </>
+    );
+}
+
+function SettingsTab() {
+    return <TabHeader>Overrides:</TabHeader>;
+}
+
+enum PageTabs {
+    CALCULATOR = "calculator",
+    SETTINGS = "settings",
+}
+
+function Calculator() {
+    const [selectedTab, setSelectedTab] = useState<PageTabs>(
+        PageTabs.CALCULATOR
+    );
+
+    return (
+        <PageContainer>
+            <Tabs role="tablist">
+                <button
+                    role="tab"
+                    aria-selected={selectedTab === PageTabs.CALCULATOR}
+                    tabIndex={selectedTab === PageTabs.CALCULATOR ? 0 : -1}
+                    onClick={() => setSelectedTab(PageTabs.CALCULATOR)}
+                >
+                    Calculator
+                </button>
+                <button
+                    role="tab"
+                    aria-selected={selectedTab === PageTabs.SETTINGS}
+                    tabIndex={selectedTab === PageTabs.SETTINGS ? 0 : -1}
+                    onClick={() => setSelectedTab(PageTabs.SETTINGS)}
+                >
+                    Settings
+                </button>
+            </Tabs>
+            <TabContainer role="tabpanel">
+                {selectedTab === PageTabs.CALCULATOR ? <CalculatorTab /> : null}
+                {selectedTab === PageTabs.SETTINGS ? <SettingsTab /> : null}
+            </TabContainer>
+        </PageContainer>
     );
 }
 

--- a/ui/src/pages/Calculator/Calculator.tsx
+++ b/ui/src/pages/Calculator/Calculator.tsx
@@ -29,13 +29,17 @@ const GET_ITEM_DETAILS_QUERY = gql(`
     }
 `);
 
+type StateProp<S> = ReturnType<typeof useState<S>>;
+
 type CalculatorTabProps = {
-    selectedItem: string | undefined;
-    onItemChange: (item: string) => void;
+    selectedItem: StateProp<string>;
+    workers: StateProp<number>;
 };
 
-function CalculatorTab({ selectedItem, onItemChange }: CalculatorTabProps) {
-    const [workers, setWorkers] = useState<number>();
+function CalculatorTab({
+    selectedItem: [selectedItem, setSelectedItem],
+    workers: [workers, setWorkers],
+}: CalculatorTabProps) {
     const [selectedTool, setSelectedTool] = useState<Tools>(Tools.None);
     const [selectedOutputUnit, setSelectedOutputUnit] = useState<OutputUnit>(
         OutputUnit.Minutes
@@ -61,7 +65,7 @@ function CalculatorTab({ selectedItem, onItemChange }: CalculatorTabProps) {
 
     useEffect(() => {
         if (!selectedItem && itemNameData?.distinctItemNames[0]) {
-            onItemChange(itemNameData.distinctItemNames[0]);
+            setSelectedItem(itemNameData.distinctItemNames[0]);
         }
     }, [selectedItem, itemNameData]);
 
@@ -83,10 +87,13 @@ function CalculatorTab({ selectedItem, onItemChange }: CalculatorTabProps) {
                 <>
                     <ItemSelector
                         items={itemNameData.distinctItemNames}
-                        onItemChange={onItemChange}
+                        onItemChange={setSelectedItem}
                         defaultSelectedItem={selectedItem}
                     />
-                    <WorkerInput onWorkerChange={setWorkers} />
+                    <WorkerInput
+                        onWorkerChange={setWorkers}
+                        defaultWorkers={workers}
+                    />
                     <ToolSelector onToolChange={setSelectedTool} />
                     <OutputUnitSelector onUnitChange={setSelectedOutputUnit} />
                 </>
@@ -145,7 +152,8 @@ function Calculator() {
         PageTabs.CALCULATOR
     );
 
-    const [selectedItem, setSelectedItem] = useState<string>();
+    const selectedItemState = useState<string>();
+    const workersState = useState<number>();
 
     return (
         <PageContainer>
@@ -170,8 +178,8 @@ function Calculator() {
             <TabContainer role="tabpanel">
                 {selectedTab === PageTabs.CALCULATOR ? (
                     <CalculatorTab
-                        selectedItem={selectedItem}
-                        onItemChange={setSelectedItem}
+                        selectedItem={selectedItemState}
+                        workers={workersState}
                     />
                 ) : null}
                 {selectedTab === PageTabs.SETTINGS ? <SettingsTab /> : null}

--- a/ui/src/pages/Calculator/Calculator.tsx
+++ b/ui/src/pages/Calculator/Calculator.tsx
@@ -7,7 +7,11 @@ import OutputUnitSelector from "./components/OutputUnitSelector";
 import Requirements from "./components/Requirements";
 import ErrorBoundary from "./components/ErrorBoundary";
 import { PageContainer, TabContainer, TabHeader, Tabs } from "./styles";
-import { OutputUnit, Tools } from "../../graphql/__generated__/graphql";
+import {
+    CreatorOverride,
+    OutputUnit,
+    Tools,
+} from "../../graphql/__generated__/graphql";
 import OptimalOutput from "./components/OptimalOutput";
 import { gql } from "../../graphql/__generated__";
 import ToolSelector from "./components/ToolSelector";
@@ -144,11 +148,23 @@ function CalculatorTab({
     );
 }
 
-function SettingsTab() {
+type SettingsTabProps = {
+    selectedCreatorOverrides: StateProp<CreatorOverride[]>;
+};
+
+function SettingsTab({
+    selectedCreatorOverrides: [
+        selectedCreatorOverrides,
+        setSelectedCreatorOverrides,
+    ],
+}: SettingsTabProps) {
     return (
         <>
             <TabHeader>Overrides:</TabHeader>
-            <CreatorOverrides />
+            <CreatorOverrides
+                defaultOverrides={selectedCreatorOverrides}
+                onOverridesUpdate={setSelectedCreatorOverrides}
+            />
         </>
     );
 }
@@ -167,6 +183,7 @@ function Calculator() {
     const workersState = useState<number>();
     const selectedToolState = useState<Tools>(Tools.None);
     const selectedOutputUnitState = useState<OutputUnit>(OutputUnit.Minutes);
+    const selectedCreatorOverrides = useState<CreatorOverride[]>([]);
 
     return (
         <PageContainer>
@@ -197,7 +214,11 @@ function Calculator() {
                         selectedOutputUnit={selectedOutputUnitState}
                     />
                 ) : null}
-                {selectedTab === PageTabs.SETTINGS ? <SettingsTab /> : null}
+                {selectedTab === PageTabs.SETTINGS ? (
+                    <SettingsTab
+                        selectedCreatorOverrides={selectedCreatorOverrides}
+                    />
+                ) : null}
             </TabContainer>
         </PageContainer>
     );

--- a/ui/src/pages/Calculator/__tests__/Calculator-creator-overrides.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-creator-overrides.test.tsx
@@ -17,6 +17,7 @@ import {
     expectedCreatorOverrideQueryName,
     expectedAddCreatorOverrideButtonText,
     openSelectMenu,
+    expectedRemoveCreatorOverrideButtonText,
 } from "./utils";
 import { expectedItemDetailsQueryName } from "./utils";
 import { CreatorOverride } from "../../../graphql/__generated__/graphql";
@@ -374,6 +375,70 @@ describe("given items w/ multiple creators returned", () => {
                     selected: true,
                 })
             ).toBeVisible();
+        });
+
+        test("removes the add creator override button once override is added", async () => {
+            await renderSettingsTab();
+            await clickByName(expectedAddCreatorOverrideButtonText, "button");
+            await screen.findByRole("combobox", {
+                name: expectedCreatorSelectOverrideLabel,
+            });
+
+            expect(
+                screen.queryByRole("button", {
+                    name: expectedAddCreatorOverrideButtonText,
+                })
+            ).not.toBeInTheDocument();
+        });
+
+        test("displays a remove creator override button once an override is added", async () => {
+            await renderSettingsTab();
+            await clickByName(expectedAddCreatorOverrideButtonText, "button");
+
+            expect(
+                await screen.findByRole("button", {
+                    name: expectedRemoveCreatorOverrideButtonText,
+                })
+            ).toBeVisible();
+        });
+
+        test("re-displays the add creator override if the added override is removed", async () => {
+            await renderSettingsTab();
+            await clickByName(expectedAddCreatorOverrideButtonText, "button");
+            await screen.findByRole("combobox", {
+                name: expectedCreatorSelectOverrideLabel,
+            });
+            await clickByName(
+                expectedRemoveCreatorOverrideButtonText,
+                "button"
+            );
+
+            expect(
+                await screen.findByRole("button", {
+                    name: expectedAddCreatorOverrideButtonText,
+                })
+            ).toBeVisible();
+        });
+
+        test("removes the creator override if the remove button is pressed", async () => {
+            await renderSettingsTab();
+            await clickByName(expectedAddCreatorOverrideButtonText, "button");
+            await screen.findByRole("combobox", {
+                name: expectedCreatorSelectOverrideLabel,
+            });
+            await clickByName(
+                expectedRemoveCreatorOverrideButtonText,
+                "button"
+            );
+            await screen.findByRole("button", {
+                name: expectedAddCreatorOverrideButtonText,
+            });
+
+            expect(
+                screen.queryByRole("combobox", {
+                    name: expectedCreatorSelectOverrideLabel,
+                })
+            ).not.toBeInTheDocument();
         });
     });
 });

--- a/ui/src/pages/Calculator/__tests__/Calculator-creator-overrides.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-creator-overrides.test.tsx
@@ -19,6 +19,8 @@ import {
     openSelectMenu,
     expectedRemoveCreatorOverrideButtonText,
     selectOption,
+    expectedCalculatorTab,
+    expectedCalculatorTabHeader,
 } from "./utils";
 import { expectedItemDetailsQueryName } from "./utils";
 import { CreatorOverride } from "../../../graphql/__generated__/graphql";
@@ -704,6 +706,110 @@ describe("given items w/ multiple creators returned", () => {
                     })
                 ).not.toBeInTheDocument();
             });
+        });
+
+        test("does not reset the currently selected item overrides if tab changes", async () => {
+            await renderSettingsTab();
+            await clickByName(expectedAddCreatorOverrideButtonText, "button");
+            await clickByName(expectedAddCreatorOverrideButtonText, "button");
+            await clickByName(expectedCalculatorTab, "tab");
+            await screen.findByRole("heading", {
+                name: expectedCalculatorTabHeader,
+                level: 2,
+            });
+            await clickByName(expectedSettingsTab, "tab");
+            await screen.findByRole("heading", {
+                name: expectedSettingsTabHeader,
+                level: 2,
+            });
+
+            const itemOverrideSelects = await screen.findAllByRole("combobox", {
+                name: expectedItemSelectOverrideLabel,
+            });
+            expect(itemOverrideSelects[0]).toHaveTextContent(
+                expectedFirstItemName
+            );
+            expect(itemOverrideSelects[1]).toHaveTextContent(
+                expectedSecondItemName
+            );
+        });
+
+        test("does not reset the currently selected creator overrides if tab changes", async () => {
+            await renderSettingsTab();
+            await clickByName(expectedAddCreatorOverrideButtonText, "button");
+            await clickByName(expectedAddCreatorOverrideButtonText, "button");
+            await clickByName(expectedCalculatorTab, "tab");
+            await screen.findByRole("heading", {
+                name: expectedCalculatorTabHeader,
+                level: 2,
+            });
+            await clickByName(expectedSettingsTab, "tab");
+            await screen.findByRole("heading", {
+                name: expectedSettingsTabHeader,
+                level: 2,
+            });
+
+            const creatorOverrideSelects = screen.getAllByRole("combobox", {
+                name: expectedCreatorSelectOverrideLabel,
+            });
+            expect(creatorOverrideSelects[0]).toHaveTextContent(
+                expectedFirstItemOverrides[0].creator
+            );
+            expect(creatorOverrideSelects[1]).toHaveTextContent(
+                expectedSecondItemOverrides[0].creator
+            );
+        });
+
+        test("does not reset the currently selected item override if non-default item selected", async () => {
+            await renderSettingsTab();
+            await clickByName(expectedAddCreatorOverrideButtonText, "button");
+            await selectOption({
+                selectLabel: expectedItemSelectOverrideLabel,
+                optionName: expectedSecondItemName,
+            });
+            await clickByName(expectedCalculatorTab, "tab");
+            await screen.findByRole("heading", {
+                name: expectedCalculatorTabHeader,
+                level: 2,
+            });
+            await clickByName(expectedSettingsTab, "tab");
+            await screen.findByRole("heading", {
+                name: expectedSettingsTabHeader,
+                level: 2,
+            });
+
+            expect(
+                screen.getByRole("combobox", {
+                    name: expectedItemSelectOverrideLabel,
+                })
+            ).toHaveTextContent(expectedSecondItemName);
+        });
+
+        test("does not reset the currently selected creator override if non-default creator selected", async () => {
+            const expected = expectedFirstItemOverrides[1].creator;
+
+            await renderSettingsTab();
+            await clickByName(expectedAddCreatorOverrideButtonText, "button");
+            await selectOption({
+                selectLabel: expectedCreatorSelectOverrideLabel,
+                optionName: expected,
+            });
+            await clickByName(expectedCalculatorTab, "tab");
+            await screen.findByRole("heading", {
+                name: expectedCalculatorTabHeader,
+                level: 2,
+            });
+            await clickByName(expectedSettingsTab, "tab");
+            await screen.findByRole("heading", {
+                name: expectedSettingsTabHeader,
+                level: 2,
+            });
+
+            expect(
+                screen.getByRole("combobox", {
+                    name: expectedCreatorSelectOverrideLabel,
+                })
+            ).toHaveTextContent(expected);
         });
     });
 });

--- a/ui/src/pages/Calculator/__tests__/Calculator-creator-overrides.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-creator-overrides.test.tsx
@@ -1,0 +1,187 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { graphql } from "msw";
+import { setupServer } from "msw/node";
+
+import { waitForRequest } from "../../../helpers/utils";
+import Calculator from "../Calculator";
+import { renderWithTestProviders as render } from "../../../test/utils";
+import {
+    expectedRequirementsQueryName,
+    expectedOutputQueryName,
+    expectedItemNameQueryName,
+    ItemName,
+    openTab,
+    expectedSettingsTab,
+    expectedSettingsTabHeader,
+    expectedCreatorOverrideQueryName,
+} from "./utils";
+import { expectedItemDetailsQueryName } from "./utils";
+import { CreatorOverride } from "../../../graphql/__generated__/graphql";
+
+const expectedGraphQLAPIURL = "http://localhost:3000/graphql";
+const expectedLoadingMessage = "Loading overrides...";
+const expectedNoOverridesMessage = "No overrides available";
+
+const items: ItemName[] = [
+    { name: "Item 1" },
+    { name: "Item 2" },
+    { name: "Item 3" },
+];
+const expectedCreatorOverrides: CreatorOverride[] = [
+    { itemName: items[0].name, creator: "Creator 1" },
+    { itemName: items[0].name, creator: "Creator 2" },
+    { itemName: items[2].name, creator: "Creator 3" },
+    { itemName: items[2].name, creator: "Creator 4" },
+    { itemName: items[2].name, creator: "Creator 5" },
+];
+
+const server = setupServer(
+    graphql.query(expectedItemNameQueryName, (_, res, ctx) => {
+        return res(
+            ctx.data({ distinctItemNames: items.map((item) => item.name) })
+        );
+    }),
+    graphql.query(expectedItemDetailsQueryName, (_, res, ctx) => {
+        return res(ctx.data({ item: [] }));
+    }),
+    graphql.query(expectedRequirementsQueryName, (_, res, ctx) => {
+        return res(ctx.data({ requirement: [] }));
+    }),
+    graphql.query(expectedOutputQueryName, (_, res, ctx) => {
+        return res(ctx.data({ output: 5.2 }));
+    }),
+    graphql.query(expectedCreatorOverrideQueryName, (_, res, ctx) => {
+        return res(
+            ctx.data({
+                item: [
+                    expectedCreatorOverrides.map(({ itemName, creator }) => ({
+                        name: itemName,
+                        creator,
+                    })),
+                ],
+            })
+        );
+    })
+);
+
+beforeAll(() => {
+    server.listen();
+});
+
+beforeEach(() => {
+    server.resetHandlers();
+    server.events.removeAllListeners();
+    server.use(
+        graphql.query(expectedCreatorOverrideQueryName, (_, res, ctx) => {
+            return res(
+                ctx.data({
+                    item: [
+                        expectedCreatorOverrides.map(
+                            ({ itemName, creator }) => ({
+                                name: itemName,
+                                creator,
+                            })
+                        ),
+                    ],
+                })
+            );
+        })
+    );
+});
+
+async function renderSettingsTab(apiURL = expectedGraphQLAPIURL) {
+    render(<Calculator />, apiURL);
+    await openTab(expectedSettingsTab);
+    await screen.findByRole("heading", {
+        name: expectedSettingsTabHeader,
+        level: 2,
+    });
+}
+
+test("queries all known item names", async () => {
+    const expectedRequest = waitForRequest(
+        server,
+        "POST",
+        expectedGraphQLAPIURL,
+        expectedCreatorOverrideQueryName
+    );
+
+    await renderSettingsTab();
+
+    await expect(expectedRequest).resolves.not.toThrow();
+});
+
+test("displays optimal default calculation explanation", async () => {
+    const expectedExplanationText =
+        "By default, the calculator will use the recipe with the highest output per second unless an override is applied.";
+
+    await renderSettingsTab();
+
+    expect(screen.getByText(expectedExplanationText)).toBeVisible();
+});
+
+describe("handles creator override list loading", () => {
+    beforeEach(() => {
+        server.use(
+            graphql.query(expectedCreatorOverrideQueryName, (_, res, ctx) => {
+                return res(ctx.delay("infinite"));
+            })
+        );
+    });
+
+    test("renders a loading message", async () => {
+        await renderSettingsTab();
+
+        expect(await screen.findByText(expectedLoadingMessage)).toBeVisible();
+    });
+
+    test("does not render any error messages", async () => {
+        await renderSettingsTab();
+
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+});
+
+describe("given no creator overrides returned", () => {
+    beforeEach(() => {
+        server.use(
+            graphql.query(expectedCreatorOverrideQueryName, (_, res, ctx) => {
+                return res(
+                    ctx.data({
+                        item: [],
+                    })
+                );
+            })
+        );
+    });
+
+    test("renders a missing overrides error", async () => {
+        await renderSettingsTab();
+
+        expect(await screen.findByRole("alert")).toHaveTextContent(
+            expectedNoOverridesMessage
+        );
+    });
+
+    test("does not render a loading message once data loaded", async () => {
+        await renderSettingsTab();
+        await screen.findByRole("alert");
+
+        expect(
+            screen.queryByText(expectedLoadingMessage)
+        ).not.toBeInTheDocument();
+    });
+});
+
+describe("given creator overrides returned", async () => {
+    test("does not render any errors", async () => {
+        await renderSettingsTab();
+
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+});
+
+afterAll(() => {
+    server.close();
+});

--- a/ui/src/pages/Calculator/__tests__/Calculator-creator-overrides.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-creator-overrides.test.tsx
@@ -22,6 +22,7 @@ import { CreatorOverride } from "../../../graphql/__generated__/graphql";
 const expectedGraphQLAPIURL = "http://localhost:3000/graphql";
 const expectedLoadingMessage = "Loading overrides...";
 const expectedNoOverridesMessage = "No overrides available";
+const expectedAddButtonText = "Add creator override";
 
 const items: ItemName[] = [
     { name: "Item 1" },
@@ -141,6 +142,14 @@ describe("handles creator override list loading", () => {
 
         expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     });
+
+    test("does not render an add creator override button", async () => {
+        await renderSettingsTab();
+
+        expect(
+            screen.queryByRole("button", { name: expectedAddButtonText })
+        ).not.toBeInTheDocument();
+    });
 });
 
 describe("given no creator overrides returned", () => {
@@ -172,6 +181,15 @@ describe("given no creator overrides returned", () => {
             screen.queryByText(expectedLoadingMessage)
         ).not.toBeInTheDocument();
     });
+
+    test("does not render an add creator override button", async () => {
+        await renderSettingsTab();
+        await screen.findByRole("alert");
+
+        expect(
+            screen.queryByRole("button", { name: expectedAddButtonText })
+        ).not.toBeInTheDocument();
+    });
 });
 
 describe("given creator overrides returned", async () => {
@@ -179,6 +197,14 @@ describe("given creator overrides returned", async () => {
         await renderSettingsTab();
 
         expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    test("renders an add creator override button", async () => {
+        await renderSettingsTab();
+
+        expect(
+            await screen.findByRole("button", { name: expectedAddButtonText })
+        ).toBeVisible();
     });
 });
 

--- a/ui/src/pages/Calculator/__tests__/Calculator-creator-overrides.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-creator-overrides.test.tsx
@@ -843,6 +843,93 @@ describe("given items w/ multiple creators returned", () => {
 
             await expect(expectedRequest).resolves.not.toThrow();
         });
+
+        test("provides all creator overrides when querying requirements", async () => {
+            const user = userEvent.setup();
+            const expectedItem = expectedSecondItemName;
+            const expectedWorkers = 5;
+            const expectedOverrides: CreatorOverride[] = [
+                {
+                    itemName: expectedFirstItemName,
+                    creator: expectedFirstItemOverrides[1].creator,
+                },
+                {
+                    itemName: expectedSecondItemName,
+                    creator: expectedSecondItemOverrides[1].creator,
+                },
+            ];
+            const expectedTool = Tools.None;
+            const expectedRequest = waitForRequest(
+                server,
+                "POST",
+                expectedGraphQLAPIURL,
+                expectedRequirementsQueryName,
+                {
+                    name: expectedItem,
+                    workers: expectedWorkers,
+                    maxAvailableTool: expectedTool,
+                    creatorOverrides: expectedOverrides,
+                }
+            );
+
+            await renderSettingsTab();
+            await clickByName(expectedAddCreatorOverrideButtonText, "button");
+            await clickByName(expectedAddCreatorOverrideButtonText, "button");
+            const creatorOverrideSelects = await screen.findAllByRole(
+                "combobox",
+                { name: expectedCreatorSelectOverrideLabel }
+            );
+            await act(() => user.click(creatorOverrideSelects[0]));
+            const firstItemCreatorOption = await screen.findByRole("option", {
+                name: expectedFirstItemOverrides[1].creator,
+            });
+            await act(() => user.click(firstItemCreatorOption));
+            await act(() => user.click(creatorOverrideSelects[1]));
+            const secondItemCreatorOption = await screen.findByRole("option", {
+                name: expectedSecondItemOverrides[1].creator,
+            });
+            await act(() => user.click(secondItemCreatorOption));
+            await clickByName(expectedCalculatorTab, "tab");
+            await selectItemAndWorkers({
+                itemName: expectedItem,
+                workers: expectedWorkers,
+            });
+
+            await expect(expectedRequest).resolves.not.toThrow();
+        });
+
+        test("returns to querying requirements without creator overrides if removed", async () => {
+            const expectedItem = expectedSecondItemName;
+            const expectedWorkers = 5;
+            const expectedTool = Tools.None;
+            const expectedRequest = waitForRequest(
+                server,
+                "POST",
+                expectedGraphQLAPIURL,
+                expectedRequirementsQueryName,
+                {
+                    name: expectedItem,
+                    workers: expectedWorkers,
+                    maxAvailableTool: expectedTool,
+                }
+            );
+
+            await renderSettingsTab();
+            await clickByName(expectedAddCreatorOverrideButtonText, "button");
+            await clickByName(expectedCalculatorTab, "tab");
+            await selectItemAndWorkers({
+                itemName: expectedItem,
+                workers: expectedWorkers,
+            });
+            await clickByName(expectedSettingsTab, "tab");
+            await clickByName(
+                expectedRemoveCreatorOverrideButtonText,
+                "button"
+            );
+            await clickByName(expectedCalculatorTab, "tab");
+
+            await expect(expectedRequest).resolves.not.toThrow();
+        });
     });
 });
 

--- a/ui/src/pages/Calculator/__tests__/Calculator-item-selection.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-item-selection.test.tsx
@@ -14,7 +14,7 @@ import {
     expectedItemSelectLabel,
     expectedWorkerInputLabel,
     ItemName,
-    expectedDesiredOutputHeader,
+    expectedCalculatorTabHeader,
     expectedToolSelectLabel,
     openSelectMenu,
     selectOption,
@@ -80,7 +80,7 @@ test("renders desired output header", async () => {
 
     expect(
         await screen.findByRole("heading", {
-            name: expectedDesiredOutputHeader,
+            name: expectedCalculatorTabHeader,
         })
     ).toBeVisible();
 });
@@ -108,7 +108,7 @@ describe("handles item loading", () => {
 
         expect(
             screen.queryByRole("heading", {
-                name: expectedDesiredOutputHeader,
+                name: expectedCalculatorTabHeader,
             })
         ).not.toBeInTheDocument();
     });

--- a/ui/src/pages/Calculator/__tests__/Calculator-item-selection.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-item-selection.test.tsx
@@ -18,10 +18,11 @@ import {
     expectedToolSelectLabel,
     openSelectMenu,
     selectOption,
-    openTab,
+    clickByName,
     expectedSettingsTab,
     expectedSettingsTabHeader,
     expectedCalculatorTab,
+    expectedCreatorOverrideQueryName,
 } from "./utils";
 import { expectedItemDetailsQueryName } from "./utils";
 
@@ -46,6 +47,13 @@ const server = setupServer(
     }),
     graphql.query(expectedOutputQueryName, (_, res, ctx) => {
         return res(ctx.data({ output: 5.2 }));
+    }),
+    graphql.query(expectedCreatorOverrideQueryName, (_, res, ctx) => {
+        return res(
+            ctx.data({
+                item: [],
+            })
+        );
     })
 );
 
@@ -333,12 +341,12 @@ test("does not reset the currently selected item after changing tabs", async () 
         selectLabel: expectedItemSelectLabel,
         optionName: expected,
     });
-    await openTab(expectedSettingsTab);
+    await clickByName(expectedSettingsTab, "tab");
     await screen.findByRole("heading", {
         name: expectedSettingsTabHeader,
         level: 2,
     });
-    await openTab(expectedCalculatorTab);
+    await clickByName(expectedCalculatorTab, "tab");
 
     expect(
         await screen.findByRole("combobox", { name: expectedItemSelectLabel })

--- a/ui/src/pages/Calculator/__tests__/Calculator-item-selection.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-item-selection.test.tsx
@@ -18,6 +18,10 @@ import {
     expectedToolSelectLabel,
     openSelectMenu,
     selectOption,
+    openTab,
+    expectedSettingsTab,
+    expectedSettingsTabHeader,
+    expectedCalculatorTab,
 } from "./utils";
 import { expectedItemDetailsQueryName } from "./utils";
 
@@ -237,12 +241,17 @@ test("renders each item name returned as an option in the combo box", async () =
 });
 
 test("renders the first option in the item name list as selected by default", async () => {
+    const expected = items[0].name;
+
     render(<Calculator />);
     await openSelectMenu({ selectLabel: expectedItemSelectLabel });
 
     expect(
-        await screen.findByRole("option", {
-            name: items[0].name,
+        await screen.findByRole("combobox", { name: expectedItemSelectLabel })
+    ).toHaveTextContent(expected);
+    expect(
+        screen.getByRole("option", {
+            name: expected,
             selected: true,
         })
     ).toBeVisible();
@@ -263,6 +272,27 @@ test("requests item details on the first option in the item name list without se
     expect(matchedRequestDetails.variables).toEqual({
         filters: { name: items[0].name, optimal: { maxAvailableTool: "NONE" } },
     });
+});
+
+test("updates the selected option if selected is changed", async () => {
+    const expected = items[1].name;
+
+    render(<Calculator />);
+    await selectOption({
+        selectLabel: expectedItemSelectLabel,
+        optionName: expected,
+    });
+    await openSelectMenu({ selectLabel: expectedItemSelectLabel });
+
+    expect(
+        await screen.findByRole("combobox", { name: expectedItemSelectLabel })
+    ).toHaveTextContent(expected);
+    expect(
+        screen.getByRole("option", {
+            name: expected,
+            selected: true,
+        })
+    ).toBeVisible();
 });
 
 test("requests item details for newly selected item if selection is changed", async () => {
@@ -293,6 +323,26 @@ test("requests item details for newly selected item if selection is changed", as
             optimal: { maxAvailableTool: "NONE" },
         },
     });
+});
+
+test("does not reset the currently selected item after changing tabs", async () => {
+    const expected = items[1].name;
+
+    render(<Calculator />);
+    await selectOption({
+        selectLabel: expectedItemSelectLabel,
+        optionName: expected,
+    });
+    await openTab(expectedSettingsTab);
+    await screen.findByRole("heading", {
+        name: expectedSettingsTabHeader,
+        level: 2,
+    });
+    await openTab(expectedCalculatorTab);
+
+    expect(
+        await screen.findByRole("combobox", { name: expectedItemSelectLabel })
+    ).toHaveTextContent(expected);
 });
 
 describe("item name request error handling", () => {

--- a/ui/src/pages/Calculator/__tests__/Calculator-item-selection.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-item-selection.test.tsx
@@ -100,7 +100,7 @@ describe("handles item loading", () => {
         );
     });
 
-    test("renders a loading message...", async () => {
+    test("renders a loading message", async () => {
         render(<Calculator />);
 
         expect(await screen.findByText(expectedMessage)).toBeVisible();

--- a/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
@@ -21,9 +21,10 @@ import {
     expectedSettingsTab,
     expectedSettingsTabHeader,
     openSelectMenu,
-    openTab,
+    clickByName,
     selectItemAndWorkers,
     selectOutputUnit,
+    expectedCreatorOverrideQueryName,
 } from "./utils";
 import { OutputUnit } from "../../../graphql/__generated__/graphql";
 
@@ -45,6 +46,13 @@ const server = setupServer(
     }),
     graphql.query(expectedOutputQueryName, (_, res, ctx) => {
         return res(ctx.data({ output: 5.2 }));
+    }),
+    graphql.query(expectedCreatorOverrideQueryName, (_, res, ctx) => {
+        return res(
+            ctx.data({
+                item: [],
+            })
+        );
     })
 );
 
@@ -111,12 +119,12 @@ test("does not reset the currently selected output unit after changing tabs", as
 
     render(<Calculator />);
     await selectOutputUnit(OutputUnit.GameDays);
-    await openTab(expectedSettingsTab);
+    await clickByName(expectedSettingsTab, "tab");
     await screen.findByRole("heading", {
         name: expectedSettingsTabHeader,
         level: 2,
     });
-    await openTab(expectedCalculatorTab);
+    await clickByName(expectedCalculatorTab, "tab");
 
     expect(
         await screen.findByRole("combobox", { name: expectedOutputUnitLabel })

--- a/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
@@ -11,13 +11,17 @@ import {
 import { waitForRequest } from "../../../helpers/utils";
 import {
     ItemName,
+    expectedCalculatorTab,
     expectedItemDetailsQueryName,
     expectedItemNameQueryName,
     expectedOutputPrefix,
     expectedOutputQueryName,
     expectedOutputUnitLabel,
     expectedRequirementsQueryName,
+    expectedSettingsTab,
+    expectedSettingsTabHeader,
     openSelectMenu,
+    openTab,
     selectItemAndWorkers,
     selectOutputUnit,
 } from "./utils";
@@ -68,15 +72,55 @@ test.each(["Minutes", "Game days"])(
 );
 
 test("selects the Minutes option by default", async () => {
+    const expected = "Minutes";
+
     render(<Calculator />, expectedGraphQLAPIURL);
     await openSelectMenu({ selectLabel: expectedOutputUnitLabel });
 
     expect(
-        await screen.findByRole("option", {
-            name: "Minutes",
+        await screen.findByRole("combobox", { name: expectedOutputUnitLabel })
+    ).toHaveTextContent(expected);
+    expect(
+        screen.getByRole("option", {
+            name: expected,
             selected: true,
         })
-    ).toBeInTheDocument();
+    ).toBeVisible();
+});
+
+test("updates the selected output unit if selected is changed", async () => {
+    const expected = "Game days";
+
+    render(<Calculator />);
+    await selectOutputUnit(OutputUnit.GameDays);
+    await openSelectMenu({ selectLabel: expectedOutputUnitLabel });
+
+    expect(
+        await screen.findByRole("combobox", { name: expectedOutputUnitLabel })
+    ).toHaveTextContent(expected);
+    expect(
+        screen.getByRole("option", {
+            name: expected,
+            selected: true,
+        })
+    ).toBeVisible();
+});
+
+test("does not reset the currently selected output unit after changing tabs", async () => {
+    const expected = "Game days";
+
+    render(<Calculator />);
+    await selectOutputUnit(OutputUnit.GameDays);
+    await openTab(expectedSettingsTab);
+    await screen.findByRole("heading", {
+        name: expectedSettingsTabHeader,
+        level: 2,
+    });
+    await openTab(expectedCalculatorTab);
+
+    expect(
+        await screen.findByRole("combobox", { name: expectedOutputUnitLabel })
+    ).toHaveTextContent(expected);
 });
 
 test("queries optimal output if item and workers inputted with default unit selected", async () => {

--- a/ui/src/pages/Calculator/__tests__/Calculator-requirements.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-requirements.test.tsx
@@ -25,6 +25,7 @@ import {
     ItemName,
     expectedItemNameQueryName,
     expectedItemDetailsQueryName,
+    expectedCreatorOverrideQueryName,
 } from "./utils";
 import Requirements from "../components/Requirements";
 
@@ -70,6 +71,13 @@ const server = setupServer(
     }),
     graphql.query(expectedOutputQueryName, (_, res, ctx) => {
         return res(ctx.data({ output: expectedOutput }));
+    }),
+    graphql.query(expectedCreatorOverrideQueryName, (_, res, ctx) => {
+        return res(
+            ctx.data({
+                item: [],
+            })
+        );
     })
 );
 

--- a/ui/src/pages/Calculator/__tests__/Calculator-tool-selection.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-tool-selection.test.tsx
@@ -14,9 +14,10 @@ import {
     expectedSettingsTabHeader,
     expectedToolSelectLabel,
     openSelectMenu,
-    openTab,
+    clickByName,
     selectItemAndWorkers,
     selectTool,
+    expectedCreatorOverrideQueryName,
 } from "./utils";
 import { renderWithTestProviders as render } from "../../../test/utils";
 import Calculator from "../Calculator";
@@ -38,6 +39,13 @@ const server = setupServer(
     }),
     graphql.query(expectedOutputQueryName, (_, res, ctx) => {
         return res(ctx.data({ output: 5.2 }));
+    }),
+    graphql.query(expectedCreatorOverrideQueryName, (_, res, ctx) => {
+        return res(
+            ctx.data({
+                item: [],
+            })
+        );
     })
 );
 
@@ -262,12 +270,12 @@ test("does not reset the currently selected tool after changing tabs", async () 
 
     render(<Calculator />);
     await selectTool(Tools.Iron);
-    await openTab(expectedSettingsTab);
+    await clickByName(expectedSettingsTab, "tab");
     await screen.findByRole("heading", {
         name: expectedSettingsTabHeader,
         level: 2,
     });
-    await openTab(expectedCalculatorTab);
+    await clickByName(expectedCalculatorTab, "tab");
 
     expect(
         await screen.findByRole("combobox", { name: expectedToolSelectLabel })

--- a/ui/src/pages/Calculator/__tests__/Calculator-tool-selection.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-tool-selection.test.tsx
@@ -5,12 +5,16 @@ import { screen } from "@testing-library/react";
 
 import {
     ItemName,
+    expectedCalculatorTab,
     expectedItemDetailsQueryName,
     expectedItemNameQueryName,
     expectedOutputQueryName,
     expectedRequirementsQueryName,
+    expectedSettingsTab,
+    expectedSettingsTabHeader,
     expectedToolSelectLabel,
     openSelectMenu,
+    openTab,
     selectItemAndWorkers,
     selectTool,
 } from "./utils";
@@ -65,11 +69,34 @@ test.each(["None", "Stone", "Copper", "Iron", "Bronze", "Steel"])(
 );
 
 test("renders none as the selected tool by default", async () => {
+    const expected = "None";
+
     render(<Calculator />);
     await openSelectMenu({ selectLabel: expectedToolSelectLabel });
 
     expect(
-        await screen.findByRole("option", { name: "None", selected: true })
+        await screen.findByRole("combobox", { name: expectedToolSelectLabel })
+    ).toHaveTextContent(expected);
+    expect(
+        screen.getByRole("option", { name: expected, selected: true })
+    ).toBeVisible();
+});
+
+test("updates the selected tool if selected is changed", async () => {
+    const expected = "Iron";
+
+    render(<Calculator />);
+    await selectTool(Tools.Iron);
+    await openSelectMenu({ selectLabel: expectedToolSelectLabel });
+
+    expect(
+        await screen.findByRole("combobox", { name: expectedToolSelectLabel })
+    ).toHaveTextContent(expected);
+    expect(
+        screen.getByRole("option", {
+            name: expected,
+            selected: true,
+        })
     ).toBeVisible();
 });
 
@@ -228,6 +255,23 @@ test("queries item details again if tool is changed after first query", async ()
     await selectTool(expectedTool);
 
     await expect(expectedRequest).resolves.not.toThrow();
+});
+
+test("does not reset the currently selected tool after changing tabs", async () => {
+    const expected = "Iron";
+
+    render(<Calculator />);
+    await selectTool(Tools.Iron);
+    await openTab(expectedSettingsTab);
+    await screen.findByRole("heading", {
+        name: expectedSettingsTabHeader,
+        level: 2,
+    });
+    await openTab(expectedCalculatorTab);
+
+    expect(
+        await screen.findByRole("combobox", { name: expectedToolSelectLabel })
+    ).toHaveTextContent(expected);
 });
 
 afterAll(() => {

--- a/ui/src/pages/Calculator/__tests__/Calculator.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import { graphql } from "msw";
 import { setupServer } from "msw/node";
 
@@ -15,6 +15,11 @@ import {
     expectedOutputPrefix,
     expectedFarmSizeNotePrefix,
     ItemName,
+    expectedCalculatorTab,
+    expectedSettingsTab,
+    expectedCalculatorTabHeader,
+    openTab,
+    expectedSettingsTabHeader,
 } from "./utils";
 import { expectedItemDetailsQueryName } from "./utils";
 
@@ -55,6 +60,156 @@ beforeAll(() => {
 beforeEach(() => {
     server.resetHandlers();
     server.events.removeAllListeners();
+});
+
+describe("tab rendering", async () => {
+    test("renders a list of tabs", async () => {
+        render(<Calculator />);
+
+        expect(await screen.findByRole("tablist")).toBeVisible();
+    });
+
+    test.each([expectedCalculatorTab, expectedSettingsTab])(
+        "renders the %s tab inside the tab list",
+        async (expected: string) => {
+            render(<Calculator />);
+            const tablist = await screen.findByRole("tablist");
+
+            expect(
+                within(tablist).getByRole("tab", { name: expected })
+            ).toBeVisible();
+        }
+    );
+
+    test("renders the calculator tab as selected by default", async () => {
+        render(<Calculator />);
+        const tablist = await screen.findByRole("tablist");
+
+        const calculatorTab = within(tablist).getByRole("tab", {
+            name: expectedCalculatorTab,
+            selected: true,
+        });
+        expect(calculatorTab).toBeVisible();
+        expect(calculatorTab).toHaveAttribute("tabindex", "0");
+    });
+
+    test("renders the settings tab as not selected by default", async () => {
+        render(<Calculator />);
+        const tablist = await screen.findByRole("tablist");
+
+        const settingsTab = within(tablist).getByRole("tab", {
+            name: expectedSettingsTab,
+            selected: false,
+        });
+        expect(settingsTab).toBeVisible();
+        expect(settingsTab).toHaveAttribute("tabindex", "-1");
+    });
+
+    test("renders the calculator tab content inside a tab panel by default", async () => {
+        render(<Calculator />);
+        const panel = await screen.findByRole("tabpanel");
+
+        expect(
+            await within(panel).findByRole("heading", {
+                level: 2,
+                name: expectedCalculatorTabHeader,
+            })
+        ).toBeVisible();
+    });
+
+    test("sets the settings tab to selected if clicked", async () => {
+        render(<Calculator />);
+        await openTab(expectedSettingsTab);
+
+        const settingsTab = await screen.findByRole("tab", {
+            name: expectedSettingsTab,
+            selected: true,
+        });
+        expect(settingsTab).toBeVisible();
+        expect(settingsTab).toHaveAttribute("tabindex", "0");
+    });
+
+    test("sets the calculator tab back to selected if re-opened", async () => {
+        render(<Calculator />);
+        const tablist = await screen.findByRole("tablist");
+        await openTab(expectedSettingsTab);
+        await within(tablist).findByRole("tab", {
+            name: expectedSettingsTab,
+            selected: true,
+        });
+        await openTab(expectedCalculatorTab);
+
+        const calculatorTab = await within(tablist).findByRole("tab", {
+            name: expectedCalculatorTab,
+            selected: true,
+        });
+        expect(calculatorTab).toBeVisible();
+        expect(calculatorTab).toHaveAttribute("tabindex", "0");
+    });
+
+    test("renders the settings tab content inside a tab panel if settings tab is selected", async () => {
+        render(<Calculator />);
+        await openTab(expectedSettingsTab);
+        const panel = await screen.findByRole("tabpanel");
+
+        expect(
+            await within(panel).findByRole("heading", {
+                level: 2,
+                name: expectedSettingsTabHeader,
+            })
+        ).toBeVisible();
+    });
+
+    test("does not render the settings tab if the calculator tab is selected (default)", async () => {
+        render(<Calculator />);
+        const panel = await screen.findByRole("tabpanel");
+        await within(panel).findByRole("heading", {
+            level: 2,
+            name: expectedCalculatorTabHeader,
+        });
+
+        expect(
+            within(panel).queryByRole("heading", {
+                level: 2,
+                name: expectedSettingsTabHeader,
+            })
+        ).not.toBeInTheDocument();
+    });
+
+    test("hides the settings tab if the calculator tab is re-opened", async () => {
+        render(<Calculator />);
+        await openTab(expectedSettingsTab);
+        const panel = await screen.findByRole("tabpanel");
+        await within(panel).findByRole("heading", {
+            level: 2,
+            name: expectedSettingsTabHeader,
+        });
+        await openTab(expectedCalculatorTab);
+
+        expect(
+            within(panel).queryByRole("heading", {
+                level: 2,
+                name: expectedSettingsTabHeader,
+            })
+        ).not.toBeInTheDocument();
+    });
+
+    test("hides the calculator tab if the settings tab is opened", async () => {
+        render(<Calculator />);
+        await openTab(expectedSettingsTab);
+        const panel = await screen.findByRole("tabpanel");
+        await within(panel).findByRole("heading", {
+            level: 2,
+            name: expectedSettingsTabHeader,
+        });
+
+        expect(
+            within(panel).queryByRole("heading", {
+                level: 2,
+                name: expectedCalculatorTabHeader,
+            })
+        ).not.toBeInTheDocument();
+    });
 });
 
 describe("worker input rendering", () => {

--- a/ui/src/pages/Calculator/__tests__/Calculator.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator.test.tsx
@@ -284,6 +284,25 @@ describe("worker input rendering", () => {
 
         expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     });
+
+    test("does not reset worker input after tab is changed", async () => {
+        const expectedWorkerValue = "24";
+
+        render(<Calculator />);
+        await selectItemAndWorkers({ workers: expectedWorkerValue });
+        await openTab(expectedSettingsTab);
+        await screen.findByRole("heading", {
+            name: expectedSettingsTabHeader,
+            level: 2,
+        });
+        await openTab(expectedCalculatorTab);
+
+        expect(
+            await screen.findByLabelText(expectedWorkerInputLabel, {
+                selector: "input",
+            })
+        ).toHaveValue(expectedWorkerValue);
+    });
 });
 
 describe("optimal farm size note rendering", () => {

--- a/ui/src/pages/Calculator/__tests__/Calculator.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator.test.tsx
@@ -18,8 +18,9 @@ import {
     expectedCalculatorTab,
     expectedSettingsTab,
     expectedCalculatorTabHeader,
-    openTab,
+    clickByName,
     expectedSettingsTabHeader,
+    expectedCreatorOverrideQueryName,
 } from "./utils";
 import { expectedItemDetailsQueryName } from "./utils";
 
@@ -50,6 +51,13 @@ const server = setupServer(
     }),
     graphql.query(expectedOutputQueryName, (_, res, ctx) => {
         return res(ctx.data({ output: 5.2 }));
+    }),
+    graphql.query(expectedCreatorOverrideQueryName, (_, res, ctx) => {
+        return res(
+            ctx.data({
+                item: [],
+            })
+        );
     })
 );
 
@@ -119,7 +127,7 @@ describe("tab rendering", async () => {
 
     test("sets the settings tab to selected if clicked", async () => {
         render(<Calculator />);
-        await openTab(expectedSettingsTab);
+        await clickByName(expectedSettingsTab, "tab");
 
         const settingsTab = await screen.findByRole("tab", {
             name: expectedSettingsTab,
@@ -132,12 +140,12 @@ describe("tab rendering", async () => {
     test("sets the calculator tab back to selected if re-opened", async () => {
         render(<Calculator />);
         const tablist = await screen.findByRole("tablist");
-        await openTab(expectedSettingsTab);
+        await clickByName(expectedSettingsTab, "tab");
         await within(tablist).findByRole("tab", {
             name: expectedSettingsTab,
             selected: true,
         });
-        await openTab(expectedCalculatorTab);
+        await clickByName(expectedCalculatorTab, "tab");
 
         const calculatorTab = await within(tablist).findByRole("tab", {
             name: expectedCalculatorTab,
@@ -149,7 +157,7 @@ describe("tab rendering", async () => {
 
     test("renders the settings tab content inside a tab panel if settings tab is selected", async () => {
         render(<Calculator />);
-        await openTab(expectedSettingsTab);
+        await clickByName(expectedSettingsTab, "tab");
         const panel = await screen.findByRole("tabpanel");
 
         expect(
@@ -178,13 +186,13 @@ describe("tab rendering", async () => {
 
     test("hides the settings tab if the calculator tab is re-opened", async () => {
         render(<Calculator />);
-        await openTab(expectedSettingsTab);
+        await clickByName(expectedSettingsTab, "tab");
         const panel = await screen.findByRole("tabpanel");
         await within(panel).findByRole("heading", {
             level: 2,
             name: expectedSettingsTabHeader,
         });
-        await openTab(expectedCalculatorTab);
+        await clickByName(expectedCalculatorTab, "tab");
 
         expect(
             within(panel).queryByRole("heading", {
@@ -196,7 +204,7 @@ describe("tab rendering", async () => {
 
     test("hides the calculator tab if the settings tab is opened", async () => {
         render(<Calculator />);
-        await openTab(expectedSettingsTab);
+        await clickByName(expectedSettingsTab, "tab");
         const panel = await screen.findByRole("tabpanel");
         await within(panel).findByRole("heading", {
             level: 2,
@@ -290,12 +298,12 @@ describe("worker input rendering", () => {
 
         render(<Calculator />);
         await selectItemAndWorkers({ workers: expectedWorkerValue });
-        await openTab(expectedSettingsTab);
+        await clickByName(expectedSettingsTab, "tab");
         await screen.findByRole("heading", {
             name: expectedSettingsTabHeader,
             level: 2,
         });
-        await openTab(expectedCalculatorTab);
+        await clickByName(expectedCalculatorTab, "tab");
 
         expect(
             await screen.findByLabelText(expectedWorkerInputLabel, {

--- a/ui/src/pages/Calculator/__tests__/utils/constants.ts
+++ b/ui/src/pages/Calculator/__tests__/utils/constants.ts
@@ -1,26 +1,17 @@
-const expectedRequirementsQueryName = "GetItemRequirements";
-const expectedOutputQueryName = "GetOptimalOutput";
-const expectedItemNameQueryName = "GetItemNames";
-const expectedItemDetailsQueryName = "GetItemDetails";
+export const expectedRequirementsQueryName = "GetItemRequirements";
+export const expectedOutputQueryName = "GetOptimalOutput";
+export const expectedItemNameQueryName = "GetItemNames";
+export const expectedItemDetailsQueryName = "GetItemDetails";
 
-const expectedDesiredOutputHeader = "Desired output:";
-const expectedItemSelectLabel = "Item:";
-const expectedWorkerInputLabel = "Workers:";
-const expectedOutputUnitLabel = "Desired output units:";
-const expectedToolSelectLabel = "Tools:";
-const expectedOutputPrefix = "Optimal output:";
-const expectedFarmSizeNotePrefix = "Calculations use optimal farm size:";
+export const expectedCalculatorTabHeader = "Desired output:";
+export const expectedItemSelectLabel = "Item:";
+export const expectedWorkerInputLabel = "Workers:";
+export const expectedOutputUnitLabel = "Desired output units:";
+export const expectedToolSelectLabel = "Tools:";
+export const expectedOutputPrefix = "Optimal output:";
+export const expectedFarmSizeNotePrefix = "Calculations use optimal farm size:";
 
-export {
-    expectedRequirementsQueryName,
-    expectedOutputQueryName,
-    expectedItemNameQueryName,
-    expectedItemDetailsQueryName,
-    expectedDesiredOutputHeader,
-    expectedItemSelectLabel,
-    expectedWorkerInputLabel,
-    expectedOutputUnitLabel,
-    expectedToolSelectLabel,
-    expectedOutputPrefix,
-    expectedFarmSizeNotePrefix,
-};
+export const expectedCalculatorTab = "Calculator";
+export const expectedSettingsTab = "Settings";
+
+export const expectedSettingsTabHeader = "Overrides:";

--- a/ui/src/pages/Calculator/__tests__/utils/constants.ts
+++ b/ui/src/pages/Calculator/__tests__/utils/constants.ts
@@ -16,3 +16,4 @@ export const expectedCalculatorTab = "Calculator";
 export const expectedSettingsTab = "Settings";
 
 export const expectedSettingsTabHeader = "Overrides:";
+export const expectedAddCreatorOverrideButtonText = "Add creator override";

--- a/ui/src/pages/Calculator/__tests__/utils/constants.ts
+++ b/ui/src/pages/Calculator/__tests__/utils/constants.ts
@@ -2,6 +2,7 @@ export const expectedRequirementsQueryName = "GetItemRequirements";
 export const expectedOutputQueryName = "GetOptimalOutput";
 export const expectedItemNameQueryName = "GetItemNames";
 export const expectedItemDetailsQueryName = "GetItemDetails";
+export const expectedCreatorOverrideQueryName = "GetMultipleCreatorDetails";
 
 export const expectedCalculatorTabHeader = "Desired output:";
 export const expectedItemSelectLabel = "Item:";

--- a/ui/src/pages/Calculator/__tests__/utils/constants.ts
+++ b/ui/src/pages/Calculator/__tests__/utils/constants.ts
@@ -17,3 +17,4 @@ export const expectedSettingsTab = "Settings";
 
 export const expectedSettingsTabHeader = "Overrides:";
 export const expectedAddCreatorOverrideButtonText = "Add creator override";
+export const expectedRemoveCreatorOverrideButtonText = "Remove";

--- a/ui/src/pages/Calculator/__tests__/utils/input-utils.ts
+++ b/ui/src/pages/Calculator/__tests__/utils/input-utils.ts
@@ -83,8 +83,16 @@ async function selectTool(tool: Tools) {
     });
 }
 
+async function openTab(name: string) {
+    const user = userEvent.setup();
+    const tab = await screen.findByRole("tab", { name });
+
+    await act(() => user.click(tab));
+}
+
 export {
     openSelectMenu,
+    openTab,
     selectOption,
     selectItemAndWorkers,
     selectOutputUnit,

--- a/ui/src/pages/Calculator/__tests__/utils/input-utils.ts
+++ b/ui/src/pages/Calculator/__tests__/utils/input-utils.ts
@@ -1,4 +1,4 @@
-import { act, screen } from "@testing-library/react";
+import { ByRoleMatcher, act, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import {
@@ -83,16 +83,16 @@ async function selectTool(tool: Tools) {
     });
 }
 
-async function openTab(name: string) {
+async function clickByName(name: string, matcher: ByRoleMatcher) {
     const user = userEvent.setup();
-    const tab = await screen.findByRole("tab", { name });
+    const tab = await screen.findByRole(matcher, { name });
 
     await act(() => user.click(tab));
 }
 
 export {
+    clickByName,
     openSelectMenu,
-    openTab,
     selectOption,
     selectItemAndWorkers,
     selectOutputUnit,

--- a/ui/src/pages/Calculator/components/CreatorOverrides/CreatorOverrideSelector.tsx
+++ b/ui/src/pages/Calculator/components/CreatorOverrides/CreatorOverrideSelector.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from "react";
+import { faRemove } from "@fortawesome/free-solid-svg-icons";
+
+import { Selector } from "../../../../common";
+import { CreatorOverride } from "../../../../graphql/__generated__/graphql";
+import {
+    Icon,
+    OverrideContainer,
+    RemoveButton,
+    RemoveButtonContainer,
+} from "./styles";
+
+type CreatorOverrideSelectorProps = {
+    defaultOverride: CreatorOverride;
+    items: string[];
+    creators: string[];
+    onSelectedItemChange: (newItem: string, oldItem: string) => void;
+    onSelectedCreatorChange: (item: string, newCreator: string) => void;
+    onRemove: (selectedItem: string) => void;
+};
+
+function CreatorOverrideSelector({
+    defaultOverride,
+    items,
+    creators,
+    onSelectedItemChange,
+    onSelectedCreatorChange,
+    onRemove,
+}: CreatorOverrideSelectorProps) {
+    const [selectedItem, setSelectedItem] = useState<string>(
+        defaultOverride.itemName
+    );
+
+    const handleSelectedItemChange = (value?: string) => {
+        if (!value) {
+            return;
+        }
+
+        const oldItem = selectedItem;
+        setSelectedItem(value);
+        onSelectedItemChange(value, oldItem);
+    };
+
+    const handleSelectedCreatorChange = (value?: string) => {
+        if (!value) {
+            return;
+        }
+
+        onSelectedCreatorChange(selectedItem, value);
+    };
+
+    const handleRemove = () => {
+        onRemove(selectedItem);
+    };
+
+    return (
+        <OverrideContainer>
+            <Selector
+                items={items}
+                itemToKey={(name) => name}
+                itemToDisplayText={(name) => name}
+                labelText="Item:"
+                defaultSelectedItem={defaultOverride.itemName}
+                onSelectedItemChange={handleSelectedItemChange}
+            />
+            <Selector
+                items={creators}
+                itemToKey={(creator) => creator}
+                itemToDisplayText={(creator) => creator}
+                labelText="Creator:"
+                defaultSelectedItem={defaultOverride.creator}
+                onSelectedItemChange={handleSelectedCreatorChange}
+            />
+            <RemoveButtonContainer>
+                <RemoveButton onClick={handleRemove}>
+                    <span>Remove</span>
+                    <Icon icon={faRemove} />
+                </RemoveButton>
+            </RemoveButtonContainer>
+        </OverrideContainer>
+    );
+}
+
+export { CreatorOverrideSelector };

--- a/ui/src/pages/Calculator/components/CreatorOverrides/CreatorOverrides.tsx
+++ b/ui/src/pages/Calculator/components/CreatorOverrides/CreatorOverrides.tsx
@@ -1,9 +1,16 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useQuery } from "@apollo/client";
 import { faAdd } from "@fortawesome/free-solid-svg-icons";
 
 import { gql } from "../../../../graphql/__generated__";
-import { AddIcon, LargeAddButton, OverrideListContainer } from "./styles";
+import {
+    AddIcon,
+    LargeAddButton,
+    OverrideContainer,
+    OverrideListContainer,
+} from "./styles";
+import { Selector } from "../../../../common";
+import { Item } from "../../../../graphql/__generated__/graphql";
 
 const GET_ITEMS_WITH_MULTIPLE_CREATORS = gql(`
     query GetMultipleCreatorDetails {
@@ -14,8 +21,42 @@ const GET_ITEMS_WITH_MULTIPLE_CREATORS = gql(`
     }
 `);
 
+type CreatorMap = Map<string, string[]>;
+type Overrides = { name: string; creators: string[] };
+
+function groupByCreators(items: Pick<Item, "name" | "creator">[]): CreatorMap {
+    return items.reduce((acc, { name, creator }) => {
+        const creators = acc.get(name);
+        acc.set(name, creators ? [...creators, creator] : [creator]);
+        return acc;
+    }, new Map<string, string[]>());
+}
+
 function CreatorOverrides() {
     const { loading, data } = useQuery(GET_ITEMS_WITH_MULTIPLE_CREATORS);
+    const [itemCreatorMap, setItemCreatorMap] = useState<CreatorMap>(new Map());
+    const [overrides, setOverrides] = useState<Overrides[]>([]);
+
+    useEffect(() => {
+        if (data?.item) {
+            setItemCreatorMap(groupByCreators(data.item));
+        }
+    }, [data]);
+
+    const addOverride = () => {
+        const groupedItems = Array.from(itemCreatorMap.keys());
+        if (groupedItems.length === 0) {
+            return;
+        }
+
+        const item = groupedItems[0];
+        const creators = itemCreatorMap.get(item);
+        if (!creators) {
+            return;
+        }
+
+        setOverrides([{ name: item, creators }]);
+    };
 
     return (
         <>
@@ -29,10 +70,28 @@ function CreatorOverrides() {
             ) : null}
             {data && data.item.length > 0 ? (
                 <OverrideListContainer>
-                    <LargeAddButton>
+                    <LargeAddButton onClick={addOverride}>
                         <span>Add creator override</span>
                         <AddIcon icon={faAdd} />
                     </LargeAddButton>
+                    {overrides.length > 0 ? (
+                        <OverrideContainer>
+                            <Selector
+                                items={overrides}
+                                itemToKey={(item) => item.name}
+                                itemToDisplayText={(item) => item.name}
+                                labelText="Item:"
+                                defaultSelectedItem={overrides[0]}
+                            />
+                            <Selector
+                                items={overrides[0].creators}
+                                itemToKey={(creator) => creator}
+                                itemToDisplayText={(creator) => creator}
+                                labelText="Creator:"
+                                defaultSelectedItem={overrides[0].creators[0]}
+                            />
+                        </OverrideContainer>
+                    ) : null}
                 </OverrideListContainer>
             ) : null}
         </>

--- a/ui/src/pages/Calculator/components/CreatorOverrides/CreatorOverrides.tsx
+++ b/ui/src/pages/Calculator/components/CreatorOverrides/CreatorOverrides.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { useQuery } from "@apollo/client";
+import { faAdd } from "@fortawesome/free-solid-svg-icons";
 
 import { gql } from "../../../../graphql/__generated__";
+import { AddIcon, LargeAddButton, OverrideListContainer } from "./styles";
 
 const GET_ITEMS_WITH_MULTIPLE_CREATORS = gql(`
     query GetMultipleCreatorDetails {
@@ -24,6 +26,14 @@ function CreatorOverrides() {
             {loading ? <span>Loading overrides...</span> : null}
             {!loading && data?.item.length === 0 ? (
                 <span role="alert">No overrides available</span>
+            ) : null}
+            {data && data.item.length > 0 ? (
+                <OverrideListContainer>
+                    <LargeAddButton>
+                        <span>Add creator override</span>
+                        <AddIcon icon={faAdd} />
+                    </LargeAddButton>
+                </OverrideListContainer>
             ) : null}
         </>
     );

--- a/ui/src/pages/Calculator/components/CreatorOverrides/CreatorOverrides.tsx
+++ b/ui/src/pages/Calculator/components/CreatorOverrides/CreatorOverrides.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { useQuery } from "@apollo/client";
+
+import { gql } from "../../../../graphql/__generated__";
+
+const GET_ITEMS_WITH_MULTIPLE_CREATORS = gql(`
+    query GetMultipleCreatorDetails {
+        item(filters: { minimumCreators: 2 }) {
+            name
+            creator
+        }
+    }
+`);
+
+function CreatorOverrides() {
+    const { loading, data } = useQuery(GET_ITEMS_WITH_MULTIPLE_CREATORS);
+
+    return (
+        <>
+            <span>
+                By default, the calculator will use the recipe with the highest
+                output per second unless an override is applied.
+            </span>
+            {loading ? <span>Loading overrides...</span> : null}
+            {!loading && data?.item.length === 0 ? (
+                <span role="alert">No overrides available</span>
+            ) : null}
+        </>
+    );
+}
+
+export { CreatorOverrides };

--- a/ui/src/pages/Calculator/components/CreatorOverrides/index.ts
+++ b/ui/src/pages/Calculator/components/CreatorOverrides/index.ts
@@ -1,0 +1,3 @@
+import { CreatorOverrides } from "./CreatorOverrides";
+
+export default CreatorOverrides;

--- a/ui/src/pages/Calculator/components/CreatorOverrides/styles.ts
+++ b/ui/src/pages/Calculator/components/CreatorOverrides/styles.ts
@@ -2,11 +2,15 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import styled, { css } from "styled-components";
 
 export const OverrideListContainer = styled.div`
-    max-width: 30rem;
+    max-width: 40rem;
     width: 100%;
 
     display: flex;
     flex-direction: column;
+
+    > :not(:first-child) {
+        margin-top: 1rem;
+    }
 `;
 
 export const LargeAddButton = styled.button`
@@ -45,7 +49,7 @@ export const RemoveButton = styled.button`
     `};
 
     display: flex;
-    flex-grow: 1;
+    flex: 1;
     justify-content: space-between;
     align-items: center;
     padding: 0.5rem;

--- a/ui/src/pages/Calculator/components/CreatorOverrides/styles.ts
+++ b/ui/src/pages/Calculator/components/CreatorOverrides/styles.ts
@@ -31,3 +31,12 @@ export const LargeAddButton = styled.button`
 export const AddIcon = styled(FontAwesomeIcon)`
     margin-left: 0.5rem;
 `;
+
+export const OverrideContainer = styled.div`
+    display: flex;
+    column-gap: 0.5rem;
+
+    div {
+        flex: 1;
+    }
+`;

--- a/ui/src/pages/Calculator/components/CreatorOverrides/styles.ts
+++ b/ui/src/pages/Calculator/components/CreatorOverrides/styles.ts
@@ -2,7 +2,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import styled, { css } from "styled-components";
 
 export const OverrideListContainer = styled.div`
-    max-width: 25rem;
+    max-width: 30rem;
     width: 100%;
 
     display: flex;
@@ -28,13 +28,40 @@ export const LargeAddButton = styled.button`
     cursor: pointer;
 `;
 
-export const AddIcon = styled(FontAwesomeIcon)`
+export const RemoveButtonContainer = styled.div`
+    display: flex;
+    align-items: flex-end;
+`;
+
+export const RemoveButton = styled.button`
+    ${({ theme }) => css`
+        color: ${theme.color.error.on_container};
+        background-color: ${theme.color.error.container};
+        border: 1px solid ${theme.color.error.container};
+
+        :hover {
+            border-color: ${theme.color.error.on_container};
+        }
+    `};
+
+    display: flex;
+    flex-grow: 1;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5rem;
+    border-radius: 0.25rem;
+    cursor: pointer;
+`;
+
+export const Icon = styled(FontAwesomeIcon)`
     margin-left: 0.5rem;
 `;
 
 export const OverrideContainer = styled.div`
     display: flex;
+    flex-wrap: wrap;
     column-gap: 0.5rem;
+    row-gap: 0.5rem;
 
     div {
         flex: 1;

--- a/ui/src/pages/Calculator/components/CreatorOverrides/styles.ts
+++ b/ui/src/pages/Calculator/components/CreatorOverrides/styles.ts
@@ -1,0 +1,33 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import styled, { css } from "styled-components";
+
+export const OverrideListContainer = styled.div`
+    max-width: 25rem;
+    width: 100%;
+
+    display: flex;
+    flex-direction: column;
+`;
+
+export const LargeAddButton = styled.button`
+    ${({ theme }) => css`
+        color: ${theme.color.primary.on_container};
+        background-color: ${theme.color.primary.container};
+        border: 1px solid ${theme.color.primary.container};
+
+        :hover {
+            border-color: ${theme.color.primary.on_container};
+        }
+    `};
+
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5rem;
+    border-radius: 0.25rem;
+    cursor: pointer;
+`;
+
+export const AddIcon = styled(FontAwesomeIcon)`
+    margin-left: 0.5rem;
+`;

--- a/ui/src/pages/Calculator/components/ItemSelector/ItemSelector.tsx
+++ b/ui/src/pages/Calculator/components/ItemSelector/ItemSelector.tsx
@@ -5,9 +5,14 @@ import { Selector } from "../../../../common/components";
 type ItemSelectorProps = {
     items: string[];
     onItemChange: (item: string) => void;
+    defaultSelectedItem?: string;
 };
 
-function ItemSelector({ items, onItemChange }: ItemSelectorProps) {
+function ItemSelector({
+    items,
+    defaultSelectedItem,
+    onItemChange,
+}: ItemSelectorProps) {
     const handleItemChange = (selectedItem?: string) => {
         if (selectedItem) onItemChange(selectedItem);
     };
@@ -18,7 +23,7 @@ function ItemSelector({ items, onItemChange }: ItemSelectorProps) {
             itemToKey={(item) => item}
             itemToDisplayText={(item) => item}
             labelText="Item:"
-            defaultSelectedItem={items[0]}
+            defaultSelectedItem={defaultSelectedItem ?? items[0]}
             onSelectedItemChange={handleItemChange}
             palette="secondary"
         />

--- a/ui/src/pages/Calculator/components/OutputUnitSelector/OutputUnitSelector.tsx
+++ b/ui/src/pages/Calculator/components/OutputUnitSelector/OutputUnitSelector.tsx
@@ -6,11 +6,12 @@ import { Selector } from "../../../../common/components";
 
 type ItemSelectorProps = {
     onUnitChange: (unit: OutputUnit) => void;
+    defaultUnit?: OutputUnit;
 };
 
 const outputUnits = Object.values(OutputUnit);
 
-function OutputUnitSelector({ onUnitChange }: ItemSelectorProps) {
+function OutputUnitSelector({ onUnitChange, defaultUnit }: ItemSelectorProps) {
     const handleUnitChange = (selectedUnit?: OutputUnit) => {
         if (selectedUnit) onUnitChange(selectedUnit);
     };
@@ -21,7 +22,7 @@ function OutputUnitSelector({ onUnitChange }: ItemSelectorProps) {
             itemToKey={(unit) => unit}
             itemToDisplayText={(unit) => OutputUnitSelectorMappings[unit]}
             labelText="Desired output units:"
-            defaultSelectedItem={outputUnits[1]}
+            defaultSelectedItem={defaultUnit ?? outputUnits[1]}
             onSelectedItemChange={handleUnitChange}
             palette="secondary"
         />

--- a/ui/src/pages/Calculator/components/Requirements/Requirements.tsx
+++ b/ui/src/pages/Calculator/components/Requirements/Requirements.tsx
@@ -18,7 +18,11 @@ import {
     SortableHeader,
 } from "./styles";
 import { gql } from "../../../../graphql/__generated__";
-import { Requirement, Tools } from "../../../../graphql/__generated__/graphql";
+import {
+    CreatorOverride,
+    Requirement,
+    Tools,
+} from "../../../../graphql/__generated__/graphql";
 import { DEFAULT_DEBOUNCE } from "../../utils";
 
 type ValidSortDirections = "none" | "ascending" | "descending";
@@ -26,6 +30,7 @@ type RequirementsProps = {
     selectedItemName: string;
     workers: number;
     maxAvailableTool?: Tools;
+    creatorOverrides?: CreatorOverride[];
 };
 
 const sortDirectionOrderMap: {
@@ -43,8 +48,8 @@ const sortDirectionIconMap: { [key in ValidSortDirections]: IconDefinition } = {
 };
 
 const GET_ITEM_REQUIREMENTS = gql(`
-    query GetItemRequirements($name: ID!, $workers: Int!, $maxAvailableTool: Tools) {
-        requirement(name: $name, workers: $workers, maxAvailableTool: $maxAvailableTool) {
+    query GetItemRequirements($name: ID!, $workers: Int!, $maxAvailableTool: Tools, $creatorOverrides: [CreatorOverride!]) {
+        requirement(name: $name, workers: $workers, maxAvailableTool: $maxAvailableTool, creatorOverrides: $creatorOverrides) {
             name
             workers
         }
@@ -70,6 +75,7 @@ function Requirements({
     selectedItemName,
     workers,
     maxAvailableTool,
+    creatorOverrides,
 }: RequirementsProps) {
     const [getItemRequirements, { loading, data, error }] = useLazyQuery(
         GET_ITEM_REQUIREMENTS
@@ -85,14 +91,25 @@ function Requirements({
     };
 
     useEffect(() => {
+        const creatorOverridesFilter =
+            creatorOverrides && creatorOverrides.length > 0
+                ? creatorOverrides
+                : undefined;
+
         getItemRequirements({
             variables: {
                 name: selectedItemName,
                 workers: debouncedWorkers,
                 maxAvailableTool,
+                creatorOverrides: creatorOverridesFilter,
             },
         });
-    }, [selectedItemName, debouncedWorkers, maxAvailableTool]);
+    }, [
+        selectedItemName,
+        debouncedWorkers,
+        maxAvailableTool,
+        creatorOverrides,
+    ]);
 
     if (error) {
         return (

--- a/ui/src/pages/Calculator/components/ToolSelector/ToolSelector.tsx
+++ b/ui/src/pages/Calculator/components/ToolSelector/ToolSelector.tsx
@@ -6,11 +6,12 @@ import { Selector } from "../../../../common/components";
 
 type ToolSelectorProps = {
     onToolChange: (unit: Tools) => void;
+    defaultTool?: Tools;
 };
 
 const tools = Object.values(Tools);
 
-function ToolSelector({ onToolChange }: ToolSelectorProps) {
+function ToolSelector({ onToolChange, defaultTool }: ToolSelectorProps) {
     const handleToolChange = (selectedTool?: Tools) => {
         if (selectedTool) onToolChange(selectedTool);
     };
@@ -21,7 +22,7 @@ function ToolSelector({ onToolChange }: ToolSelectorProps) {
             itemToKey={(tool) => tool}
             itemToDisplayText={(tool) => ToolSelectorMappings[tool]}
             labelText="Tools:"
-            defaultSelectedItem={tools[3]}
+            defaultSelectedItem={defaultTool ?? tools[3]}
             onSelectedItemChange={handleToolChange}
             palette="secondary"
         />

--- a/ui/src/pages/Calculator/components/WorkerInput/WorkerInput.tsx
+++ b/ui/src/pages/Calculator/components/WorkerInput/WorkerInput.tsx
@@ -4,9 +4,10 @@ import { Input } from "../../../../common/components";
 
 type ItemSelectorProps = {
     onWorkerChange: (workers?: number) => void;
+    defaultWorkers?: number;
 };
 
-function WorkerInput({ onWorkerChange }: ItemSelectorProps) {
+function WorkerInput({ onWorkerChange, defaultWorkers }: ItemSelectorProps) {
     const parseValue = (value: unknown): number => {
         const input = Number(value);
         if (!isNaN(input) && input > 0 && input % 1 === 0) {
@@ -24,6 +25,7 @@ function WorkerInput({ onWorkerChange }: ItemSelectorProps) {
             errorMessage="Invalid input, must be a positive non-zero whole number"
             inputMode="numeric"
             clearIconLabel="Clear worker input"
+            defaultValue={defaultWorkers?.toString()}
         />
     );
 }

--- a/ui/src/pages/Calculator/styles.tsx
+++ b/ui/src/pages/Calculator/styles.tsx
@@ -1,13 +1,50 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
-export const CalculatorContainer = styled.div`
+export const PageContainer = styled.div``;
+
+export const Tabs = styled.div`
+    button[role="tab"] {
+        background-color: inherit;
+        border-width: 0.1rem 0.1rem 0 0.1rem;
+        border-style: solid;
+        padding: 0.5rem;
+        cursor: pointer;
+
+        :first-child {
+            border-top-left-radius: 0.4rem;
+        }
+
+        :last-child {
+            border-width: 0.1rem 0.1rem 0 0;
+            border-top-right-radius: 0.4rem;
+        }
+
+        ${({ theme }) => css`
+            color: ${theme.color.background.on_main};
+            border-color: ${theme.color.surface_variant.main};
+
+            &[aria-selected="true"] {
+                background-color: ${theme.color.surface_variant.main};
+                cursor: default;
+            }
+        `};
+    }
+`;
+
+export const TabContainer = styled.div`
+    ${({ theme }) => css`
+        border: 0.1rem solid ${theme.color.surface_variant.main};
+    `};
+
     display: flex;
     flex-direction: column;
 
+    padding: 0.5rem;
     row-gap: 0.75rem;
+    border-radius: 0 0.4rem 0.4rem 0.4rem;
 `;
 
-export const CalculatorHeader = styled.h2`
+export const TabHeader = styled.h2`
     margin-top: 0rem;
     margin-bottom: 0rem;
 `;


### PR DESCRIPTION
#  What

Updated UI to include a settings and calculator tab
Settings tab includes new selector list that allows selection of specific recipes / creator overrides
- If a creator override is specified then it will be used to fetch item details and in requirements calculations

Updated static items list to include second example of item w/ multiple creators

# Why

Enables users of the calculator to use recipes / sub-recipes that are not the optimal recipe. Allows the calculator to be more flexible to the particular situation a user may be in.
- A user may not have all optimal recipes unlocked, therefore, w/o this change the calculator would not be useful