### PR TITLE
feat(api): update requirements lp to calculate overall item production + per recipe demand

### DIFF
--- a/api/src/functions/query-requirements/domain/item-utils.ts
+++ b/api/src/functions/query-requirements/domain/item-utils.ts
@@ -54,7 +54,7 @@ function getLowestRequiredTool(items: Items): Tools {
 
 type RecipeMap = Map<string, Items>;
 
-function groupItemsByName(items: Items): RecipeMap {
+function groupItemsByName(items: Readonly<Items>): RecipeMap {
     const itemRecipes = new Map<string, Items>();
     for (const item of items) {
         const recipes = itemRecipes.get(item.name) ?? [];

--- a/api/src/functions/query-requirements/domain/query-requirements.ts
+++ b/api/src/functions/query-requirements/domain/query-requirements.ts
@@ -7,8 +7,8 @@ import { Items, Tools } from "../../../types";
 import { isAvailableToolSufficient } from "../../../common/modifiers";
 import { RequiredWorkers } from "../interfaces/query-requirements-primary-port";
 import {
+    RECIPE_PREFIX,
     VertexOutput,
-    WORKERS_PROPERTY,
     computeRequirementVertices,
 } from "./requirements-linear-program";
 import {
@@ -84,12 +84,12 @@ function mapResults(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { bounded, ...workerKeys } = results;
     for (const [variableKey, workers] of Object.entries(workerKeys)) {
-        const itemName = variableKey.split("-")[0] as string;
-        if (
-            itemName != inputItemName &&
-            workers !== 0 &&
-            variableKey !== WORKERS_PROPERTY
-        ) {
+        if (!variableKey.startsWith(RECIPE_PREFIX)) {
+            continue;
+        }
+
+        const itemName = variableKey.split("-")[1] as string;
+        if (itemName != inputItemName && workers !== 0) {
             const currentWorkers = requiredWorkers.get(itemName) ?? 0;
             requiredWorkers.set(itemName, currentWorkers + workers);
         }

--- a/api/src/functions/query-requirements/domain/requirements-linear-program.ts
+++ b/api/src/functions/query-requirements/domain/requirements-linear-program.ts
@@ -6,10 +6,12 @@ import { calculateCreateTime, groupItemsByName } from "./item-utils";
 import { isAvailableToolSufficient } from "../../../common/modifiers";
 
 export const WORKERS_PROPERTY = "workers";
+export const REQUIREMENT_PREFIX = "requirement-";
+export const RECIPE_PREFIX = "recipe-";
 
 type Constraints = IModelBase["constraints"];
 type Variables = IModelBase["variables"];
-type VariableProperties = Variables[number];
+type VariableProperties = NonNullable<Variables[number]>;
 
 export type VertexOutput = {
     [key: string]: number;
@@ -38,74 +40,125 @@ function createVariableName({
     return `${name}-${creator}`;
 }
 
-function createMultiObjectiveModel(
-    items: Items,
-    inputItemName: string,
-    workers: number,
+function filterCreatable(
+    items: Readonly<Items>,
     maxAvailableTool: Tools
-): IMultiObjectiveModel {
+): Items {
+    return items.filter((item) =>
+        isAvailableToolSufficient(item.minimumTool, maxAvailableTool)
+    );
+}
+
+function createBaseOutputPropertyName(itemName: string) {
+    return `${itemName}-base`;
+}
+
+function createSpecificRecipeRequirementPropertyName(
+    itemName: string,
+    requiring: Pick<Item, "name" | "creator">
+) {
+    return `${REQUIREMENT_PREFIX}${requiring.name}-${requiring.creator}-${itemName}`;
+}
+
+function createDemandVariables(
+    items: Readonly<Items>,
+    maxAvailableTool: Tools,
+    inputItemName: string
+): Variables {
     const recipeMap = groupItemsByName(items);
-    const constraints: Constraints = {};
 
-    // Set input item total workers constraint
-    const outputWorkersPropertyName =
+    const inputItemWorkersPropertyName =
         createInputWorkersPropertyName(inputItemName);
-    constraints[outputWorkersPropertyName] = { equal: workers };
-
-    for (const { name } of items) {
-        // Set minimum output constraint (non-negative)
-        constraints[name] = { min: 0 };
-    }
 
     const variables: Variables = {};
-    for (const item of items) {
-        // Skip if not creatable
-        if (!isAvailableToolSufficient(item.minimumTool, maxAvailableTool)) {
-            continue;
-        }
+    for (const [itemName, recipes] of recipeMap.entries()) {
+        const totalOutputVariable: VariableProperties = {};
 
-        const properties: VariableProperties = {};
+        // Set total output properties
+        const baseItemPropertyName = createBaseOutputPropertyName(itemName);
+        totalOutputVariable[itemName] = 1;
+        totalOutputVariable[baseItemPropertyName] = -1;
 
-        // Set worker properties
-        properties[WORKERS_PROPERTY] = 1;
-        if (item.name === inputItemName) {
-            properties[outputWorkersPropertyName] = 1;
-        }
+        for (const recipe of recipes) {
+            const recipeVariable: VariableProperties = {};
 
-        // Set base output properties
-        const createTime = calculateCreateTime(item, maxAvailableTool);
-        properties[item.name] = item.output / createTime;
+            // Set recipe output properties
+            const createTime = calculateCreateTime(recipe, maxAvailableTool);
+            recipeVariable[baseItemPropertyName] = recipe.output / createTime;
 
-        // Set base requirement properties
-        for (const requirement of item.requires) {
-            // Throw an error if no recipes exist for provided item
-            if (!recipeMap.get(requirement.name)) {
-                throw new Error(INTERNAL_SERVER_ERROR);
+            // Set worker properties
+            recipeVariable[WORKERS_PROPERTY] = 1;
+            if (itemName === inputItemName) {
+                recipeVariable[inputItemWorkersPropertyName] = 1;
             }
 
-            properties[requirement.name] =
-                (requirement.amount / createTime) * -1;
+            // Set base requirement properties
+            for (const requirement of recipe.requires) {
+                // Throw an error if no recipes exist for provided item
+                if (!recipeMap.get(requirement.name)) {
+                    throw new Error(INTERNAL_SERVER_ERROR);
+                }
+
+                const specificRecipeRequirementVariable: VariableProperties =
+                    {};
+
+                // Create specific recipe output properties
+                const specificRecipeRequirementPropertyName =
+                    createSpecificRecipeRequirementPropertyName(
+                        requirement.name,
+                        recipe
+                    );
+                specificRecipeRequirementVariable[requirement.name] = -1;
+                specificRecipeRequirementVariable[
+                    specificRecipeRequirementPropertyName
+                ] = 1;
+
+                recipeVariable[specificRecipeRequirementPropertyName] =
+                    (requirement.amount / createTime) * -1;
+                variables[specificRecipeRequirementPropertyName] =
+                    specificRecipeRequirementVariable;
+            }
+
+            // Set optional output properties
+            for (const optional of recipe.optionalOutputs ?? []) {
+                const baseItemPropertyName = createBaseOutputPropertyName(
+                    optional.name
+                );
+                const currentOutput = recipeVariable[baseItemPropertyName] ?? 0;
+                const optionalOutput =
+                    (optional.amount / createTime) * optional.likelihood;
+                recipeVariable[optional.name] = currentOutput + optionalOutput;
+            }
+
+            variables[`${RECIPE_PREFIX}${createVariableName(recipe)}`] =
+                recipeVariable;
         }
 
-        // Set optional output properties (Updating demand/output as may be additional)
-        for (const optional of item.optionalOutputs ?? []) {
-            const currentOutput = properties[optional.name] ?? 0;
-            const optionalOutput =
-                (optional.amount / createTime) * optional.likelihood;
-            properties[optional.name] = currentOutput + optionalOutput;
-        }
-
-        variables[createVariableName(item)] = properties;
+        variables[itemName] = totalOutputVariable;
     }
 
-    return {
-        optimize: {
-            [inputItemName]: "max",
-            [WORKERS_PROPERTY]: "min",
-        },
-        constraints,
-        variables,
-    };
+    return variables;
+}
+
+function createDemandConstraints(
+    variables: Readonly<Variables>,
+    inputItemName: string
+): Constraints {
+    const uniqueConstraints: Constraints = {};
+    const inputItemWorkerVariable =
+        createInputWorkersPropertyName(inputItemName);
+    for (const properties of Object.values(variables)) {
+        for (const property of Object.keys(properties ?? {})) {
+            if (
+                property !== WORKERS_PROPERTY &&
+                property !== inputItemWorkerVariable
+            ) {
+                uniqueConstraints[property] = { min: 0 };
+            }
+        }
+    }
+
+    return uniqueConstraints;
 }
 
 function getVertexWithHighestOutputAndLowestWorkers(
@@ -146,14 +199,30 @@ function computeRequirementVertices(
     if (!input) {
         throw new Error(UNKNOWN_ITEM_ERROR);
     }
-    const model = createMultiObjectiveModel(
-        requirements,
-        inputItemName,
-        workers,
-        maxAvailableTool
+
+    const createAbleItems = filterCreatable(requirements, maxAvailableTool);
+    const variables = createDemandVariables(
+        createAbleItems,
+        maxAvailableTool,
+        inputItemName
     );
 
+    const demandConstraints = createDemandConstraints(variables, inputItemName);
+    demandConstraints[createInputWorkersPropertyName(inputItemName)] = {
+        equal: workers,
+    };
+
+    const model: IMultiObjectiveModel = {
+        optimize: {
+            [inputItemName]: "max",
+            [WORKERS_PROPERTY]: "min",
+        },
+        constraints: demandConstraints,
+        variables: variables,
+    };
+
     const result = solver.MultiObjective(model) as LinearProgramOutput;
+
     return getVertexWithHighestOutputAndLowestWorkers(
         inputItemName,
         result.vertices


### PR DESCRIPTION
# What

Updated requirements linear programming solver to include new variables that reflect:
- Overall item production
- Per recipe item demand

# Why

Enables future effort to update the query-requirements response to include:
- Overall output/demand of each item per second (Rather than just number of workers required to satisfy demand)
- Per recipe demand of each item per second - Such that you can determine how much each recipe requires of a given item
- Per recipe - Overall output contribution - Can see how much each recipe contributes to the overall output of a given item