### PR TITLE
feat(api): optimise query requirements lambda memory size for cost and performance

### DIFF
--- a/api/infra/main.tf
+++ b/api/infra/main.tf
@@ -341,6 +341,7 @@ resource "aws_lambda_function" "query_requirements_lambda" {
   runtime       = var.runtime
   handler       = "index.handler"
   architectures = local.architectures
+  memory_size   = 1536
 
   source_code_hash = data.archive_file.query_requirements_lambda.output_base64sha256
 


### PR DESCRIPTION
# What

Updated query requirements lambda memory size to 1536

# Why

Costs far less than current 128MB setting and has dramatic impact on performance

Output below after calling lambda to fetch requirements for "Printing press" (50 runs for each memory size)

![image](https://github.com/ashley-evans/colony-survival-calculator/assets/17100291/d8ff3313-ed27-408f-a81d-86f544c686d0)
