### PR TITLE
feat: query output second unit support

### DIFF
--- a/api/src/functions/query-output/domain/__tests__/output-calculator.test.ts
+++ b/api/src/functions/query-output/domain/__tests__/output-calculator.test.ts
@@ -133,8 +133,10 @@ test("throws an error if an unhandled exception occurs while fetching item requi
 test.each([
     [OutputUnit.GAME_DAYS, 2, 3, 3262.5],
     [OutputUnit.MINUTES, 2, 3, 450],
+    [OutputUnit.SECONDS, 2, 3, 7.5],
     [OutputUnit.GAME_DAYS, 8.5, 1, 255.88],
     [OutputUnit.MINUTES, 8.5, 1, 35.29],
+    [OutputUnit.SECONDS, 8.5, 1, 0.59],
 ])(
     "returns the expected output for an item in %s given item create time of: %s and amount created: %s with 5 workers (no tools)",
     async (

--- a/api/src/functions/query-output/interfaces/query-output-primary-port.ts
+++ b/api/src/functions/query-output/interfaces/query-output-primary-port.ts
@@ -1,8 +1,9 @@
 import { Tools } from "../../../types";
 
 enum OutputUnit {
-    GAME_DAYS = "GAME_DAYS",
+    SECONDS = "SECONDS",
     MINUTES = "MINUTES",
+    GAME_DAYS = "GAME_DAYS",
 }
 
 interface QueryOutputPrimaryPort {

--- a/api/src/functions/query-output/utils/OutputUnitSecondMapping.ts
+++ b/api/src/functions/query-output/utils/OutputUnitSecondMapping.ts
@@ -1,6 +1,7 @@
 import { OutputUnit } from "../interfaces/query-output-primary-port";
 
 const OutputUnitSecondMappings: Readonly<Record<OutputUnit, number>> = {
+    [OutputUnit.SECONDS]: 1,
     [OutputUnit.MINUTES]: 60,
     [OutputUnit.GAME_DAYS]: 435,
 };

--- a/api/src/graphql/schema.graphql
+++ b/api/src/graphql/schema.graphql
@@ -38,6 +38,7 @@ type Requirement {
 }
 
 enum OutputUnit {
+    SECONDS
     MINUTES
     GAME_DAYS
 }

--- a/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
@@ -65,7 +65,7 @@ beforeEach(() => {
     server.events.removeAllListeners();
 });
 
-test.each(["Minutes", "Game days"])(
+test.each(["Seconds", "Minutes", "Game days"])(
     "renders the %s option in the output unit selector",
     async (unit: string) => {
         render(<Calculator />, expectedGraphQLAPIURL);
@@ -211,6 +211,7 @@ test("does not render the optimal output message if output has not been received
 });
 
 test.each([
+    ["seconds", OutputUnit.Seconds, 0.1, "second"],
     ["minutes", OutputUnit.Minutes, 5, "minute"],
     ["game days", OutputUnit.GameDays, 60, "game day"],
 ])(

--- a/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
@@ -240,29 +240,32 @@ test.each([
     }
 );
 
-test("rounds optimal output to 1 decimals if more than 1 decimal places", async () => {
-    const expectedOutput = `${expectedOutputPrefix} ≈28.2 per minute`;
+test.each([
+    [
+        "rounds optimal output to 1 decimals if more than 1 decimal places",
+        28.23,
+        "≈28.2",
+    ],
+    [
+        "does not show approx symbol if optimal output is only accurate to 1 decimal place",
+        28.1,
+        "28.1",
+    ],
+    [
+        "rounds optimal output to more precision if rounding would output zero",
+        0.0012,
+        "≈0.001",
+    ],
+    [
+        "does not show approx symbol if optimal output has no additional precision (below 0.1)",
+        0.001,
+        "0.001",
+    ],
+])("%s", async (_: string, actual: number, expected: string) => {
+    const expectedOutput = `${expectedOutputPrefix} ${expected} per minute`;
     server.use(
         graphql.query(expectedOutputQueryName, (_, res, ctx) => {
-            return res(ctx.data({ output: 28.23 }));
-        })
-    );
-
-    render(<Calculator />);
-    await selectItemAndWorkers({
-        itemName: item.name,
-        workers: 5,
-    });
-
-    expect(await screen.findByText(expectedOutput)).toBeVisible();
-});
-
-test("does not show approx symbol if optimal output is only accurate to 1 decimal place", async () => {
-    const output = 28.1;
-    const expectedOutput = `${expectedOutputPrefix} ${output} per minute`;
-    server.use(
-        graphql.query(expectedOutputQueryName, (_, res, ctx) => {
-            return res(ctx.data({ output }));
+            return res(ctx.data({ output: actual }));
         })
     );
 

--- a/ui/src/pages/Calculator/utils/output-units.ts
+++ b/ui/src/pages/Calculator/utils/output-units.ts
@@ -1,11 +1,13 @@
 import { OutputUnit } from "../../../graphql/__generated__/graphql";
 
 const OutputUnitDisplayMappings: Readonly<Record<OutputUnit, string>> = {
+    [OutputUnit.Seconds]: "second",
     [OutputUnit.Minutes]: "minute",
     [OutputUnit.GameDays]: "game day",
 };
 
 const OutputUnitSelectorMappings: Readonly<Record<OutputUnit, string>> = {
+    [OutputUnit.Seconds]: "Seconds",
     [OutputUnit.Minutes]: "Minutes",
     [OutputUnit.GameDays]: "Game days",
 };

--- a/ui/src/pages/Calculator/utils/round-output.ts
+++ b/ui/src/pages/Calculator/utils/round-output.ts
@@ -1,6 +1,30 @@
+function calculateOrderOfMagnitude(output: number): number {
+    if (output === 0) {
+        return 0;
+    }
+
+    return Math.floor(Math.log10(output));
+}
+
+function countDigitsAfterDecimal(output: number): number {
+    const decimalPart = output - Math.floor(output);
+    return decimalPart.toString().length - 2;
+}
+
 function roundOutput(output: number): string {
+    const approx = output + Number.EPSILON;
+    if (approx < 0.1) {
+        const magnitude = -calculateOrderOfMagnitude(approx);
+        if (countDigitsAfterDecimal(output) === magnitude) {
+            return output.toString();
+        }
+
+        const factor = 10 ** magnitude;
+        return `≈${Math.round(approx * factor) / factor}`;
+    }
+
     if ((output * 10) % 1 !== 0) {
-        return `≈${Math.round((output + Number.EPSILON) * 10) / 10}`;
+        return `≈${Math.round(approx * 10) / 10}`;
     }
 
     return output.toString();


### PR DESCRIPTION
# What

Updated `output` query handler / logic to allow querying output per second
Updated UI to allow selecting seconds as output unit
Fixed issue where UI would show "≈0" for optimal output and requirements if value was less than 0.1
- Now shows minimum amount of precision such that the number is not shown as "≈0"