### PR TITLE
feat(ui): add autocomplete to item selector

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -16,7 +16,7 @@
                 "@fortawesome/free-solid-svg-icons": "6.4.0",
                 "@fortawesome/react-fontawesome": "0.2.0",
                 "aws-appsync-auth-link": "3.0.7",
-                "downshift": "7.6.0",
+                "downshift": "8.1.0",
                 "graphql": "16.6.0",
                 "immutability-helper": "3.1.1",
                 "normalize.css": "8.0.1",
@@ -7634,9 +7634,9 @@
             }
         },
         "node_modules/downshift": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/downshift/-/downshift-7.6.0.tgz",
-            "integrity": "sha512-VSoTVynTAsabou/hbZ6HJHUVhtBiVOjQoBsCPcQq5eAROIGP+9XKMp9asAKQ3cEcUP4oe0fFdD2pziUjhFY33Q==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/downshift/-/downshift-8.1.0.tgz",
+            "integrity": "sha512-e9EBBLZvB2G73qT272x3hExttGCH1q1usbjirm+1aMcFXuzSWhgBdbnAHPlFI2rEq61cU/kDrEIMrY+ozMhvmg==",
             "dependencies": {
                 "@babel/runtime": "^7.14.8",
                 "compute-scroll-into-view": "^2.0.4",
@@ -21214,9 +21214,9 @@
             "dev": true
         },
         "downshift": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/downshift/-/downshift-7.6.0.tgz",
