### PR TITLE
fix(ui): update autocomplete selector to only render clear button if label provided

### DIFF
--- a/ui/src/common/components/Selector/AutoCompleteSelector.tsx
+++ b/ui/src/common/components/Selector/AutoCompleteSelector.tsx
@@ -91,7 +91,7 @@ function AutoCompleteSelector<Item>({
             <SelectorInputContainer palette={palette}>
                 <Input {...getInputProps()} placeholder={inputPlaceholder} />
                 <InputIconContainer>
-                    {inputValue ? (
+                    {inputValue && clearIconLabelText ? (
                         <ClearInputIcon
                             icon={faTimes}
                             role="button"

--- a/ui/src/common/components/Selector/__tests__/AutoCompleteSelector.test.tsx
+++ b/ui/src/common/components/Selector/__tests__/AutoCompleteSelector.test.tsx
@@ -424,6 +424,7 @@ test("does not render a clear input button if no label is specified and value en
     );
     await typeValue({ label: expectedLabelText, value: "1" });
 
+    expect(await screen.findAllByRole("button")).toHaveLength(1);
     expect(
         screen.queryByRole("button", { name: expectedClearLabelText })
     ).not.toBeInTheDocument();


### PR DESCRIPTION
# What

Prevent rendering of clear button if auto complete selector has not been configured with a label for that button

# Why

Prevents rendering of the component with button without a label (Accessibility issue)