### PR TITLE
feat: requirements query support output units

### DIFF
--- a/api/src/common/output/index.ts
+++ b/api/src/common/output/index.ts
@@ -4,4 +4,10 @@ enum OutputUnit {
     GAME_DAYS = "GAME_DAYS",
 }
 
-export { OutputUnit };
+const OutputUnitSecondMappings: Readonly<Record<OutputUnit, number>> = {
+    [OutputUnit.SECONDS]: 1,
+    [OutputUnit.MINUTES]: 60,
+    [OutputUnit.GAME_DAYS]: 435,
+};
+
+export { OutputUnit, OutputUnitSecondMappings };

--- a/api/src/common/output/index.ts
+++ b/api/src/common/output/index.ts
@@ -1,0 +1,7 @@
+enum OutputUnit {
+    SECONDS = "SECONDS",
+    MINUTES = "MINUTES",
+    GAME_DAYS = "GAME_DAYS",
+}
+
+export { OutputUnit };

--- a/api/src/functions/query-output/domain/__tests__/output-calculator.test.ts
+++ b/api/src/functions/query-output/domain/__tests__/output-calculator.test.ts
@@ -1,8 +1,8 @@
 import { calculateOutput } from "../output-calculator";
 import { queryOutputDetails } from "../../adapters/mongodb-output-adapter";
 import type { ItemOutputDetails } from "../../interfaces/output-database-port";
-import { OutputUnit } from "../../interfaces/query-output-primary-port";
 import { Tools } from "../../../../types";
