### PR TITLE
fix(ui): update sankey to use normal mix blend mode to align colors across browsers

### DIFF
--- a/ui/src/pages/Calculator/components/Output/components/RequirementsSankey/RequirementsSankey.tsx
+++ b/ui/src/pages/Calculator/components/Output/components/RequirementsSankey/RequirementsSankey.tsx
@@ -75,6 +75,7 @@ function RequirementsSankey({
                 enableLinkGradient={true}
                 margin={{ top: 16, bottom: 16, right: 16, left: 16 }}
                 linkOpacity={theme.type === "dark" ? 0.25 : 1}
+                linkBlendMode="normal"
             />
         </SankeyContainer>
     );


### PR DESCRIPTION
# What

Updated sankey diagram to use `mix-blend-mode: normal`

# Why

Default (Multiply) mode was causing dramatic differences in rendering on chromium based browsers vs firefox:

Chromium based:

![image](https://github.com/ashley-evans/colony-survival-calculator/assets/17100291/d712c675-9f28-4647-a620-2bf6f86426be)

Firefox:

![image](https://github.com/ashley-evans/colony-survival-calculator/assets/17100291/fef10bd4-f1de-4ad0-a1e3-fe66912bde2c)

Updating to normal aligns the two types of browsers