### PR TITLE
feat(ui): display creator breakdown

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -18,6 +18,7 @@
                 "aws-appsync-auth-link": "3.0.7",
                 "downshift": "7.6.0",
                 "graphql": "16.6.0",
+                "immutability-helper": "3.1.1",
                 "normalize.css": "8.0.1",
                 "react": "18.2.0",
                 "react-dom": "18.2.0",
@@ -9351,6 +9352,11 @@
             "engines": {
                 "node": ">=14.0.0"
             }
+        },
+        "node_modules/immutability-helper": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-3.1.1.tgz",
+            "integrity": "sha512-Q0QaXjPjwIju/28TsugCHNEASwoCcJSyJV3uO1sOIQGI0jKgm9f41Lvz0DZj3n46cNCyAZTsEYoY4C2bVRUzyQ=="
         },
         "node_modules/immutable": {
             "version": "3.7.6",
@@ -22500,6 +22506,11 @@
             "requires": {
                 "queue": "6.0.2"
             }
+        },
+        "immutability-helper": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-3.1.1.tgz",
+            "integrity": "sha512-Q0QaXjPjwIju/28TsugCHNEASwoCcJSyJV3uO1sOIQGI0jKgm9f41Lvz0DZj3n46cNCyAZTsEYoY4C2bVRUzyQ=="
         },
         "immutable": {
             "version": "3.7.6",

--- a/ui/package.json
+++ b/ui/package.json
@@ -34,6 +34,7 @@
         "aws-appsync-auth-link": "3.0.7",
         "downshift": "7.6.0",
         "graphql": "16.6.0",
+        "immutability-helper": "3.1.1",
         "normalize.css": "8.0.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",

--- a/ui/src/common/components/Input/__tests__/Input.test.tsx
+++ b/ui/src/common/components/Input/__tests__/Input.test.tsx
@@ -3,7 +3,10 @@ import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
-import { renderWithTestProviders as render } from "../../../../test/utils";
+import {
+    clickButton,
+    renderWithTestProviders as render,
+} from "../../../../test";
 import Input from "..";
 
 const expectedLabelText = "Label:";
@@ -26,15 +29,6 @@ async function typeValue({
 
     await act(async () => {
         await user.type(input, value);
-    });
-}
-
-async function clickButton({ label }: { label: string }): Promise<void> {
-    const user = userEvent.setup();
-    const button = await screen.findByRole("button", { name: label });
-
-    await act(async () => {
-        await user.click(button);
     });
 }
 

--- a/ui/src/pages/Calculator/__tests__/Calculator-requirements.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-requirements.test.tsx
@@ -855,6 +855,222 @@ describe("requirements rendering given requirements", () => {
                 })
             );
         });