-            "integrity": "sha512-VSoTVynTAsabou/hbZ6HJHUVhtBiVOjQoBsCPcQq5eAROIGP+9XKMp9asAKQ3cEcUP4oe0fFdD2pziUjhFY33Q==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/downshift/-/downshift-8.1.0.tgz",
+            "integrity": "sha512-e9EBBLZvB2G73qT272x3hExttGCH1q1usbjirm+1aMcFXuzSWhgBdbnAHPlFI2rEq61cU/kDrEIMrY+ozMhvmg==",
             "requires": {
                 "@babel/runtime": "^7.14.8",
                 "compute-scroll-into-view": "^2.0.4",

--- a/ui/package.json
+++ b/ui/package.json
@@ -32,7 +32,7 @@
         "@fortawesome/free-solid-svg-icons": "6.4.0",
         "@fortawesome/react-fontawesome": "0.2.0",
         "aws-appsync-auth-link": "3.0.7",
-        "downshift": "7.6.0",
+        "downshift": "8.1.0",
         "graphql": "16.6.0",
         "immutability-helper": "3.1.1",
         "normalize.css": "8.0.1",

--- a/ui/src/common/components/Input/Input.tsx
+++ b/ui/src/common/components/Input/Input.tsx
@@ -58,7 +58,7 @@ function Input<Type>({
     return (
         <Container className={className}>
             <label htmlFor={inputID}>{label}</label>
-            <InputContainer>
+            <InputContainer palette={palette}>
                 <StyledInput
                     id={inputID}
                     inputMode={inputMode}

--- a/ui/src/common/components/Input/__tests__/Input.test.tsx
+++ b/ui/src/common/components/Input/__tests__/Input.test.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { act, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { screen, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
 
 import {
     clickButton,
     renderWithTestProviders as render,
+    typeValue,
+    clearInput,
 } from "../../../../test";
 import Input from "..";
 
@@ -14,34 +15,6 @@ const expectedErrorMessage = "A test error message";
 const expectedClearLabel = "Clear button label";
 const invalidInput = "test";
 const mockOnChangeHandler = vi.fn();
-
-async function typeValue({
-    label,
-    value,
-}: {
-    label: string;
-    value: string;
-}): Promise<void> {
-    const user = userEvent.setup();
-    const input = await screen.findByLabelText(label, {
-        selector: "input",
-    });
-
-    await act(async () => {
-        await user.type(input, value);
-    });
-}
-
-async function clearInput({ label }: { label: string }): Promise<void> {
-    const user = userEvent.setup();
-    const input = await screen.findByLabelText(label, {
-        selector: "input",
-    });
-
-    await act(async () => {
-        await user.clear(input);
-    });
-}
 
 function parseValue(value: unknown): number {
     const parsed = Number(value);

--- a/ui/src/common/components/Input/styles.tsx
+++ b/ui/src/common/components/Input/styles.tsx
@@ -7,7 +7,15 @@ export const Container = styled.div`
     flex-direction: column;
 `;
 
-export const InputContainer = styled.div`
+type InputContainerProps = {
+    palette: ColorPalettes;
+};
+
+export const InputContainer = styled.div<InputContainerProps>`
+    ${({ theme, palette }) => css`
+        color: ${theme.color[palette].on_container};
+    `}
+
     display: flex;
     flex-direction: column;
     justify-content: center;

--- a/ui/src/common/components/Selector/AutoCompleteSelector.tsx
+++ b/ui/src/common/components/Selector/AutoCompleteSelector.tsx
@@ -4,12 +4,14 @@ import {
     UseComboboxStateChange,
     useCombobox,
 } from "downshift";
-import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
+import { faChevronDown, faTimes } from "@fortawesome/free-solid-svg-icons";
 
 import { ColorPalettes } from "../..";
 import {
+    ClearInputIcon,
     Container,
     Input,
+    InputIconContainer,
     Item,
     Menu,
     SelectorInputContainer,
@@ -23,6 +25,7 @@ interface AutoCompleteSelectorProps<Item>
     inputPlaceholder: string;
     itemToKey: (item: Item, index: number) => string;
     itemToDisplayText: (item: Item) => string;
+    clearIconLabelText?: string;
     getItemFilter?: (input: string) => (item: Item) => boolean;
     onSelectedItemChange?: (item: Item | null) => void;
     palette?: ColorPalettes;
@@ -35,6 +38,7 @@ function AutoCompleteSelector<Item>({
     labelText,
     toggleLabelText,
     inputPlaceholder,
+    clearIconLabelText,
     palette = "secondary",
     className,
     itemToDisplayText,
@@ -56,6 +60,7 @@ function AutoCompleteSelector<Item>({
 
     const {
         isOpen,
+        inputValue,
         getLabelProps,
         getInputProps,
         getToggleButtonProps,
@@ -85,14 +90,25 @@ function AutoCompleteSelector<Item>({
             <label {...getLabelProps()}>{labelText}</label>
             <SelectorInputContainer palette={palette}>
                 <Input {...getInputProps()} placeholder={inputPlaceholder} />
-                <ToggleIndicatorIcon
-                    {...getToggleButtonProps()}
-                    icon={faChevronDown}
-                    selected={isOpen}
-                    role="button"
-                    aria-hidden={false}
-                    aria-label={toggleLabelText}
-                />
+                <InputIconContainer>
+                    {inputValue ? (
+                        <ClearInputIcon
+                            icon={faTimes}
+                            role="button"
+                            onClick={() => selectItem(null)}
+                            aria-hidden={false}
+                            aria-label={clearIconLabelText}
+                        />
+                    ) : null}
+                    <ToggleIndicatorIcon
+                        {...getToggleButtonProps()}
+                        icon={faChevronDown}
+                        selected={isOpen}
+                        role="button"
+                        aria-hidden={false}
+                        aria-label={toggleLabelText}
+                    />
+                </InputIconContainer>
             </SelectorInputContainer>
             <Menu
                 {...getMenuProps()}

--- a/ui/src/common/components/Selector/AutoCompleteSelector.tsx
+++ b/ui/src/common/components/Selector/AutoCompleteSelector.tsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useState } from "react";
+import {
+    UseComboboxProps,
+    UseComboboxStateChange,
+    useCombobox,
+} from "downshift";
+import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
+
+import { ColorPalettes } from "../..";
+import {
+    Container,
+    Input,
+    Item,
+    Menu,
+    SelectorInputContainer,
+    ToggleIndicatorIcon,
+} from "./styles";
+
+interface AutoCompleteSelectorProps<Item>
+    extends Pick<UseComboboxProps<Item>, "items" | "defaultSelectedItem"> {
+    labelText: string;
+    toggleLabelText: string;
+    inputPlaceholder: string;
+    itemToKey: (item: Item, index: number) => string;
+    itemToDisplayText: (item: Item) => string;
+    getItemFilter?: (input: string) => (item: Item) => boolean;
+    onSelectedItemChange?: (item: Item | null) => void;
+    palette?: ColorPalettes;
+    className?: string;
+}
+
+function AutoCompleteSelector<Item>({
+    items,
+    defaultSelectedItem,
+    labelText,
+    toggleLabelText,
+    inputPlaceholder,
+    palette = "secondary",
+    className,
+    itemToDisplayText,
+    itemToKey,
+    getItemFilter,
+    onSelectedItemChange,
+}: AutoCompleteSelectorProps<Item>) {
+    const [filtered, setFiltered] = useState<Item[]>(items);
+
+    const handleInputChange = ({
+        inputValue,
+    }: UseComboboxStateChange<Item>) => {
+        setFiltered(
+            getItemFilter && inputValue
+                ? items.filter(getItemFilter(inputValue))
+                : items
+        );
+    };
+
+    const {
+        isOpen,
+        getLabelProps,
+        getInputProps,
+        getToggleButtonProps,
+        getMenuProps,
+        getItemProps,
+        selectItem,
+    } = useCombobox({
+        items: filtered,
+        defaultSelectedItem,
+        onInputValueChange: handleInputChange,
+        onSelectedItemChange: ({ selectedItem }) => {
+            if (onSelectedItemChange) {
+                onSelectedItemChange(selectedItem ?? null);
+            }
+        },
+        itemToString: (item) => {
+            return item ? itemToDisplayText(item) : "";
+        },
+    });
+
+    useEffect(() => {
+        selectItem(defaultSelectedItem ?? null);
+    }, [defaultSelectedItem]);
+
+    return (
+        <Container palette={palette} className={className}>
+            <label {...getLabelProps()}>{labelText}</label>
+            <SelectorInputContainer palette={palette}>
+                <Input {...getInputProps()} placeholder={inputPlaceholder} />
+                <ToggleIndicatorIcon
+                    {...getToggleButtonProps()}
+                    icon={faChevronDown}
+                    selected={isOpen}
+                    role="button"
+                    aria-hidden={false}
+                    aria-label={toggleLabelText}
+                />
+            </SelectorInputContainer>
+            <Menu
+                {...getMenuProps()}
+                isOpen={isOpen && filtered.length > 0}
+                palette={palette}
+            >
+                {isOpen ? (
+                    <>
+                        {filtered.map((item, index) => (
+                            <Item
+                                key={itemToKey(item, index)}
+                                {...getItemProps({ item, index })}
+                                palette={palette}
+                            >
+                                {itemToDisplayText(item)}
+                            </Item>
+                        ))}
+                    </>
+                ) : null}
+            </Menu>
+        </Container>
+    );
+}
+
+export { AutoCompleteSelector };

--- a/ui/src/common/components/Selector/Selector.tsx
+++ b/ui/src/common/components/Selector/Selector.tsx
@@ -6,7 +6,7 @@ import {
     Container,
     Item,
     Menu,
-    ToggleButton,
+    SelectorInputContainer,
     ToggleIndicatorIcon,
 } from "./styles";
 import { ColorPalettes } from "../..";
@@ -58,14 +58,17 @@ function Selector<Item>({
     return (
         <Container palette={palette} className={className}>
             <label {...getLabelProps()}>{labelText}</label>
-            <ToggleButton {...getToggleButtonProps()} palette={palette}>
+            <SelectorInputContainer
+                {...getToggleButtonProps()}
+                palette={palette}
+            >
                 <span>
                     {itemToDisplayText(
                         selectedItem ? selectedItem : defaultSelectedItem
                     )}
                 </span>
                 <ToggleIndicatorIcon icon={faChevronDown} selected={isOpen} />
-            </ToggleButton>
+            </SelectorInputContainer>
             <Menu {...getMenuProps()} isOpen={isOpen} palette={palette}>
                 {isOpen ? (
                     <>

--- a/ui/src/common/components/Selector/__tests__/AutoCompleteSelector.test.tsx
+++ b/ui/src/common/components/Selector/__tests__/AutoCompleteSelector.test.tsx
@@ -1,0 +1,397 @@
+import React from "react";
+import { screen, waitFor } from "@testing-library/react";
+
+import {
+    Item,
+    createItem,
+    itemToKey,
+    itemToDisplayText,
+    clickSelect,
+    clickOption,
+} from "./utils";
+import { AutoCompleteSelector } from "../AutoCompleteSelector";
+import {
+    clickButton,
+    renderWithTestProviders as render,
+    typeValue,
+    wrapWithTestProviders,
+} from "../../../../test/utils";
+import { vi } from "vitest";
+
+const items: Item[] = [createItem("test item 1"), createItem("test item 2")];
+const expectedLabelText = "Label text:";
+const expectedInputPlaceholder = "Placeholder text";
+const expectedDefaultItem = items[0];
+const expectedToggleLabelText = "Toggle label text";
+const mockOnItemChange = vi.fn();
+
+const getItemFilter = (inputValue: string) => {
+    const lowercased = inputValue.toLowerCase();
+
+    return (item: Item) => {
+        return item.name.toLowerCase().includes(lowercased);
+    };
+};
+
+beforeEach(() => {
+    mockOnItemChange.mockReset();
+});
+
+test("renders an combobox with the provided label text", async () => {
+    render(
+        <AutoCompleteSelector
+            items={items}
+            labelText={expectedLabelText}
+            toggleLabelText={expectedToggleLabelText}
+            inputPlaceholder={expectedInputPlaceholder}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+        />
+    );
+
+    expect(
+        await screen.findByRole("combobox", { name: expectedLabelText })
+    ).toBeVisible();
+});
+
+test("renders the combobox as an input", async () => {
+    render(
+        <AutoCompleteSelector
+            items={items}
+            labelText={expectedLabelText}
+            toggleLabelText={expectedToggleLabelText}
+            inputPlaceholder={expectedInputPlaceholder}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+        />
+    );
+
+    expect(
+        await screen.findByLabelText(expectedLabelText, {
+            selector: "input",
+        })
+    ).toBeVisible();
+});
+
+test("shows placeholder text if a default value is not provided", async () => {
+    render(
+        <AutoCompleteSelector
+            items={items}
+            labelText={expectedLabelText}
+            toggleLabelText={expectedToggleLabelText}
+            inputPlaceholder={expectedInputPlaceholder}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+        />
+    );
+    const combobox = await screen.findByRole("combobox", {
+        name: expectedLabelText,
+    });
+
+    expect(combobox).toHaveAttribute("placeholder", expectedInputPlaceholder);
+});
+
+test("shows the default if provided", async () => {
+    render(
+        <AutoCompleteSelector
+            items={items}
+            defaultSelectedItem={expectedDefaultItem}
+            labelText={expectedLabelText}
+            toggleLabelText={expectedToggleLabelText}
+            inputPlaceholder={expectedInputPlaceholder}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+        />
+    );
+
+    expect(
+        await screen.findByRole("combobox", { name: expectedLabelText })
+    ).toHaveValue(expectedDefaultItem.name);
+});
+
+test("does not render any options by default", async () => {
+    render(
+        <AutoCompleteSelector
+            items={items}
+            defaultSelectedItem={expectedDefaultItem}
+            labelText={expectedLabelText}
+            toggleLabelText={expectedToggleLabelText}
+            inputPlaceholder={expectedInputPlaceholder}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+        />
+    );
+    await screen.findByRole("combobox", { name: expectedLabelText });
+
+    for (const item of items) {
+        expect(
+            screen.queryByRole("option", { name: item.name })
+        ).not.toBeInTheDocument();
+    }
+});
+
+test("renders a toggle button", async () => {
+    render(
+        <AutoCompleteSelector
+            items={items}
+            defaultSelectedItem={expectedDefaultItem}
+            labelText={expectedLabelText}
+            toggleLabelText={expectedToggleLabelText}
+            inputPlaceholder={expectedInputPlaceholder}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+        />
+    );
+
+    expect(
+        await screen.findByRole("button", { name: expectedToggleLabelText })
+    ).toBeVisible();
+});
+
+test.each([
+    ["default not provided", undefined],
+    ["default provided", expectedDefaultItem],
+])(
+    "show each item provided as an option in the select when clicked if no filter specified and %s (clicking toggle button)",
+    async (_: string, defaultSelectedItem: Item | undefined) => {
+        render(
+            <AutoCompleteSelector
+                items={items}
+                labelText={expectedLabelText}
+                toggleLabelText={expectedToggleLabelText}
+                inputPlaceholder={expectedInputPlaceholder}
+                defaultSelectedItem={defaultSelectedItem}
+                itemToKey={itemToKey}
+                itemToDisplayText={itemToDisplayText}
+            />
+        );
+        await clickButton({ label: expectedToggleLabelText });
+
+        expect(await screen.findAllByRole("option")).toHaveLength(items.length);
+        for (const item of items) {
+            expect(
+                screen.getByRole("option", { name: item.name })
+            ).toBeVisible();
+        }
+    }
+);
+
+test.each([
+    ["default not provided", undefined],
+    ["default provided", expectedDefaultItem],
+])(
+    "show each item provided as an option in the select when clicked if no filter specified and %s (clicking select)",
+    async (_: string, defaultSelectedItem: Item | undefined) => {
+        render(
+            <AutoCompleteSelector
+                items={items}
+                labelText={expectedLabelText}
+                toggleLabelText={expectedToggleLabelText}
+                inputPlaceholder={expectedInputPlaceholder}
+                defaultSelectedItem={defaultSelectedItem}
+                itemToKey={itemToKey}
+                itemToDisplayText={itemToDisplayText}
+            />
+        );
+        await clickSelect(expectedLabelText);
+
+        expect(await screen.findAllByRole("option")).toHaveLength(items.length);
+        for (const item of items) {
+            expect(
+                screen.getByRole("option", { name: item.name })
+            ).toBeVisible();
+        }
+    }
+);
+
+test("changing the input value does not filter the menu if no filter provided", async () => {
+    const input = "test value";
+
+    render(
+        <AutoCompleteSelector
+            items={items}
+            labelText={expectedLabelText}
+            toggleLabelText={expectedToggleLabelText}
+            inputPlaceholder={expectedInputPlaceholder}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+        />
+    );
+    await typeValue({ label: expectedLabelText, value: input });
+    await waitFor(() =>
+        expect(
+            screen.getByRole("combobox", { name: expectedLabelText })
+        ).toHaveValue(input)
+    );
+
+    expect(screen.getAllByRole("option")).toHaveLength(items.length);
+    for (const item of items) {
+        expect(screen.getByRole("option", { name: item.name })).toBeVisible();
+    }
+});
+
+test("changing the input value filters the menu if filter is provide (no matches)", async () => {
+    const input = "unknown";
+    render(
+        <AutoCompleteSelector
+            items={items}
+            labelText={expectedLabelText}
+            toggleLabelText={expectedToggleLabelText}
+            inputPlaceholder={expectedInputPlaceholder}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+            getItemFilter={getItemFilter}
+        />
+    );
+    await typeValue({ label: expectedLabelText, value: input });
+    await waitFor(() =>
+        expect(
+            screen.getByRole("combobox", { name: expectedLabelText })
+        ).toHaveValue(input)
+    );
+
+    expect(screen.queryByRole("option")).not.toBeInTheDocument();
+});
+
+test.each([
+    ["partial match", items[0].name, [items[0]]],
+    ["all matched", "item", items],
+])(
+    "changing the input value filters the menu if filter is provided (%s)",
+    async (_: string, input: string, expectedItems: Item[]) => {
+        render(
+            <AutoCompleteSelector
+                items={items}
+                labelText={expectedLabelText}
+                toggleLabelText={expectedToggleLabelText}
+                inputPlaceholder={expectedInputPlaceholder}
+                itemToKey={itemToKey}
+                itemToDisplayText={itemToDisplayText}
+                getItemFilter={getItemFilter}
+            />
+        );
+        await typeValue({ label: expectedLabelText, value: input });
+        await waitFor(() =>
+            expect(
+                screen.getByRole("combobox", { name: expectedLabelText })
+            ).toHaveValue(input)
+        );
+
+        expect(screen.getAllByRole("option")).toHaveLength(
+            expectedItems.length
+        );
+        for (const item of expectedItems) {
+            expect(
+                screen.getByRole("option", { name: item.name })
+            ).toBeVisible();
+        }
+    }
+);
+
+test("does not apply default value as filter if filter and default provided", async () => {
+    render(
+        <AutoCompleteSelector
+            items={items}
+            labelText={expectedLabelText}
+            toggleLabelText={expectedToggleLabelText}
+            inputPlaceholder={expectedInputPlaceholder}
+            defaultSelectedItem={expectedDefaultItem}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+            getItemFilter={getItemFilter}
+        />
+    );
+    await clickSelect(expectedLabelText);
+
+    expect(screen.getAllByRole("option")).toHaveLength(items.length);
+    for (const item of items) {
+        expect(screen.getByRole("option", { name: item.name })).toBeVisible();
+    }
+});
+
+test("calls the provided on change function when an item is selected", async () => {
+    const mockOnItemChange = vi.fn();
+    const expectedItem = items[1];
+
+    render(
+        <AutoCompleteSelector
+            items={items}
+            labelText={expectedLabelText}
+            toggleLabelText={expectedToggleLabelText}
+            inputPlaceholder={expectedInputPlaceholder}
+            defaultSelectedItem={expectedDefaultItem}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+            getItemFilter={getItemFilter}
+            onSelectedItemChange={mockOnItemChange}
+        />
+    );
+    await clickSelect(expectedLabelText);
+    await clickOption(expectedItem.name);
+    await waitFor(() =>
+        expect(
+            screen.getByRole("combobox", { name: expectedLabelText })
+        ).toHaveValue(expectedItem.name)
+    );
+
+    expect(mockOnItemChange).toHaveBeenCalledTimes(1);
+    expect(mockOnItemChange).toHaveBeenCalledWith(expectedItem);
+});
+
+test("calls the provided on change function when the default item is changed", async () => {
+    const mockOnItemChange = vi.fn();
+    const expectedItem = items[1];
+    const { rerender } = render(
+        <AutoCompleteSelector
+            items={items}
+            labelText={expectedLabelText}
+            toggleLabelText={expectedToggleLabelText}
+            inputPlaceholder={expectedInputPlaceholder}
+            defaultSelectedItem={expectedDefaultItem}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+            getItemFilter={getItemFilter}
+            onSelectedItemChange={mockOnItemChange}
+        />
+    );
+
+    rerender(
+        wrapWithTestProviders(
+            <AutoCompleteSelector
+                items={items}
+                labelText={expectedLabelText}
+                toggleLabelText={expectedToggleLabelText}
+                inputPlaceholder={expectedInputPlaceholder}
+                defaultSelectedItem={expectedItem}
+                itemToKey={itemToKey}
+                itemToDisplayText={itemToDisplayText}
+                getItemFilter={getItemFilter}
+                onSelectedItemChange={mockOnItemChange}
+            />
+        )
+    );
+
+    expect(mockOnItemChange).toHaveBeenCalledTimes(1);
+    expect(mockOnItemChange).toHaveBeenCalledWith(expectedItem);
+});
+
+test("does not call the provided on change function when an invalid item is typed", async () => {
+    const input = "unknown";
+
+    render(
+        <AutoCompleteSelector
+            items={items}
+            labelText={expectedLabelText}
+            toggleLabelText={expectedToggleLabelText}
+            inputPlaceholder={expectedInputPlaceholder}
+            defaultSelectedItem={expectedDefaultItem}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+            getItemFilter={getItemFilter}
+            onSelectedItemChange={mockOnItemChange}
+        />
+    );
+    await typeValue({ label: expectedLabelText, value: input });
+
+    expect(mockOnItemChange).toHaveBeenCalledTimes(0);
+});

--- a/ui/src/common/components/Selector/__tests__/AutoCompleteSelector.test.tsx
+++ b/ui/src/common/components/Selector/__tests__/AutoCompleteSelector.test.tsx
@@ -1,20 +1,15 @@
 import React from "react";
 import { screen, waitFor } from "@testing-library/react";
 
-import {
-    Item,
-    createItem,
-    itemToKey,
-    itemToDisplayText,
-    clickSelect,
-    clickOption,
-} from "./utils";
+import { Item, createItem, itemToKey, itemToDisplayText } from "./utils";
 import { AutoCompleteSelector } from "../AutoCompleteSelector";
 import {
     clickButton,
     renderWithTestProviders as render,
     typeValue,
     wrapWithTestProviders,
+    openSelectMenu,
+    selectOption,
 } from "../../../../test/utils";
 import { vi } from "vitest";
 
@@ -193,7 +188,7 @@ test.each([
                 itemToDisplayText={itemToDisplayText}
             />
         );
-        await clickSelect(expectedLabelText);
+        await openSelectMenu({ label: expectedLabelText });
 
         expect(await screen.findAllByRole("option")).toHaveLength(items.length);
         for (const item of items) {
@@ -301,7 +296,7 @@ test("does not apply default value as filter if filter and default provided", as
             getItemFilter={getItemFilter}
         />
     );
-    await clickSelect(expectedLabelText);
+    await openSelectMenu({ label: expectedLabelText });
 
     expect(screen.getAllByRole("option")).toHaveLength(items.length);
     for (const item of items) {
@@ -326,8 +321,8 @@ test("calls the provided on change function when an item is selected", async () 
             onSelectedItemChange={mockOnItemChange}
         />
     );
-    await clickSelect(expectedLabelText);
-    await clickOption(expectedItem.name);
+    await openSelectMenu({ label: expectedLabelText });
+    await selectOption({ optionName: expectedItem.name });
     await waitFor(() =>
         expect(
             screen.getByRole("combobox", { name: expectedLabelText })

--- a/ui/src/common/components/Selector/__tests__/AutoCompleteSelector.test.tsx
+++ b/ui/src/common/components/Selector/__tests__/AutoCompleteSelector.test.tsx
@@ -18,6 +18,7 @@ const expectedLabelText = "Label text:";
 const expectedInputPlaceholder = "Placeholder text";
 const expectedDefaultItem = items[0];
 const expectedToggleLabelText = "Toggle label text";
+const expectedClearLabelText = "Clear item input";
 const mockOnItemChange = vi.fn();
 
 const getItemFilter = (inputValue: string) => {
@@ -389,4 +390,84 @@ test("does not call the provided on change function when an invalid item is type
     await typeValue({ label: expectedLabelText, value: input });
 
     expect(mockOnItemChange).toHaveBeenCalledTimes(0);
+});
+
+test("renders a clear input button with the provided label if specified and value entered", async () => {
+    render(
+        <AutoCompleteSelector
+            items={items}
+            labelText={expectedLabelText}
+            toggleLabelText={expectedToggleLabelText}
+            inputPlaceholder={expectedInputPlaceholder}
+            clearIconLabelText={expectedClearLabelText}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+        />
+    );
+    await typeValue({ label: expectedLabelText, value: "1" });
+
+    expect(
+        await screen.findByRole("button", { name: expectedClearLabelText })
+    ).toBeVisible();
+});
+
+test("does not render a clear input button if no label is specified and value entered", async () => {
+    render(
+        <AutoCompleteSelector
+            items={items}
+            labelText={expectedLabelText}
+            toggleLabelText={expectedToggleLabelText}
+            inputPlaceholder={expectedInputPlaceholder}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+        />
+    );
+    await typeValue({ label: expectedLabelText, value: "1" });
+
+    expect(
+        screen.queryByRole("button", { name: expectedClearLabelText })
+    ).not.toBeInTheDocument();
+});
+
+test("does not render a clear input button if no value entered and label is specified", async () => {
+    render(
+        <AutoCompleteSelector
+            items={items}
+            labelText={expectedLabelText}
+            toggleLabelText={expectedToggleLabelText}
+            inputPlaceholder={expectedInputPlaceholder}
+            clearIconLabelText={expectedClearLabelText}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+        />
+    );
+    await screen.findByRole("combobox", { name: expectedLabelText });
+
+    expect(
+        screen.queryByRole("button", { name: expectedClearLabelText })
+    ).not.toBeInTheDocument();
+});
+
+test("clears the currently entered value if the clear input button is pressed", async () => {
+    const expectedRemovedValue = "123";
+
+    render(
+        <AutoCompleteSelector
+            items={items}
+            labelText={expectedLabelText}
+            toggleLabelText={expectedToggleLabelText}
+            inputPlaceholder={expectedInputPlaceholder}
+            clearIconLabelText={expectedClearLabelText}
+            itemToKey={itemToKey}
+            itemToDisplayText={itemToDisplayText}
+        />
+    );
+    await typeValue({ label: expectedLabelText, value: expectedRemovedValue });
+    await clickButton({ label: expectedClearLabelText });
+
+    await waitFor(() =>
+        expect(
+            screen.getByRole("combobox", { name: expectedLabelText })
+        ).toHaveValue("")
+    );
 });

--- a/ui/src/common/components/Selector/__tests__/Selector.test.tsx
+++ b/ui/src/common/components/Selector/__tests__/Selector.test.tsx
@@ -2,20 +2,15 @@ import React from "react";
 import { screen } from "@testing-library/react";
 import { vi } from "vitest";
 
-import Selector from "..";
+import { Selector } from "../Selector";
 import {
     renderWithTestProviders as render,
     wrapWithTestProviders,
+    openSelectMenu,
+    selectOption,
 } from "../../../../test/utils";
 
-import {
-    Item,
-    createItem,
-    itemToKey,
-    itemToDisplayText,
-    clickSelect,
-    clickOption,
-} from "./utils";
+import { Item, createItem, itemToKey, itemToDisplayText } from "./utils";
 
 const items: Item[] = [createItem("test item 1"), createItem("test item 2")];
 const expectedLabelText = "Label text:";
@@ -83,7 +78,7 @@ test("show each item provided as an option in the select when clicked", async ()
             itemToDisplayText={itemToDisplayText}
         />
     );
-    await clickSelect(expectedLabelText);
+    await openSelectMenu({ label: expectedLabelText });
 
     for (const item of items) {
         expect(
@@ -104,7 +99,7 @@ test("shows the provided default item as selected in the option list by default"
             itemToDisplayText={itemToDisplayText}
         />
     );
-    await clickSelect(expectedLabelText);
+    await openSelectMenu({ label: expectedLabelText });
 
     expect(
         await screen.findByRole("option", {
@@ -126,8 +121,8 @@ test("updates the shown item when a different item is selected", async () => {
             itemToDisplayText={itemToDisplayText}
         />
     );
-    await clickSelect(expectedLabelText);
-    await clickOption(expectedShownItem.name);
+    await openSelectMenu({ label: expectedLabelText });
+    await selectOption({ optionName: expectedShownItem.name });
 
     expect(
         await screen.findByRole("combobox", { name: expectedLabelText })
@@ -147,9 +142,9 @@ test("updates the selected item in the option list after a different item is sel
             itemToDisplayText={itemToDisplayText}
         />
     );
-    await clickSelect(expectedLabelText);
-    await clickOption(expectedSelectedItem.name);
-    await clickSelect(expectedLabelText);
+    await openSelectMenu({ label: expectedLabelText });
+    await selectOption({ optionName: expectedSelectedItem.name });
+    await openSelectMenu({ label: expectedLabelText });
 
     expect(
         await screen.findByRole("option", {
@@ -179,8 +174,8 @@ test("calls the provided on change function when an item is selected", async () 
             onSelectedItemChange={mockOnItemChange}
         />
     );
-    await clickSelect(expectedLabelText);
-    await clickOption(expectedItem.name);
+    await openSelectMenu({ label: expectedLabelText });
+    await selectOption({ optionName: expectedItem.name });
     await screen.findByText(expectedItem.name);
 
     expect(mockOnItemChange).toHaveBeenCalledTimes(1);

--- a/ui/src/common/components/Selector/__tests__/Selector.test.tsx
+++ b/ui/src/common/components/Selector/__tests__/Selector.test.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { act, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { screen } from "@testing-library/react";
 import { vi } from "vitest";
 
 import Selector from "..";
@@ -9,39 +8,14 @@ import {
     wrapWithTestProviders,
 } from "../../../../test/utils";
 
-type Item = { name: string };
-
-function createItem(itemName: string): Item {
-    return { name: itemName };
-}
-
-function itemToKey(item: Item, index: number): string {
-    return `${item.name}-${index}`;
-}
-
-function itemToDisplayText(item: Item): string {
-    return item.name;
-}
-
-async function clickSelect(label: string): Promise<void> {
-    const user = userEvent.setup();
-    const select = await screen.findByRole("combobox", {
-        name: label,
-    });
-    await act(async () => {
-        await user.click(select);
-    });
-}
-
-async function clickOption(option: string): Promise<void> {
-    const user = userEvent.setup();
-    const optionElement = await screen.findByRole("option", {
-        name: option,
-    });
-    await act(async () => {
-        await user.click(optionElement);
-    });
-}
+import {
+    Item,
+    createItem,
+    itemToKey,
+    itemToDisplayText,
+    clickSelect,
+    clickOption,
+} from "./utils";
 
 const items: Item[] = [createItem("test item 1"), createItem("test item 2")];
 const expectedLabelText = "Label text:";

--- a/ui/src/common/components/Selector/__tests__/utils.ts
+++ b/ui/src/common/components/Selector/__tests__/utils.ts
@@ -1,0 +1,38 @@
+import userEvent from "@testing-library/user-event";
+import { act, screen } from "@testing-library/react";
+
+export type Item = { name: string };
+
+function createItem(itemName: string): Item {
+    return { name: itemName };
+}
+
+function itemToKey(item: Item, index: number): string {
+    return `${item.name}-${index}`;
+}
+
+function itemToDisplayText(item: Item): string {
+    return item.name;
+}
+
+async function clickSelect(label: string): Promise<void> {
+    const user = userEvent.setup();
+    const select = await screen.findByRole("combobox", {
+        name: label,
+    });
+    await act(async () => {
+        await user.click(select);
+    });
+}
+
+async function clickOption(option: string): Promise<void> {
+    const user = userEvent.setup();
+    const optionElement = await screen.findByRole("option", {
+        name: option,
+    });
+    await act(async () => {
+        await user.click(optionElement);
+    });
+}
+
+export { createItem, itemToKey, itemToDisplayText, clickSelect, clickOption };

--- a/ui/src/common/components/Selector/__tests__/utils.ts
+++ b/ui/src/common/components/Selector/__tests__/utils.ts
@@ -1,6 +1,3 @@
-import userEvent from "@testing-library/user-event";
-import { act, screen } from "@testing-library/react";
-
 export type Item = { name: string };
 
 function createItem(itemName: string): Item {
@@ -15,24 +12,4 @@ function itemToDisplayText(item: Item): string {
     return item.name;
 }
 
-async function clickSelect(label: string): Promise<void> {
-    const user = userEvent.setup();
-    const select = await screen.findByRole("combobox", {
-        name: label,
-    });
-    await act(async () => {
-        await user.click(select);
-    });
-}
-
-async function clickOption(option: string): Promise<void> {
-    const user = userEvent.setup();
-    const optionElement = await screen.findByRole("option", {
-        name: option,
-    });
-    await act(async () => {
-        await user.click(optionElement);
-    });
-}
-
-export { createItem, itemToKey, itemToDisplayText, clickSelect, clickOption };
+export { createItem, itemToKey, itemToDisplayText };

--- a/ui/src/common/components/Selector/index.ts
+++ b/ui/src/common/components/Selector/index.ts
@@ -1,3 +1,4 @@
 import { Selector } from "./Selector";
+import { AutoCompleteSelector } from "./AutoCompleteSelector";
 
-export default Selector;
+export { Selector, AutoCompleteSelector };

--- a/ui/src/common/components/Selector/styles.tsx
+++ b/ui/src/common/components/Selector/styles.tsx
@@ -75,6 +75,8 @@ export const Menu = styled.div<MenuProps>`
     border-radius: 0.25rem;
     list-style-type: none;
     cursor: pointer;
+    max-height: 9rem;
+    overflow-y: auto;
 `;
 
 export const Item = styled.li<CommonProps>`

--- a/ui/src/common/components/Selector/styles.tsx
+++ b/ui/src/common/components/Selector/styles.tsx
@@ -36,25 +36,6 @@ export const SelectorInputContainer = styled.div<CommonProps>`
     cursor: pointer;
 `;
 
-interface ToggleIndicatorIconProps extends FontAwesomeIconProps {
-    selected: boolean;
-}
-
-export const ToggleIndicatorIcon = styled(
-    FontAwesomeIcon
-)<ToggleIndicatorIconProps>`
-    ${({ selected }) => {
-        if (selected) {
-            return css`
-                transform: scaleY(-1);
-            `;
-        }
-    }}
-
-    transition: all 0.2s ease-in;
-    cursor: pointer;
-`;
-
 type MenuProps = {
     isOpen: boolean;
 } & CommonProps;
@@ -94,4 +75,39 @@ export const Input = styled.input`
     outline: none;
     background: inherit;
     border: none;
+`;
+
+export const InputIconContainer = styled.div`
+    display: flex;
+`;
+
+interface ToggleIndicatorIconProps extends FontAwesomeIconProps {
+    selected: boolean;
+}
+
+export const ToggleIndicatorIcon = styled(
+    FontAwesomeIcon
+)<ToggleIndicatorIconProps>`
+    ${({ selected }) => {
+        if (selected) {
+            return css`
+                transform: scaleY(-1);
+            `;
+        }
+    }}
+
+    transition: all 0.2s ease-in;
+    cursor: pointer;
+`;
+
+export const ClearInputIcon = styled(FontAwesomeIcon)`
+    ${({ theme }) => css`
+        :hover,
+        :focus {
+            color: ${theme.color.error.main};
+        }
+    `}
+
+    margin-right: 0.5rem;
+    cursor: pointer;
 `;

--- a/ui/src/common/components/Selector/styles.tsx
+++ b/ui/src/common/components/Selector/styles.tsx
@@ -16,7 +16,7 @@ export const Container = styled.div<CommonProps>`
     flex-direction: column;
 `;
 
-export const ToggleButton = styled.div<CommonProps>`
+export const SelectorInputContainer = styled.div<CommonProps>`
     ${({ theme, palette }) => css`
         color: ${theme.color[palette].on_container};
         background-color: ${theme.color[palette].container};
@@ -52,6 +52,7 @@ export const ToggleIndicatorIcon = styled(
     }}
 
     transition: all 0.2s ease-in;
+    cursor: pointer;
 `;
 
 type MenuProps = {
@@ -84,4 +85,11 @@ export const Item = styled.li<CommonProps>`
     `};
 
     padding: 0.5rem;
+`;
+
+export const Input = styled.input`
+    width: 100%;
+    outline: none;
+    background: inherit;
+    border: none;
 `;

--- a/ui/src/common/components/index.ts
+++ b/ui/src/common/components/index.ts
@@ -1,4 +1,4 @@
-import Selector from "./Selector";
+import { Selector, AutoCompleteSelector } from "./Selector";
 import Input from "./Input";
 
-export { Selector, Input };
+export { Selector, AutoCompleteSelector, Input };

--- a/ui/src/pages/Calculator/Calculator.tsx
+++ b/ui/src/pages/Calculator/Calculator.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useQuery } from "@apollo/client";
 
 import ItemSelector from "./components/ItemSelector";
@@ -17,7 +17,6 @@ import OptimalOutput from "./components/OptimalOutput";
 import { gql } from "../../graphql/__generated__";
 import ToolSelector from "./components/ToolSelector";
 import CreatorOverrides from "./components/CreatorOverrides";
-import { AutoCompleteSelector } from "../../common/components/Selector/AutoCompleteSelector";
 
 const GET_ITEM_NAMES_QUERY = gql(`
     query GetItemNames {
@@ -85,12 +84,6 @@ function CalculatorTab({
         }
     );
 
-    useEffect(() => {
-        if (!selectedItem && itemNameData?.distinctItemNames[0]) {
-            setSelectedItem(itemNameData.distinctItemNames[0]);
-        }
-    }, [selectedItem, itemNameData]);
-
     if (itemNamesLoading) {
         return (
             <PageContainer>
@@ -111,22 +104,6 @@ function CalculatorTab({
                         items={itemNameData.distinctItemNames}
                         onItemChange={setSelectedItem}
                         defaultSelectedItem={selectedItem}
-                    />
-                    <AutoCompleteSelector
-                        items={itemNameData.distinctItemNames}
-                        labelText="test"
-                        toggleLabelText="test toggle"
-                        inputPlaceholder="test placeholder"
-                        itemToKey={(value) => value}
-                        itemToDisplayText={(value) => value}
-                        defaultSelectedItem={itemNameData.distinctItemNames[0]}
-                        getItemFilter={(input) => {
-                            const lowercased = input.toLowerCase();
-
-                            return (item) => {
-                                return item.toLowerCase().includes(lowercased);
-                            };
-                        }}
                     />
                     <WorkerInput
                         onWorkerChange={setWorkers}

--- a/ui/src/pages/Calculator/Calculator.tsx
+++ b/ui/src/pages/Calculator/Calculator.tsx
@@ -17,6 +17,7 @@ import OptimalOutput from "./components/OptimalOutput";
 import { gql } from "../../graphql/__generated__";
 import ToolSelector from "./components/ToolSelector";
 import CreatorOverrides from "./components/CreatorOverrides";
+import { AutoCompleteSelector } from "../../common/components/Selector/AutoCompleteSelector";
 
 const GET_ITEM_NAMES_QUERY = gql(`
     query GetItemNames {
@@ -110,6 +111,22 @@ function CalculatorTab({
                         items={itemNameData.distinctItemNames}
                         onItemChange={setSelectedItem}
                         defaultSelectedItem={selectedItem}
+                    />
+                    <AutoCompleteSelector
+                        items={itemNameData.distinctItemNames}
+                        labelText="test"
+                        toggleLabelText="test toggle"
+                        inputPlaceholder="test placeholder"
+                        itemToKey={(value) => value}
+                        itemToDisplayText={(value) => value}
+                        defaultSelectedItem={itemNameData.distinctItemNames[0]}
+                        getItemFilter={(input) => {
+                            const lowercased = input.toLowerCase();
+
+                            return (item) => {
+                                return item.toLowerCase().includes(lowercased);
+                            };
+                        }}
                     />
                     <WorkerInput
                         onWorkerChange={setWorkers}

--- a/ui/src/pages/Calculator/__tests__/Calculator-creator-overrides.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-creator-overrides.test.tsx
@@ -5,7 +5,11 @@ import { setupServer } from "msw/node";
 
 import { waitForRequest } from "../../../helpers/utils";
 import Calculator from "../Calculator";
-import { renderWithTestProviders as render } from "../../../test/utils";
+import {
+    openSelectMenu,
+    renderWithTestProviders as render,
+    selectOption,
+} from "../../../test/utils";
 import {
     expectedRequirementsQueryName,
     expectedOutputQueryName,
@@ -16,9 +20,7 @@ import {
     expectedSettingsTabHeader,
     expectedCreatorOverrideQueryName,
     expectedAddCreatorOverrideButtonText,
-    openSelectMenu,
     expectedRemoveCreatorOverrideButtonText,
-    selectOption,
     expectedCalculatorTab,
     expectedCalculatorTabHeader,
     selectItemAndWorkers,
@@ -285,7 +287,7 @@ describe("given items w/ multiple creators returned", () => {
             await renderSettingsTab();
             await clickByName(expectedAddCreatorOverrideButtonText, "button");
             await openSelectMenu({
-                selectLabel: expectedItemSelectOverrideLabel,
+                label: expectedItemSelectOverrideLabel,
             });
 
             expect(
@@ -317,7 +319,7 @@ describe("given items w/ multiple creators returned", () => {
             await renderSettingsTab();
             await clickByName(expectedAddCreatorOverrideButtonText, "button");
             await openSelectMenu({
-                selectLabel: expectedItemSelectOverrideLabel,
+                label: expectedItemSelectOverrideLabel,
             });
 
             expect(
@@ -349,7 +351,7 @@ describe("given items w/ multiple creators returned", () => {
             await renderSettingsTab();
             await clickByName(expectedAddCreatorOverrideButtonText, "button");
             await openSelectMenu({
-                selectLabel: expectedCreatorSelectOverrideLabel,
+                label: expectedCreatorSelectOverrideLabel,
             });
 
             for (const { creator } of expectedOverrides) {
@@ -365,7 +367,7 @@ describe("given items w/ multiple creators returned", () => {
             await renderSettingsTab();
             await clickByName(expectedAddCreatorOverrideButtonText, "button");
             await openSelectMenu({
-                selectLabel: expectedCreatorSelectOverrideLabel,
+                label: expectedCreatorSelectOverrideLabel,
             });
 
             expect(
@@ -451,7 +453,7 @@ describe("given items w/ multiple creators returned", () => {
             await renderSettingsTab();
             await clickByName(expectedAddCreatorOverrideButtonText, "button");
             await openSelectMenu({
-                selectLabel: expectedItemSelectOverrideLabel,
+                label: expectedItemSelectOverrideLabel,
             });
 
             expect(
@@ -471,7 +473,7 @@ describe("given items w/ multiple creators returned", () => {
             await renderSettingsTab();
             await clickByName(expectedAddCreatorOverrideButtonText, "button");
             await openSelectMenu({
-                selectLabel: expectedItemSelectOverrideLabel,
+                label: expectedItemSelectOverrideLabel,
             });
 
             expect(
@@ -490,7 +492,7 @@ describe("given items w/ multiple creators returned", () => {
             await renderSettingsTab();
             await clickByName(expectedAddCreatorOverrideButtonText, "button");
             await openSelectMenu({
-                selectLabel: expectedCreatorSelectOverrideLabel,
+                label: expectedCreatorSelectOverrideLabel,
             });
 
             const creatorOptions = await screen.findAllByRole("option");
@@ -508,11 +510,11 @@ describe("given items w/ multiple creators returned", () => {
             await renderSettingsTab();
             await clickByName(expectedAddCreatorOverrideButtonText, "button");
             await selectOption({
-                selectLabel: expectedItemSelectOverrideLabel,
+                label: expectedItemSelectOverrideLabel,
                 optionName: expectedSecondItemName,
             });
             await openSelectMenu({
-                selectLabel: expectedCreatorSelectOverrideLabel,
+                label: expectedCreatorSelectOverrideLabel,
             });
 
             const creatorOptions = await screen.findAllByRole("option");
@@ -532,11 +534,11 @@ describe("given items w/ multiple creators returned", () => {
             await renderSettingsTab();
             await clickByName(expectedAddCreatorOverrideButtonText, "button");
             await selectOption({
-                selectLabel: expectedItemSelectOverrideLabel,
+                label: expectedItemSelectOverrideLabel,
                 optionName: expectedSecondItemName,
             });
             await openSelectMenu({
-                selectLabel: expectedCreatorSelectOverrideLabel,
+                label: expectedCreatorSelectOverrideLabel,
             });
 
             expect(
@@ -645,7 +647,7 @@ describe("given items w/ multiple creators returned", () => {
             });
             await act(() => user.click(removeButtons[0]));
             await openSelectMenu({
-                selectLabel: expectedItemSelectOverrideLabel,
+                label: expectedItemSelectOverrideLabel,
             });
 
             expect(
@@ -729,7 +731,7 @@ describe("given items w/ multiple creators returned", () => {
             await renderSettingsTab();
             await clickByName(expectedAddCreatorOverrideButtonText, "button");
             await selectOption({
-                selectLabel: expectedItemSelectOverrideLabel,
+                label: expectedItemSelectOverrideLabel,
                 optionName: expectedSecondItemName,
             });
             await clickByName(expectedCalculatorTab, "tab");
@@ -756,7 +758,7 @@ describe("given items w/ multiple creators returned", () => {
             await renderSettingsTab();
             await clickByName(expectedAddCreatorOverrideButtonText, "button");
             await selectOption({
-                selectLabel: expectedCreatorSelectOverrideLabel,
+                label: expectedCreatorSelectOverrideLabel,
                 optionName: expected,
             });
             await clickByName(expectedCalculatorTab, "tab");
@@ -796,11 +798,11 @@ describe("given items w/ multiple creators returned", () => {
             await renderSettingsTab();
             await clickByName(expectedAddCreatorOverrideButtonText, "button");
             await selectOption({
-                selectLabel: expectedItemSelectOverrideLabel,
+                label: expectedItemSelectOverrideLabel,
                 optionName: expectedItem,
             });
             await selectOption({
-                selectLabel: expectedCreatorSelectOverrideLabel,
+                label: expectedCreatorSelectOverrideLabel,
                 optionName: expectedCreator,
             });
             await clickByName(expectedCalculatorTab, "tab");
@@ -828,11 +830,11 @@ describe("given items w/ multiple creators returned", () => {
             await renderSettingsTab();
             await clickByName(expectedAddCreatorOverrideButtonText, "button");
             await selectOption({
-                selectLabel: expectedItemSelectOverrideLabel,
+                label: expectedItemSelectOverrideLabel,
                 optionName: expectedItem,
             });
             await selectOption({
-                selectLabel: expectedCreatorSelectOverrideLabel,
+                label: expectedCreatorSelectOverrideLabel,
                 optionName: expectedSecondItemOverrides[1].creator,
             });
             await clickByName(expectedCalculatorTab, "tab");
@@ -959,11 +961,11 @@ describe("given items w/ multiple creators returned", () => {
             await renderSettingsTab();
             await clickByName(expectedAddCreatorOverrideButtonText, "button");
             await selectOption({
-                selectLabel: expectedItemSelectOverrideLabel,
+                label: expectedItemSelectOverrideLabel,
                 optionName: expectedItem,
             });
             await selectOption({
-                selectLabel: expectedCreatorSelectOverrideLabel,
+                label: expectedCreatorSelectOverrideLabel,
                 optionName: expectedCreator,
             });
             await clickByName(expectedCalculatorTab, "tab");
@@ -996,11 +998,11 @@ describe("given items w/ multiple creators returned", () => {
             await renderSettingsTab();
             await clickByName(expectedAddCreatorOverrideButtonText, "button");
             await selectOption({
-                selectLabel: expectedItemSelectOverrideLabel,
+                label: expectedItemSelectOverrideLabel,
                 optionName: expectedItem,
             });
             await selectOption({
-                selectLabel: expectedCreatorSelectOverrideLabel,
+                label: expectedCreatorSelectOverrideLabel,
                 optionName: expectedSecondItemOverrides[1].creator,
             });
             await clickByName(expectedCalculatorTab, "tab");

--- a/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
@@ -5,6 +5,7 @@ import { act, screen, render as rtlRender } from "@testing-library/react";
 import { vi } from "vitest";
 
 import {
+    openSelectMenu,
     renderWithTestProviders as render,
     wrapWithTestProviders,
 } from "../../../test/utils";
@@ -20,7 +21,6 @@ import {
     expectedRequirementsQueryName,
     expectedSettingsTab,
     expectedSettingsTabHeader,
-    openSelectMenu,
     clickByName,
     selectItemAndWorkers,
     selectOutputUnit,
@@ -69,7 +69,7 @@ test.each(["Seconds", "Minutes", "Game days"])(
     "renders the %s option in the output unit selector",
     async (unit: string) => {
         render(<Calculator />, expectedGraphQLAPIURL);
-        await openSelectMenu({ selectLabel: expectedOutputUnitLabel });
+        await openSelectMenu({ label: expectedOutputUnitLabel });
 
         expect(
             await screen.findByRole("option", {
@@ -83,7 +83,7 @@ test("selects the Minutes option by default", async () => {
     const expected = "Minutes";
 
     render(<Calculator />, expectedGraphQLAPIURL);
-    await openSelectMenu({ selectLabel: expectedOutputUnitLabel });
+    await openSelectMenu({ label: expectedOutputUnitLabel });
 
     expect(
         await screen.findByRole("combobox", { name: expectedOutputUnitLabel })
@@ -101,7 +101,7 @@ test("updates the selected output unit if selected is changed", async () => {
 
     render(<Calculator />);
     await selectOutputUnit(OutputUnit.GameDays);
-    await openSelectMenu({ selectLabel: expectedOutputUnitLabel });
+    await openSelectMenu({ label: expectedOutputUnitLabel });
 
     expect(
         await screen.findByRole("combobox", { name: expectedOutputUnitLabel })

--- a/ui/src/pages/Calculator/__tests__/Calculator-tool-selection.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-tool-selection.test.tsx
@@ -13,13 +13,15 @@ import {
     expectedSettingsTab,
     expectedSettingsTabHeader,
     expectedToolSelectLabel,
-    openSelectMenu,
     clickByName,
     selectItemAndWorkers,
     selectTool,
     expectedCreatorOverrideQueryName,
 } from "./utils";
-import { renderWithTestProviders as render } from "../../../test/utils";
+import {
+    openSelectMenu,
+    renderWithTestProviders as render,
+} from "../../../test/utils";
 import Calculator from "../Calculator";
 import { waitForRequest } from "../../../helpers/utils";
 import { OutputUnit, Tools } from "../../../graphql/__generated__/graphql";
@@ -70,7 +72,7 @@ test.each(["None", "Stone", "Copper", "Iron", "Bronze", "Steel"])(
     "renders the %s tool option in the tool selector",
     async (tool: string) => {
         render(<Calculator />, expectedGraphQLAPIURL);
-        await openSelectMenu({ selectLabel: expectedToolSelectLabel });
+        await openSelectMenu({ label: expectedToolSelectLabel });
 
         expect(await screen.findByRole("option", { name: tool })).toBeVisible();
     }
@@ -80,7 +82,7 @@ test("renders none as the selected tool by default", async () => {
     const expected = "None";
 
     render(<Calculator />);
-    await openSelectMenu({ selectLabel: expectedToolSelectLabel });
+    await openSelectMenu({ label: expectedToolSelectLabel });
 
     expect(
         await screen.findByRole("combobox", { name: expectedToolSelectLabel })
@@ -95,7 +97,7 @@ test("updates the selected tool if selected is changed", async () => {
 
     render(<Calculator />);
     await selectTool(Tools.Iron);
-    await openSelectMenu({ selectLabel: expectedToolSelectLabel });
+    await openSelectMenu({ label: expectedToolSelectLabel });
 
     expect(
         await screen.findByRole("combobox", { name: expectedToolSelectLabel })

--- a/ui/src/pages/Calculator/__tests__/Calculator.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator.test.tsx
@@ -341,6 +341,9 @@ describe("optimal farm size note rendering", () => {
         );
 
         render(<Calculator />);
+        await selectItemAndWorkers({
+            itemName: items[0].name,
+        });
         await screen.findByRole("alert");
 
         expect(

--- a/ui/src/pages/Calculator/__tests__/utils/input-utils.ts
+++ b/ui/src/pages/Calculator/__tests__/utils/input-utils.ts
@@ -9,33 +9,7 @@ import {
 } from "./constants";
 import { OutputUnit, Tools } from "../../../../graphql/__generated__/graphql";
 import { OutputUnitSelectorMappings, ToolSelectorMappings } from "../../utils";
-
-async function openSelectMenu({ selectLabel }: { selectLabel: string }) {
-    const user = userEvent.setup();
-    const select = await screen.findByRole("combobox", { name: selectLabel });
-
-    await act(async () => {
-        await user.click(select);
-    });
-}
-
-async function selectOption({
-    optionName,
-    selectLabel,
-}: {
-    optionName: string;
-    selectLabel?: string;
-}) {
-    if (selectLabel) {
-        await openSelectMenu({ selectLabel });
-    }
-
-    const user = userEvent.setup();
-    const option = await screen.findByRole("option", { name: optionName });
-    await act(async () => {
-        await user.click(option);
-    });
-}
+import { selectOption } from "../../../../test";
 
 async function selectItemAndWorkers({
     itemName,
@@ -63,7 +37,7 @@ async function selectItemAndWorkers({
 
     if (itemName) {
         await selectOption({
-            selectLabel: expectedItemSelectLabel,
+            label: expectedItemSelectLabel,
             optionName: itemName,
         });
     }
@@ -71,14 +45,14 @@ async function selectItemAndWorkers({
 
 async function selectOutputUnit(unit: OutputUnit) {
     return selectOption({
-        selectLabel: expectedOutputUnitLabel,
+        label: expectedOutputUnitLabel,
         optionName: OutputUnitSelectorMappings[unit],
     });
 }
 
 async function selectTool(tool: Tools) {
     return selectOption({
-        selectLabel: expectedToolSelectLabel,
+        label: expectedToolSelectLabel,
         optionName: ToolSelectorMappings[tool],
     });
 }
@@ -90,11 +64,4 @@ async function clickByName(name: string, matcher: ByRoleMatcher) {
     await act(() => user.click(tab));
 }
 
-export {
-    clickByName,
-    openSelectMenu,
-    selectOption,
-    selectItemAndWorkers,
-    selectOutputUnit,
-    selectTool,
-};
+export { clickByName, selectItemAndWorkers, selectOutputUnit, selectTool };

--- a/ui/src/pages/Calculator/components/ItemSelector/ItemSelector.tsx
+++ b/ui/src/pages/Calculator/components/ItemSelector/ItemSelector.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Selector } from "../../../../common/components";
+import { AutoCompleteSelector } from "../../../../common/components";
 
 type ItemSelectorProps = {
     items: string[];
@@ -13,19 +13,29 @@ function ItemSelector({
     defaultSelectedItem,
     onItemChange,
 }: ItemSelectorProps) {
-    const handleItemChange = (selectedItem?: string) => {
+    const handleItemChange = (selectedItem: string | null) => {
         if (selectedItem) onItemChange(selectedItem);
     };
 
+    const getItemFilter = (input: string) => {
+        const lowercased = input.toLowerCase();
+
+        return (item: string) => {
+            return item.toLowerCase().includes(lowercased);
+        };
+    };
+
     return (
-        <Selector
+        <AutoCompleteSelector
             items={items}
-            itemToKey={(item) => item}
-            itemToDisplayText={(item) => item}
             labelText="Item:"
-            defaultSelectedItem={defaultSelectedItem ?? items[0]}
+            toggleLabelText="Open item list"
+            inputPlaceholder="Select an item to use in calculations"
+            defaultSelectedItem={defaultSelectedItem}
+            itemToKey={(value) => value}
+            itemToDisplayText={(value) => value}
+            getItemFilter={getItemFilter}
             onSelectedItemChange={handleItemChange}
-            palette="secondary"
         />
     );
 }

--- a/ui/src/test/utils.tsx
+++ b/ui/src/test/utils.tsx
@@ -75,9 +75,39 @@ async function clickButton({ label }: { label: string }): Promise<void> {
     });
 }
 
+async function typeValue({
+    label,
+    value,
+}: {
+    label: string;
+    value: string;
+}): Promise<void> {
+    const user = userEvent.setup();
+    const input = await screen.findByLabelText(label, {
+        selector: "input",
+    });
+
+    await act(async () => {
+        await user.type(input, value);
+    });
+}
+
+async function clearInput({ label }: { label: string }): Promise<void> {
+    const user = userEvent.setup();
+    const input = await screen.findByLabelText(label, {
+        selector: "input",
+    });
+
+    await act(async () => {
+        await user.clear(input);
+    });
+}
+
 export {
     wrapWithTestProviders,
     renderWithRouterProvider,
     renderWithTestProviders,
     clickButton,
+    typeValue,
+    clearInput,
 };

--- a/ui/src/test/utils.tsx
+++ b/ui/src/test/utils.tsx
@@ -103,6 +103,33 @@ async function clearInput({ label }: { label: string }): Promise<void> {
     });
 }
 
+async function openSelectMenu({ label }: { label: string }) {
+    const user = userEvent.setup();
+    const select = await screen.findByRole("combobox", { name: label });
+
+    await act(async () => {
+        await user.click(select);
+    });
+}
+
+async function selectOption({
+    optionName,
+    label,
+}: {
+    optionName: string;
+    label?: string;
+}) {
+    if (label) {
+        await openSelectMenu({ label });
+    }
+
+    const user = userEvent.setup();
+    const option = await screen.findByRole("option", { name: optionName });
+    await act(async () => {
+        await user.click(option);
+    });
+}
+
 export {
     wrapWithTestProviders,
     renderWithRouterProvider,
@@ -110,4 +137,6 @@ export {
     clickButton,
     typeValue,
     clearInput,
+    openSelectMenu,
+    selectOption,
 };


### PR DESCRIPTION
# What

Added a new common `AutoCompleteSelector` component that allows users to type and filter menu list
Updated item selector to use new auto complete selector

# Why

To improve the usability of the item selector, particularly when the number of items increases