+import { OutputUnit } from "../../../../common/output";
 
 jest.mock("../../adapters/mongodb-output-adapter", () => ({
     queryOutputDetails: jest.fn(),

--- a/api/src/functions/query-output/domain/output-calculator.ts
+++ b/api/src/functions/query-output/domain/output-calculator.ts
@@ -3,13 +3,11 @@ import {
     getMaxToolModifier,
     isAvailableToolSufficient,
 } from "../../../common/modifiers";
+import { OutputUnit } from "../../../common/output";
 import { Tools } from "../../../types";
 import { queryOutputDetails } from "../adapters/mongodb-output-adapter";
 import { ItemOutputDetails } from "../interfaces/output-database-port";
-import type {
-    OutputUnit,
-    QueryOutputPrimaryPort,
-} from "../interfaces/query-output-primary-port";
+import type { QueryOutputPrimaryPort } from "../interfaces/query-output-primary-port";
 import OutputUnitSecondMappings from "../utils/OutputUnitSecondMapping";
 
 const INVALID_ITEM_NAME_ERROR =

--- a/api/src/functions/query-output/domain/output-calculator.ts
+++ b/api/src/functions/query-output/domain/output-calculator.ts
@@ -3,12 +3,11 @@ import {
     getMaxToolModifier,
     isAvailableToolSufficient,
 } from "../../../common/modifiers";
-import { OutputUnit } from "../../../common/output";
+import { OutputUnit, OutputUnitSecondMappings } from "../../../common/output";
 import { Tools } from "../../../types";
 import { queryOutputDetails } from "../adapters/mongodb-output-adapter";
 import { ItemOutputDetails } from "../interfaces/output-database-port";
 import type { QueryOutputPrimaryPort } from "../interfaces/query-output-primary-port";
-import OutputUnitSecondMappings from "../utils/OutputUnitSecondMapping";
 
 const INVALID_ITEM_NAME_ERROR =
     "Invalid item name provided, must be a non-empty string";

--- a/api/src/functions/query-output/handler.ts
+++ b/api/src/functions/query-output/handler.ts
@@ -1,8 +1,8 @@
 import type { QueryOutputArgs } from "../../graphql/schema";
 import type { GraphQLEventHandler } from "../../interfaces/GraphQLEventHandler";
 import { calculateOutput } from "./domain/output-calculator";
-import { OutputUnit } from "./interfaces/query-output-primary-port";
 import { ToolSchemaMap } from "../../common/modifiers";
+import { OutputUnit } from "../../common/output";
 
 const handler: GraphQLEventHandler<QueryOutputArgs, number> = async (event) => {
     const { name, workers, unit, maxAvailableTool, creator } = event.arguments;

--- a/api/src/functions/query-output/interfaces/query-output-primary-port.ts
+++ b/api/src/functions/query-output/interfaces/query-output-primary-port.ts
@@ -1,10 +1,5 @@
+import { OutputUnit } from "../../../common/output";
 import { Tools } from "../../../types";
-
-enum OutputUnit {
-    SECONDS = "SECONDS",
-    MINUTES = "MINUTES",
-    GAME_DAYS = "GAME_DAYS",
-}
 
 interface QueryOutputPrimaryPort {
     (input: {
@@ -16,4 +11,4 @@ interface QueryOutputPrimaryPort {
     }): Promise<number>;
 }
 
-export { OutputUnit, QueryOutputPrimaryPort };
+export { QueryOutputPrimaryPort };

--- a/api/src/functions/query-output/utils/OutputUnitSecondMapping.ts
+++ b/api/src/functions/query-output/utils/OutputUnitSecondMapping.ts
@@ -1,9 +1,0 @@
-import { OutputUnit } from "../../../common/output";
-
-const OutputUnitSecondMappings: Readonly<Record<OutputUnit, number>> = {
-    [OutputUnit.SECONDS]: 1,
-    [OutputUnit.MINUTES]: 60,
-    [OutputUnit.GAME_DAYS]: 435,
-};
-
-export default OutputUnitSecondMappings;

--- a/api/src/functions/query-output/utils/OutputUnitSecondMapping.ts
+++ b/api/src/functions/query-output/utils/OutputUnitSecondMapping.ts
@@ -1,4 +1,4 @@
-import { OutputUnit } from "../interfaces/query-output-primary-port";
+import { OutputUnit } from "../../../common/output";
 
 const OutputUnitSecondMappings: Readonly<Record<OutputUnit, number>> = {
     [OutputUnit.SECONDS]: 1,

--- a/api/src/functions/query-requirements/handler.ts
+++ b/api/src/functions/query-requirements/handler.ts
@@ -4,12 +4,30 @@ import type { QueryRequirementArgs, Requirement } from "../../graphql/schema";
 import type { GraphQLEventHandler } from "../../interfaces/GraphQLEventHandler";
 import { queryRequirements } from "./domain/query-requirements";
 
+const INVALID_ARGUMENT_ERROR =
+    "Invalid arguments: Must provide output unit when querying amounts";
+
+const amountFields = new Set([
+    "amount",
+    "creators/amount",
+    "creators/demands/amount",
+]);
+
 const handler: GraphQLEventHandler<
     QueryRequirementArgs,
     Requirement[]
 > = async (event) => {
     const { name, workers, unit, maxAvailableTool, creatorOverrides } =
         event.arguments;
+    const { selectionSetList } = event.info;
+
+    const selectedAmountFields = selectionSetList.filter((value) =>
+        amountFields.has(value)
+    );
+
+    if (selectedAmountFields.length > 0 && !unit) {
+        throw new Error(INVALID_ARGUMENT_ERROR);
+    }
 
     return await queryRequirements({
         name,

--- a/api/src/functions/query-requirements/handler.ts
+++ b/api/src/functions/query-requirements/handler.ts
@@ -1,4 +1,5 @@
 import { ToolSchemaMap } from "../../common/modifiers";
+import { OutputUnit } from "../../common/output";
 import type { QueryRequirementArgs, Requirement } from "../../graphql/schema";
 import type { GraphQLEventHandler } from "../../interfaces/GraphQLEventHandler";
 import { queryRequirements } from "./domain/query-requirements";
@@ -7,12 +8,13 @@ const handler: GraphQLEventHandler<
     QueryRequirementArgs,
     Requirement[]
 > = async (event) => {
-    const { name, workers, maxAvailableTool, creatorOverrides } =
+    const { name, workers, unit, maxAvailableTool, creatorOverrides } =
         event.arguments;
 
     return await queryRequirements({
         name,
         workers,
+        ...(unit ? { unit: OutputUnit[unit] } : {}),
         ...(maxAvailableTool
             ? { maxAvailableTool: ToolSchemaMap[maxAvailableTool] }
             : {}),

--- a/api/src/functions/query-requirements/interfaces/query-requirements-primary-port.ts
+++ b/api/src/functions/query-requirements/interfaces/query-requirements-primary-port.ts
@@ -1,3 +1,4 @@
+import { OutputUnit } from "../../../common/output";
 import { Tools } from "../../../types";
 
 type CreatorOverride = {
@@ -28,6 +29,7 @@ interface QueryRequirementsPrimaryPort {
     (input: {
         name: string;
         workers: number;
+        unit?: OutputUnit;
         maxAvailableTool?: Tools;
         creatorOverrides?: CreatorOverride[];
     }): Promise<Requirement[]>;

--- a/api/src/graphql/schema.graphql
+++ b/api/src/graphql/schema.graphql
@@ -71,6 +71,7 @@ type Query {
         workers: Int!
         maxAvailableTool: Tools
         creatorOverrides: [CreatorOverride!]
+        unit: OutputUnit
     ): [Requirement!]!
     output(
         name: ID!

--- a/ui/src/pages/Calculator/Calculator.tsx
+++ b/ui/src/pages/Calculator/Calculator.tsx
@@ -149,6 +149,7 @@ function CalculatorTab({
                             workers={workers}
                             maxAvailableTool={selectedTool}
                             creatorOverrides={selectedCreatorOverrides}
+                            unit={selectedOutputUnit}
                         />
                     ) : null}
                 </>

--- a/ui/src/pages/Calculator/__tests__/Calculator-creator-overrides.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-creator-overrides.test.tsx
@@ -872,6 +872,7 @@ describe("given items w/ multiple creators returned", () => {
                     workers: expectedWorkers,
                     maxAvailableTool: expectedTool,
                     creatorOverrides: expectedOverrides,
+                    unit: OutputUnit.Minutes,
                 }
             );
 
@@ -914,6 +915,7 @@ describe("given items w/ multiple creators returned", () => {
                     name: expectedItem,
                     workers: expectedWorkers,
                     maxAvailableTool: expectedTool,
+                    unit: OutputUnit.Minutes,
                 }
             );
 

--- a/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
@@ -261,6 +261,11 @@ test.each([
         0.001,
         "0.001",
     ],
+    [
+        "rounds optimal output to 1 decimal place (recurring close to ceil)",
+        0.8999999999999999,
+        "≈0.9",
+    ],
 ])("%s", async (_: string, actual: number, expected: string) => {
     const expectedOutput = `${expectedOutputPrefix} ${expected} per minute`;
     server.use(

--- a/ui/src/pages/Calculator/__tests__/Calculator-requirements.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-requirements.test.tsx
@@ -601,6 +601,11 @@ describe("requirements rendering given requirements", () => {
             0.001,
             "0.001",
         ],
+        [
+            "rounds amount to 1 decimal place (recurring close to ceil)",
+            0.8999999999999999,
+            "≈0.9",
+        ],
     ])("%s", async (_: string, actual: number, expected: string) => {
         server.use(
             graphql.query<GetItemRequirementsQuery>(

--- a/ui/src/pages/Calculator/__tests__/Calculator-requirements.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-requirements.test.tsx
@@ -15,7 +15,10 @@ import {
     renderWithTestProviders as render,
     wrapWithTestProviders,
 } from "../../../test/utils";
-import { GetItemRequirementsQuery } from "../../../graphql/__generated__/graphql";
+import {
+    GetItemRequirementsQuery,
+    OutputUnit,
+} from "../../../graphql/__generated__/graphql";
 import { waitForRequest } from "../../../helpers/utils";
 import Calculator from "../Calculator";
 import {
@@ -25,6 +28,7 @@ import {
     expectedItemNameQueryName,
     expectedItemDetailsQueryName,
     expectedCreatorOverrideQueryName,
+    selectOutputUnit,
 } from "./utils";
 import Requirements from "../components/Requirements";
 import { RequirementsTableRow } from "../components/Requirements/Requirements";
@@ -84,6 +88,7 @@ const requirements: RequirementsResponse[] = [
     }),
 ];
 
+const expectedWorkers = 5;
 const selectedItemName = "Selected Item";
 const selectedItem: RequirementsResponse = createRequirement({
     name: selectedItemName,
@@ -134,8 +139,7 @@ beforeEach(() => {
     server.events.removeAllListeners();
 });
 
-test("queries requirements if item and workers inputted", async () => {
-    const expectedWorkers = 5;
+test("queries requirements if item and workers inputted with default unit selected", async () => {
     const expectedRequest = waitForRequest(
         server,
         "POST",
@@ -153,6 +157,31 @@ test("queries requirements if item and workers inputted", async () => {
     expect(matchedRequestDetails.variables).toEqual({
         name: selectedItemName,
         workers: expectedWorkers,
+        maxAvailableTool: "NONE",
+        unit: OutputUnit.Minutes,
+    });
+});
+
+test("queries requirements if item and workers inputted with non-default unit selected", async () => {
+    const expectedRequest = waitForRequest(
+        server,
+        "POST",
+        expectedGraphQLAPIURL,
+        expectedRequirementsQueryName
+    );
+
+    render(<Calculator />, expectedGraphQLAPIURL);
+    await selectOutputUnit(OutputUnit.GameDays);
+    await selectItemAndWorkers({
+        itemName: selectedItemName,
+        workers: expectedWorkers,
+    });
+    const { matchedRequestDetails } = await expectedRequest;
+
+    expect(matchedRequestDetails.variables).toEqual({
+        name: selectedItemName,
+        workers: expectedWorkers,
+        unit: OutputUnit.GameDays,
         maxAvailableTool: "NONE",
     });
 });
@@ -998,7 +1027,7 @@ describe("debounces requirement requests", () => {
             "POST",
             expectedGraphQLAPIURL,
             expectedRequirementsQueryName,
-            { name: expectedItemName, workers: 3 }
+            { name: expectedItemName, workers: 3, unit: OutputUnit.Minutes }
         );
 
         const { rerender } = rtlRender(
@@ -1006,6 +1035,7 @@ describe("debounces requirement requests", () => {
                 <Requirements
                     selectedItemName={expectedItemName}
                     workers={1}
+                    unit={OutputUnit.Minutes}
                 />,
                 expectedGraphQLAPIURL
             )
@@ -1015,6 +1045,7 @@ describe("debounces requirement requests", () => {
                 <Requirements
                     selectedItemName={expectedItemName}
                     workers={2}
+                    unit={OutputUnit.Minutes}
                 />,
                 expectedGraphQLAPIURL
             )
@@ -1024,6 +1055,7 @@ describe("debounces requirement requests", () => {
                 <Requirements
                     selectedItemName={expectedItemName}
                     workers={3}
+                    unit={OutputUnit.Minutes}
                 />,
                 expectedGraphQLAPIURL
             )

--- a/ui/src/pages/Calculator/__tests__/Calculator-tool-selection.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-tool-selection.test.tsx
@@ -183,6 +183,7 @@ test("queries requirements with provided tool if non default selected", async ()
         name: item.name,
         workers: expectedWorkers,
         maxAvailableTool: expectedTool,
+        unit: OutputUnit.Minutes,
     });
 });
 
@@ -198,6 +199,7 @@ test("queries requirements again if tool is changed after first query", async ()
             name: item.name,
             workers: expectedWorkers,
             maxAvailableTool: expectedTool,
+            unit: OutputUnit.Minutes,
         }
     );
 

--- a/ui/src/pages/Calculator/components/Requirements/Requirements.tsx
+++ b/ui/src/pages/Calculator/components/Requirements/Requirements.tsx
@@ -21,6 +21,7 @@ import { gql } from "../../../../graphql/__generated__";
 import {
     CreatorOverride,
     GetItemRequirementsQuery,
+    OutputUnit,
     Tools,
 } from "../../../../graphql/__generated__/graphql";
 import { DEFAULT_DEBOUNCE, roundOutput } from "../../utils";
@@ -43,6 +44,7 @@ type RequirementsProps = {
     workers: number;
     maxAvailableTool?: Tools;
     creatorOverrides?: CreatorOverride[];
+    unit?: OutputUnit;
 };
 type Requirements = GetItemRequirementsQuery["requirement"];
 
@@ -61,8 +63,8 @@ const sortDirectionIconMap: { [key in ValidSortDirections]: IconDefinition } = {
 };
 
 const GET_ITEM_REQUIREMENTS = gql(`
-    query GetItemRequirements($name: ID!, $workers: Int!, $maxAvailableTool: Tools, $creatorOverrides: [CreatorOverride!]) {
-        requirement(name: $name, workers: $workers, maxAvailableTool: $maxAvailableTool, creatorOverrides: $creatorOverrides) {
+    query GetItemRequirements($name: ID!, $workers: Int!, $maxAvailableTool: Tools, $creatorOverrides: [CreatorOverride!], $unit: OutputUnit) {
+        requirement(name: $name, workers: $workers, maxAvailableTool: $maxAvailableTool, creatorOverrides: $creatorOverrides, unit: $unit) {
             name
             amount
             creators {
@@ -134,6 +136,7 @@ function Requirements({
     workers,
     maxAvailableTool,
     creatorOverrides,
+    unit,
 }: RequirementsProps) {
     const [getItemRequirements, { loading, data, error }] = useLazyQuery(
         GET_ITEM_REQUIREMENTS
@@ -169,6 +172,7 @@ function Requirements({
                 workers: debouncedWorkers,
                 maxAvailableTool,
                 creatorOverrides: creatorOverridesFilter,
+                unit,
             },
         });
     }, [
@@ -176,6 +180,7 @@ function Requirements({
         debouncedWorkers,
         maxAvailableTool,
         creatorOverrides,
+        unit,
     ]);
 
     if (error) {

--- a/ui/src/pages/Calculator/utils/round-output.ts
+++ b/ui/src/pages/Calculator/utils/round-output.ts
@@ -7,15 +7,16 @@ function calculateOrderOfMagnitude(output: number): number {
 }
 
 function countDigitsAfterDecimal(output: number): number {
-    const decimalPart = output - Math.floor(output);
-    return decimalPart.toString().length - 2;
+    const split = output.toString().split(".")[1];
+    return split ? split.length : 0;
 }
 
 function roundOutput(output: number): string {
+    const decimalDigits = countDigitsAfterDecimal(output);
     const approx = output + Number.EPSILON;
     if (approx < 0.1) {
         const magnitude = -calculateOrderOfMagnitude(approx);
-        if (countDigitsAfterDecimal(output) === magnitude) {
+        if (decimalDigits === magnitude) {
             return output.toString();
         }
 
@@ -23,7 +24,7 @@ function roundOutput(output: number): string {
         return `≈${Math.round(approx * factor) / factor}`;
     }
 
-    if ((output * 10) % 1 !== 0) {
+    if (decimalDigits > 1) {
         return `≈${Math.round(approx * 10) / 10}`;
     }
 


### PR DESCRIPTION
# What

Updated `requirements` query to allow providing unit for amount values
- Required if an amount property is queried, optional otherwise

Updated UI to fetch requirements with currently selected output unit
Fixed issue where recurring amounts were showing with max precision (0.899999999999 etc.)

# Why

To ensure that allow output amounts shown on the calculator are in the same unit