+
+        test.each([
+            [
+                "descending",
+                [
+                    requirementWithMultipleCreators.creators[1],
+                    requirementWithMultipleCreators.creators[0],
+                ],
+                [
+                    requirementWithMultipleCreators.creators[0],
+                    requirementWithMultipleCreators.creators[1],
+                ],
+                1,
+            ],
+            [
+                "ascending",
+                [
+                    requirementWithMultipleCreators.creators[0],
+                    requirementWithMultipleCreators.creators[1],
+                ],
+                [
+                    requirementWithMultipleCreators.creators[1],
+                    requirementWithMultipleCreators.creators[0],
+                ],
+                2,
+            ],
+            [
+                "default",
+                [
+                    requirementWithMultipleCreators.creators[0],
+                    requirementWithMultipleCreators.creators[1],
+                ],
+                [
+                    requirementWithMultipleCreators.creators[0],
+                    requirementWithMultipleCreators.creators[1],
+                ],
+                3,
+            ],
+        ])(
+            "sorts creator breakdowns in %s order if amount column is sorted in that order",
+            async (
+                _: string,
+                unsorted: RequirementCreator[],
+                expected: RequirementCreator[],
+                numberOfClicks: number
+            ) => {
+                server.use(
+                    graphql.query<GetItemRequirementsQuery>(
+                        expectedRequirementsQueryName,
+                        (_, res, ctx) => {
+                            return res.once(
+                                ctx.data({
+                                    requirement: [
+                                        {
+                                            ...requirementWithMultipleCreators,
+                                            creators: unsorted,
+                                        },
+                                    ],
+                                })
+                            );
+                        }
+                    )
+                );
+
+                const user = userEvent.setup();
+
+                render(<Calculator />, expectedGraphQLAPIURL);
+                await selectItemAndWorkers({
+                    itemName: selectedItemName,
+                    workers: 5,
+                });
+                const requirementsTable = await screen.findByRole("table");
+                const amountColumnHeader = within(requirementsTable).getByRole(
+                    "columnheader",
+                    { name: expectedAmountColumnName }
+                );
+                await clickButton({
+                    label: expectedExpandCreatorBreakdownLabel,
+                });
+                for (let i = 0; i < numberOfClicks; i++) {
+                    await act(async () => {
+                        await user.click(amountColumnHeader);
+                    });
+                }
+                const rows = within(requirementsTable).getAllByRole("row");
+
+                for (let i = 0; i < expected.length; i++) {
+                    const expectedRowNumber = i + 2;
+                    const creatorDetails = expected[i];
+
+                    expect(
+                        within(rows[expectedRowNumber]).getByRole("cell", {
+                            name: creatorDetails.creator,
+                        })
+                    );
+                    expect(
+                        within(rows[expectedRowNumber]).getByRole("cell", {
+                            name: creatorDetails.amount.toString(),
+                        })
+                    );
+                    expect(
+                        within(rows[expectedRowNumber]).getByRole("cell", {
+                            name: creatorDetails.workers.toString(),
+                        })
+                    );
+                }
+            }
+        );
+
+        test.each([
+            [
+                "descending",
+                [
+                    requirementWithMultipleCreators.creators[1],
+                    requirementWithMultipleCreators.creators[0],
+                ],
+                [
+                    requirementWithMultipleCreators.creators[0],
+                    requirementWithMultipleCreators.creators[1],
+                ],
+                1,
+            ],
+            [
+                "ascending",
+                [
+                    requirementWithMultipleCreators.creators[0],
+                    requirementWithMultipleCreators.creators[1],
+                ],
+                [
+                    requirementWithMultipleCreators.creators[1],
+                    requirementWithMultipleCreators.creators[0],
+                ],
+                2,
+            ],
+            [
+                "default",
+                [
+                    requirementWithMultipleCreators.creators[0],
+                    requirementWithMultipleCreators.creators[1],
+                ],
+                [
+                    requirementWithMultipleCreators.creators[0],
+                    requirementWithMultipleCreators.creators[1],
+                ],
+                3,
+            ],
+        ])(
+            "sorts creator breakdowns in %s order if worker column is sorted in that order",
+            async (
+                _: string,
+                unsorted: RequirementCreator[],
+                expected: RequirementCreator[],
+                numberOfClicks: number
+            ) => {
+                server.use(
+                    graphql.query<GetItemRequirementsQuery>(
+                        expectedRequirementsQueryName,
+                        (_, res, ctx) => {
+                            return res.once(
+                                ctx.data({
+                                    requirement: [
+                                        {
+                                            ...requirementWithMultipleCreators,
+                                            creators: unsorted,
+                                        },
+                                    ],
+                                })
+                            );
+                        }
+                    )
+                );
+
+                const user = userEvent.setup();
+
+                render(<Calculator />, expectedGraphQLAPIURL);
+                await selectItemAndWorkers({
+                    itemName: selectedItemName,
+                    workers: 5,
+                });
+                const requirementsTable = await screen.findByRole("table");
+                const workersColumnHeader = within(requirementsTable).getByRole(
+                    "columnheader",
+                    { name: expectedWorkerColumnName }
+                );
+                await clickButton({
+                    label: expectedExpandCreatorBreakdownLabel,
+                });
+                for (let i = 0; i < numberOfClicks; i++) {
+                    await act(async () => {
+                        await user.click(workersColumnHeader);
+                    });
+                }
+                const rows = within(requirementsTable).getAllByRole("row");
+
+                for (let i = 0; i < expected.length; i++) {
+                    const expectedRowNumber = i + 2;
+                    const creatorDetails = expected[i];
+
+                    expect(
+                        within(rows[expectedRowNumber]).getByRole("cell", {
+                            name: creatorDetails.creator,
+                        })
+                    );
+                    expect(
+                        within(rows[expectedRowNumber]).getByRole("cell", {
+                            name: creatorDetails.amount.toString(),
+                        })
+                    );
+                    expect(
+                        within(rows[expectedRowNumber]).getByRole("cell", {
+                            name: creatorDetails.workers.toString(),
+                        })
+                    );
+                }
+            }
+        );
     });
 
     test.each([

--- a/ui/src/pages/Calculator/__tests__/Calculator-requirements.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-requirements.test.tsx
@@ -645,6 +645,7 @@ describe("requirements rendering given requirements", () => {
             server.use(
                 createRequirementsResponseHandler([
                     requirementWithMultipleCreators,
+                    ...requirementsWithSingleCreator,
                 ])
             );
         });
@@ -743,6 +744,34 @@ describe("requirements rendering given requirements", () => {
             expect(
                 await within(itemCell).findByRole("button", {
                     name: expectedExpandCreatorBreakdownLabel,
+                })
+            ).toBeVisible();
+        });
+
+        test("can toggle creator expansion even if rows sorted", async () => {
+            const user = userEvent.setup();
+
+            render(<Calculator />, expectedGraphQLAPIURL);
+            await selectItemAndWorkers({
+                itemName: selectedItemName,
+                workers: 5,
+            });
+            const requirementsTable = await screen.findByRole("table");
+            const workersColumnHeader = within(requirementsTable).getByRole(
+                "columnheader",
+                { name: expectedWorkerColumnName }
+            );
+            await act(async () => {
+                await user.click(workersColumnHeader);
+            });
+            await clickButton({ label: expectedExpandCreatorBreakdownLabel });
+            const itemCell = await screen.findByRole("cell", {
+                name: requirementWithMultipleCreators.name,
+            });
+
+            expect(
+                await within(itemCell).findByRole("button", {
+                    name: expectedCollapseCreatorBreakdownLabel,
                 })
             ).toBeVisible();
         });

--- a/ui/src/pages/Calculator/components/Requirements/RequirementRow.tsx
+++ b/ui/src/pages/Calculator/components/Requirements/RequirementRow.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
+
+import { roundOutput } from "../../utils";
+import {
+    CreatorBreakdownRow,
+    ExpandRowIconContainer,
+    NumberColumnCell,
+    TextColumnCell,
+} from "./styles";
+
+export type SingleCreatorRequirementsTableRow = {
+    name: string;
+    creator: string;
+    amount: number;
+    workers: number;
+};
+
+export type MultipleCreatorRequirementsTableRow = Omit<
+    SingleCreatorRequirementsTableRow,
+    "creator"
+> & {
+    isExpanded: boolean;
+    creatorBreakdownRows: Omit<SingleCreatorRequirementsTableRow, "name">[];
+};
+
+export type RequirementsTableRow =
+    | SingleCreatorRequirementsTableRow
+    | MultipleCreatorRequirementsTableRow;
+
+function isSingleCreatorRow(
+    row: RequirementsTableRow
+): row is SingleCreatorRequirementsTableRow {
+    const casted = row as SingleCreatorRequirementsTableRow;
+    return casted.creator !== undefined;
+}
+
+type RequirementsRowProps = {
+    row: RequirementsTableRow;
+    toggleCreatorBreakdown: (itemName: string) => void;
+};
+
+function SingleCreatorRow({ row }: { row: SingleCreatorRequirementsTableRow }) {
+    return (
+        <tr>
+            <TextColumnCell>{row.name}</TextColumnCell>
+            <TextColumnCell>{row.creator}</TextColumnCell>
+            <NumberColumnCell>{roundOutput(row.amount)}</NumberColumnCell>
+            <NumberColumnCell>{Math.ceil(row.workers)}</NumberColumnCell>
+        </tr>
+    );
+}
+
+type MultipleCreatorProps = Pick<
+    RequirementsRowProps,
+    "toggleCreatorBreakdown"
+> & {
+    row: MultipleCreatorRequirementsTableRow;
+};
+
+function MultipleCreatorRow({
+    row,
+    toggleCreatorBreakdown,
+}: MultipleCreatorProps) {
+    return (
+        <>
+            <tr>
+                <TextColumnCell>
+                    {row.isExpanded ? (
+                        <ExpandRowIconContainer
+                            role="button"
+                            aria-label={"Collapse creator breakdown"}
+                            tabIndex={0}
+                            onClick={() => toggleCreatorBreakdown(row.name)}
+                        >
+                            <FontAwesomeIcon icon={faMinus} />
+                        </ExpandRowIconContainer>
+                    ) : (
+                        <ExpandRowIconContainer
+                            role="button"
+                            aria-label={"Expand creator breakdown"}
+                            tabIndex={0}
+                            onClick={() => toggleCreatorBreakdown(row.name)}
+                        >
+                            <FontAwesomeIcon icon={faPlus} />
+                        </ExpandRowIconContainer>
+                    )}
+
+                    {row.name}
+                </TextColumnCell>
+                <TextColumnCell>
+                    {isSingleCreatorRow(row) ? row.creator : ""}
+                </TextColumnCell>
+                <NumberColumnCell>{roundOutput(row.amount)}</NumberColumnCell>
+                <NumberColumnCell>{Math.ceil(row.workers)}</NumberColumnCell>
+            </tr>
+            {row.isExpanded
+                ? row.creatorBreakdownRows.map((breakdown) => (
+                      <CreatorBreakdownRow
+                          key={`${row.name}-${breakdown.creator}`}
+                      >
+                          <TextColumnCell></TextColumnCell>
+                          <TextColumnCell>{breakdown.creator}</TextColumnCell>
+                          <NumberColumnCell>
+                              {roundOutput(breakdown.amount)}
+                          </NumberColumnCell>
+                          <NumberColumnCell>
+                              {Math.ceil(breakdown.workers)}
+                          </NumberColumnCell>
+                      </CreatorBreakdownRow>
+                  ))
+                : null}
+        </>
+    );
+}
+
+function RequirementRow({ row, toggleCreatorBreakdown }: RequirementsRowProps) {
+    return isSingleCreatorRow(row) ? (
+        <SingleCreatorRow row={row} />
+    ) : (
+        <MultipleCreatorRow
+            row={row}
+            toggleCreatorBreakdown={toggleCreatorBreakdown}
+        />
+    );
+}
+
+export { RequirementRow, isSingleCreatorRow };

--- a/ui/src/pages/Calculator/components/Requirements/RequirementRow.tsx
+++ b/ui/src/pages/Calculator/components/Requirements/RequirementRow.tsx
@@ -10,11 +10,14 @@ import {
     TextColumnCell,
 } from "./styles";
 
-export type SingleCreatorRequirementsTableRow = {
-    name: string;
-    creator: string;
+export type SortableFields = {
     amount: number;
     workers: number;
+};
+
+export type SingleCreatorRequirementsTableRow = SortableFields & {
+    name: string;
+    creator: string;
 };
 
 export type MultipleCreatorRequirementsTableRow = Omit<

--- a/ui/src/pages/Calculator/components/Requirements/Requirements.tsx
+++ b/ui/src/pages/Calculator/components/Requirements/Requirements.tsx
@@ -194,7 +194,8 @@ function Requirements({
         setWorkerSortDirection(sortDirectionOrderMap[workerSortDirection]);
     };
 
-    const toggleRowExpansion = (index: number) => {
+    const toggleRowExpansion = (itemName: string) => {
+        const index = rows.findIndex((row) => row.name === itemName);
         const row = rows[index];
         if (!isSingleCreatorRow(row)) {
             const updated = update(rows, {
@@ -290,7 +291,7 @@ function Requirements({
                     </tr>
                 </thead>
                 <tbody>
-                    {sortedRows.map((requirement, index) => (
+                    {sortedRows.map((requirement) => (
                         <tr key={requirement.name}>
                             {isSingleCreatorRow(requirement) ? (
                                 <TextColumnCell>
@@ -306,7 +307,9 @@ function Requirements({
                                             }
                                             tabIndex={0}
                                             onClick={() =>
-                                                toggleRowExpansion(index)
+                                                toggleRowExpansion(
+                                                    requirement.name
+                                                )
                                             }
                                         >
                                             <FontAwesomeIcon icon={faMinus} />
@@ -319,7 +322,9 @@ function Requirements({
                                             }
                                             tabIndex={0}
                                             onClick={() =>
-                                                toggleRowExpansion(index)
+                                                toggleRowExpansion(
+                                                    requirement.name
+                                                )
                                             }
                                         >
                                             <FontAwesomeIcon icon={faPlus} />

--- a/ui/src/pages/Calculator/components/Requirements/Requirements.tsx
+++ b/ui/src/pages/Calculator/components/Requirements/Requirements.tsx
@@ -29,16 +29,8 @@ import {
     RequirementsTableRow,
     isSingleCreatorRow,
 } from "./RequirementRow";
+import { ValidSortDirections, sortBy, sortDirectionOrderMap } from "./utils";
 
-type SortableProperty = NonNullable<
-    {
-        [K in keyof RequirementsTableRow]: RequirementsTableRow[K] extends number
-            ? K
-            : never;
-    }[keyof RequirementsTableRow]
->;
-
-type ValidSortDirections = "none" | "ascending" | "descending";
 type RequirementsProps = {
     selectedItemName: string;
     workers: number;
@@ -47,14 +39,6 @@ type RequirementsProps = {
     unit?: OutputUnit;
 };
 type Requirements = GetItemRequirementsQuery["requirement"];
-
-const sortDirectionOrderMap: {
-    [key in ValidSortDirections]: ValidSortDirections;
-} = {
-    none: "descending",
-    descending: "ascending",
-    ascending: "none",
-};
 
 const sortDirectionIconMap: { [key in ValidSortDirections]: IconDefinition } = {
     none: faSort,
@@ -76,22 +60,6 @@ const GET_ITEM_REQUIREMENTS = gql(`
         }
     }
 `);
-
-function sortBy(
-    requirements: Readonly<RequirementsTableRow[]>,
-    order: ValidSortDirections,
-    property: SortableProperty
-): RequirementsTableRow[] {
-    const reference = [...requirements];
-    switch (order) {
-        case "descending":
-            return reference.sort((a, b) => b[property] - a[property]);
-        case "ascending":
-            return reference.sort((a, b) => a[property] - b[property]);
-        default:
-            return reference;
-    }
-}
 
 function removeSelectedItemRows(
     selectedItemName: string,

--- a/ui/src/pages/Calculator/components/Requirements/index.ts
+++ b/ui/src/pages/Calculator/components/Requirements/index.ts
@@ -1,3 +1,13 @@
 import { Requirements } from "./Requirements";
+import {
+    RequirementsTableRow,
+    SingleCreatorRequirementsTableRow,
+    MultipleCreatorRequirementsTableRow,
+} from "./RequirementRow";
 
 export default Requirements;
+export type {
+    RequirementsTableRow,
+    SingleCreatorRequirementsTableRow,
+    MultipleCreatorRequirementsTableRow,
+};

--- a/ui/src/pages/Calculator/components/Requirements/styles.ts
+++ b/ui/src/pages/Calculator/components/Requirements/styles.ts
@@ -58,3 +58,8 @@ export const TextColumnCell = styled.td`
 export const NumberColumnCell = styled.td`
     text-align: end;
 `;
+
+export const ExpandRowIconContainer = styled.span`
+    cursor: pointer;
+    margin-right: 0.5rem;
+`;

--- a/ui/src/pages/Calculator/components/Requirements/styles.ts
+++ b/ui/src/pages/Calculator/components/Requirements/styles.ts
@@ -65,3 +65,7 @@ export const ExpandRowIconContainer = styled.span`
     cursor: pointer;
     margin-right: 0.5rem;
 `;
+
+export const CreatorBreakdownRow = styled.tr`
+    background-color: ${(props) => props.theme.color.tertiary.on_main};
+`;

--- a/ui/src/pages/Calculator/components/Requirements/styles.ts
+++ b/ui/src/pages/Calculator/components/Requirements/styles.ts
@@ -41,6 +41,8 @@ export const SortableHeader = styled.th<SortableHeaderProps>`
             }
         `}
 
+        cursor: pointer;
+
         button {
             border: none;
             background: none;

--- a/ui/src/pages/Calculator/components/Requirements/utils.ts
+++ b/ui/src/pages/Calculator/components/Requirements/utils.ts
@@ -1,0 +1,48 @@
+import {
+    RequirementsTableRow,
+    SortableFields,
+    isSingleCreatorRow,
+} from "./RequirementRow";
+
+export type ValidSortDirections = "none" | "ascending" | "descending";
+
+const sortDirectionOrderMap: {
+    [key in ValidSortDirections]: ValidSortDirections;
+} = {
+    none: "descending",
+    descending: "ascending",
+    ascending: "none",
+};
+
+function sortBy(
+    unsorted: Readonly<RequirementsTableRow[]>,
+    order: ValidSortDirections,
+    property: keyof SortableFields
+): RequirementsTableRow[] {
+    const sort = <T extends SortableFields>(unsorted: Readonly<T[]>) => {
+        const reference = [...unsorted];
+        switch (order) {
+            case "descending":
+                return reference.sort((a, b) => b[property] - a[property]);
+            case "ascending":
+                return reference.sort((a, b) => a[property] - b[property]);
+            default:
+                return reference;
+        }
+    };
+
+    const sortedCreators = unsorted.map((current) => {
+        if (isSingleCreatorRow(current)) {
+            return current;
+        }
+
+        return {
+            ...current,
+            creatorBreakdownRows: sort(current.creatorBreakdownRows),
+        };
+    });
+
+    return sort(sortedCreators);
+}
+
+export { sortDirectionOrderMap, sortBy };

--- a/ui/src/test/index.ts
+++ b/ui/src/test/index.ts
@@ -1,0 +1,1 @@
+export * from "./utils";

--- a/ui/src/test/utils.tsx
+++ b/ui/src/test/utils.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from "react";
 import { render } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { RouterProviderProps, RouterProvider } from "react-router-dom";
 import { ThemeProvider } from "styled-components";
@@ -65,8 +66,18 @@ function renderWithTestProviders(
     };
 }
 
+async function clickButton({ label }: { label: string }): Promise<void> {
+    const user = userEvent.setup();
+    const button = await screen.findByRole("button", { name: label });
+
+    await act(async () => {
+        await user.click(button);
+    });
+}
+
 export {
     wrapWithTestProviders,
     renderWithRouterProvider,
     renderWithTestProviders,
+    clickButton,
 };


### PR DESCRIPTION
# What

Updated requirements table to:
- Show creator name for any requirement that has one creator
- Allow expansion of requirement creation breakdown for those requirements that have multiple creators
- The breakdown shows the number of that requirement created by each creator and how many workers are being used by that creator's recipe to produce the amount shown

# Why

To provide a more granular view of how the requirements are produced