### PR TITLE
fix: selector sizing mobile

### DIFF
--- a/ui/src/common/components/Selector/styles.tsx
+++ b/ui/src/common/components/Selector/styles.tsx
@@ -68,7 +68,8 @@ export const Menu = styled.div<MenuProps>`
     position: absolute;
     z-index: 1;
     width: 100%;
-    margin-top: 4rem;
+    top: 100%;
+    margin-top: 0.5rem;
     padding: 0.25rem 0rem;
     border-radius: 0.25rem;
     list-style-type: none;

--- a/ui/src/pages/Calculator/components/CreatorOverrides/styles.ts
+++ b/ui/src/pages/Calculator/components/CreatorOverrides/styles.ts
@@ -2,7 +2,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import styled, { css } from "styled-components";
 
 export const OverrideListContainer = styled.div`
-    max-width: 40rem;
+    max-width: 45rem;
     width: 100%;
 
     display: flex;
@@ -67,7 +67,7 @@ export const OverrideContainer = styled.div`
     column-gap: 0.5rem;
     row-gap: 0.5rem;
 
-    div {
-        flex: 1;
+    > div {
+        flex: 1 0 13rem;
     }
 `;


### PR DESCRIPTION
# What

Updated selector CSS to prevent overlap when selector is different height
Updated override selector to add initial min-width of selectors