### PR TITLE
feat: support new version recipes

### DIFF
--- a/api/src/json/items.json
+++ b/api/src/json/items.json
@@ -75,6 +75,144 @@
         ]
     },
     {
+        "name": "Door",
+        "creator": "Artist",
+        "createTime": 180,
+        "requires": [
+            { "name": "Planks", "amount": 2 },
+            { "name": "Copper ingot", "amount": 1 }
+        ],
+        "output": 1,
+        "minimumTool": "none",
+        "maximumTool": "steel"
+    },
+    {
+        "name": "Sign",
+        "creator": "Artist",
+        "createTime": 360,
+        "requires": [{ "name": "Planks", "amount": 4 }],
+        "output": 1,
+        "minimumTool": "none",
+        "maximumTool": "steel"
+    },
+    {
+        "name": "Crown Moulding",
+        "creator": "Artist",
+        "createTime": 100,
+        "requires": [{ "name": "Planks", "amount": 1 }],
+        "output": 1,
+        "minimumTool": "none",
+        "maximumTool": "steel"
+    },
+    {
+        "name": "Wooden stairs",
+        "creator": "Artist",
+        "createTime": 120,
+        "requires": [{ "name": "Planks", "amount": 2 }],
+        "output": 1,
+        "minimumTool": "none",
+        "maximumTool": "steel"
+    },
+    {
+        "name": "Stone stairs",
+        "creator": "Artist",
+        "createTime": 180,
+        "requires": [{ "name": "Stone rubble", "amount": 5 }],
+        "output": 1,
+        "minimumTool": "none",
+        "maximumTool": "steel"
+    },
+    {
+        "name": "Window",
+        "creator": "Artist",
+        "createTime": 180,
+        "requires": [{ "name": "Planks", "amount": 2 }],
+        "output": 1,
+        "minimumTool": "none",
+        "maximumTool": "steel"
+    },
+    {
+        "name": "Flower box",
+        "creator": "Artist",
+        "createTime": 240,
+        "requires": [{ "name": "Planks", "amount": 2 }],
+        "output": 1,
+        "minimumTool": "none",
+        "maximumTool": "steel"
+    },
+    {
+        "name": "Pillar",
+        "creator": "Artist",
+        "createTime": 360,
+        "requires": [{ "name": "Stone bricks", "amount": 4 }],
+        "output": 1,
+        "minimumTool": "none",
+        "maximumTool": "steel"
+    },
+    {
+        "name": "Architrave",
+        "creator": "Artist",
+        "createTime": 360,
+        "requires": [{ "name": "Stone bricks", "amount": 4 }],
+        "output": 1,
+        "minimumTool": "none",
+        "maximumTool": "steel"
+    },
+    {
+        "name": "Corbel",
+        "creator": "Artist",
+        "createTime": 360,
+        "requires": [{ "name": "Stone bricks", "amount": 2 }],
+        "output": 1,
+        "minimumTool": "none",
+        "maximumTool": "steel"
+    },
+    {
+        "name": "Paint stripper",
+        "creator": "Artist",
+        "createTime": 360,
+        "requires": [{ "name": "Iron tools", "amount": 1 }],
+        "output": 100,
+        "minimumTool": "none",
+        "maximumTool": "steel"
+    },
+    {
+        "name": "White paint",
+        "creator": "Artist",
+        "createTime": 40,
+        "requires": [{ "name": "Hemp", "amount": 1 }],
+        "output": 1,
+        "minimumTool": "none",
+        "maximumTool": "steel"
+    },
+    {
+        "name": "Red paint",
+        "creator": "Artist",
+        "createTime": 40,
+        "requires": [{ "name": "Hollyhock", "amount": 1 }],
+        "output": 1,
+        "minimumTool": "none",
+        "maximumTool": "steel"
+    },
+    {
+        "name": "Blue paint",
+        "creator": "Artist",
+        "createTime": 40,
+        "requires": [{ "name": "Alkanet", "amount": 1 }],
+        "output": 1,
+        "minimumTool": "none",
+        "maximumTool": "steel"
+    },
+    {
+        "name": "Green paint",
+        "creator": "Artist",
+        "createTime": 40,
+        "requires": [{ "name": "Wolfsbane", "amount": 1 }],
+        "output": 1,
+        "minimumTool": "none",
+        "maximumTool": "steel"
+    },
+    {
         "name": "Candle",
         "creator": "Beekeeper",
         "createTime": 10,
@@ -590,6 +728,18 @@
         "maximumTool": "steel"
     },
     {
+        "name": "Street light",
+        "creator": "Engineer",
+        "createTime": 360,
+        "requires": [
+            { "name": "Iron wrought", "amount": 1 },
+            { "name": "Piece of glass", "amount": 1 }
+        ],
+        "output": 1,
+        "minimumTool": "copper",
+        "maximumTool": "steel"
+    },
+    {
         "name": "Dropper trap ammo",
         "creator": "Engineer",
         "createTime": 160,
@@ -740,26 +890,48 @@
         "maximumTool": "steel"
     },
     {
-        "name": "Horizontal elevator",
+        "name": "Rail station",
         "creator": "Engineer",
         "createTime": 480,
         "requires": [
             { "name": "Iron wrought", "amount": 5 },
-            { "name": "Metal gear", "amount": 4 },
-            { "name": "Bronze ingot", "amount": 2 }
+            { "name": "Metal gear", "amount": 4 }
         ],
         "output": 1,
         "minimumTool": "copper",
         "maximumTool": "steel"
     },
     {
-        "name": "Horizontal elevator shaft",
+        "name": "Rails",
         "creator": "Engineer",
         "createTime": 180,
         "requires": [
             { "name": "Iron wrought", "amount": 2 },
-            { "name": "Metal gear", "amount": 1 },
-            { "name": "Bronze ingot", "amount": 1 }
+            { "name": "Metal gear", "amount": 1 }
+        ],
+        "output": 1,
+        "minimumTool": "copper",
+        "maximumTool": "steel"
+    },
+    {
+        "name": "Rail gate",
+        "creator": "Engineer",
+        "createTime": 180,
+        "requires": [
+            { "name": "Iron wrought", "amount": 4 },
+            { "name": "Metal gear", "amount": 8 }
+        ],
+        "output": 1,
+        "minimumTool": "copper",
+        "maximumTool": "steel"
+    },
+    {
+        "name": "Archimedean Screw",
+        "creator": "Engineer",
+        "createTime": 480,
+        "requires": [
+            { "name": "Planks", "amount": 10 },
+            { "name": "Copper ingot", "amount": 5 }
         ],
         "output": 1,
         "minimumTool": "copper",
@@ -796,7 +968,7 @@
     {
         "name": "Raw fish",
         "creator": "Fisherman",
-        "createTime": 64,
+        "createTime": 125,
         "requires": [],
         "output": 1,
         "minimumTool": "none",
@@ -1150,6 +1322,18 @@
         "requires": [
             { "name": "Planks", "amount": 1 },
             { "name": "Copper ingot", "amount": 3 }
+        ],
+        "output": 1,
+        "minimumTool": "none",
+        "maximumTool": "steel"
+    },
+    {
+        "name": "Artist's Workbench",
+        "creator": "Job block crafter",
+        "createTime": 240,
+        "requires": [
+            { "name": "Planks", "amount": 4 },
+            { "name": "Copper tools", "amount": 1 }
         ],
         "output": 1,
         "minimumTool": "none",
@@ -1635,6 +1819,38 @@
         "output": 8,
         "minimumTool": "none",
         "maximumTool": "steel"
+    },
+    {
+        "name": "Tiled roof",
+        "creator": "Potter",
+        "createTime": 80,
+        "requires": [
+            { "name": "Clay", "amount": 5 },
+            { "name": "Planks", "amount": 2 },
+            { "name": "Pot of water", "amount": 1 }
+        ],
+        "output": 1,
+        "minimumTool": "none",
+        "maximumTool": "none",
+        "optionalOutputs": [
+            { "name": "Empty pot", "likelihood": 0.95, "amount": 1 }
+        ]
+    },
+    {
+        "name": "Blue tiled roof",
+        "creator": "Potter",
+        "createTime": 80,
+        "requires": [
+            { "name": "Clay", "amount": 5 },
+            { "name": "Planks", "amount": 2 },
+            { "name": "Pot of water", "amount": 1 }
+        ],
+        "output": 1,
+        "minimumTool": "none",
+        "maximumTool": "none",
+        "optionalOutputs": [
+            { "name": "Empty pot", "likelihood": 0.95, "amount": 1 }
+        ]
     },
     {
         "name": "Empty pot",
@@ -2179,6 +2395,15 @@
         "output": 1,
         "minimumTool": "none",
         "maximumTool": "none"
+    },
+    {
+        "name": "Fence",
+        "creator": "Woodcutter",
+        "createTime": 100,
+        "requires": [{ "name": "Planks", "amount": 2 }],
+        "output": 1,
+        "minimumTool": "none",
+        "maximumTool": "steel"
     },
     {
         "name": "Planks",

--- a/scripts/recipe-json-converter/README.md
+++ b/scripts/recipe-json-converter/README.md
@@ -5,7 +5,7 @@
 Requires the following Colony Survival files to be placed in a single folder for reading:
 
 -   `toolsets.json`
--   `generateblocks.json`
+-   All `generateblocks_*.json`
 -   All `recipes_*.json` files
 -   `types.json`
 -   `growables.json`
@@ -16,14 +16,27 @@ This can be found in Colony Survival's steam folder.
 
 The following amendments must be made to the Colony Survival files before executing the script:
 
+Artist's recipe's needs to be updated to:
+
+-   Rename all usages of `stonebricksnew` with `stonebricks`
+-   Align result type and names for sign recipe:
+    -   Update `signitem` to `sign`
+
+Artist sign recipe needs to be manually updated to align result type and name:
+
+-   Update `signitem` to `sign`
+
 Berry farmer recipe needs to be manually updated as does not follow same naming convention as other recipes
 
 -   Update: `gather` to `berry`
 -   Update creator: `berry` to `berryfarmer`
 
-Engineer's elevator recipe needs to be manually updated to align result type and name:
+Engineer's recipe's needs to be updated to:
 
--   Update: `elevatorstation` to `elevator`
+-   Rename `lantern` recipe to `streetlight`
+    -   Including updating `lanternitem` result to `streetlight`
+-   Align result type and names for elevator recipe:
+    -   Update `elevatorstation` to `elevator`
 
 Grinder's flour pot recipe needs to be manually duplicated to have:
 
@@ -53,7 +66,7 @@ Tanner's process recipe needs to be manually duplicated to have:
 
 Tinkerer's recipe's needs to be updated to:
 
--   Only include one planks recipe, remove entry for: `plankstiaga`
+-   Only include one planks recipe, remove entry for: `plankstaiga`
 -   Only include one tinkerer table recipe, remove entry for: `tinkerertabletaiga`
 -   Align result type and name for: slinger jobs:
     -   Update: `slingday` to: `guardslingerdayjob`

--- a/scripts/recipe-json-converter/domain/craftable-recipe-converter.ts
+++ b/scripts/recipe-json-converter/domain/craftable-recipe-converter.ts
@@ -31,7 +31,7 @@ import {
 import { JSON_FILE_EXTENSION } from "./constants";
 
 const TOOLSETS_FILE_NAME = "toolsets";
-const BLOCK_BEHAVIOURS_FILE_NAME = "generateblocks";
+const BLOCK_BEHAVIOURS_PREFIX = "generateblocks";
 const RECIPE_PREFIX = "recipes_";
 const RECIPE_EXCLUSION_SET = new Set<string>(["recipes_merchant.json"]);
 
@@ -70,20 +70,20 @@ const getBlockBehaviours = async (
     const blockBehavioursFiles = await findFiles({
         root: inputDirectoryPath,
         fileExtension: JSON_FILE_EXTENSION,
-        exact: BLOCK_BEHAVIOURS_FILE_NAME,
+        prefix: BLOCK_BEHAVIOURS_PREFIX,
     });
 
     if (blockBehavioursFiles.length === 0) {
         throw new Error(
-            `No ${BLOCK_BEHAVIOURS_FILE_NAME}${JSON_FILE_EXTENSION} file found in provided directory`
-        );
-    } else if (blockBehavioursFiles.length > 1) {
-        throw new Error(
-            `Multiple ${BLOCK_BEHAVIOURS_FILE_NAME}${JSON_FILE_EXTENSION} files found, ensure only one exists`
+            `No ${BLOCK_BEHAVIOURS_PREFIX}*${JSON_FILE_EXTENSION} file(s) found in provided directory`
         );
     }
 
-    return readBehavioursFile(blockBehavioursFiles[0] as string);
+    const behaviours = await Promise.all(
+        blockBehavioursFiles.map((path) => readBehavioursFile(path))
+    );
+
+    return behaviours.flat();
 };
 
 const getKnownRecipes = async (
@@ -106,6 +106,7 @@ const getKnownRecipes = async (
     const recipes = await Promise.all(
         filtered.map((path) => readRecipeFile(path))
     );
+
     return recipes.flat();
 };
 

--- a/scripts/recipe-json-converter/domain/recipe-dictionary.ts
+++ b/scripts/recipe-json-converter/domain/recipe-dictionary.ts
@@ -108,8 +108,7 @@ const piplizItemNameMap: Readonly<Record<string, string>> = {
     bookofknowledge: "Book of knowledge",
     elevatorshaft: "Elevator shaft",
     elevator: "Elevator",
-    elevatorhorizontal: "Horizontal elevator",
-    elevatorshafthorizontal: "Horizontal elevator shaft",
+    elevatorhorizontal: "Rail station",
     wheatporridge: "Wheat porridge",
     wheat: "Wheat",
     bow: "Bow",
@@ -237,6 +236,29 @@ const piplizItemNameMap: Readonly<Record<string, string>> = {
     quarterblockbrownlight: "Light brown quarter block",
     cotton: "Cotton",
     wisteriaplant: "Wisteria flower",
+    doorclosed: "Door",
+    sign: "Sign",
+    mouldingitem: "Crown Moulding",
+    woodstair: "Wooden stairs",
+    stonestair: "Stone stairs",
+    window: "Window",
+    flowerboxitem: "Flower box",
+    pillar: "Pillar",
+    architrave: "Architrave",
+    corbel: "Corbel",
+    paintstripped: "Paint stripper",
+    paintwhite: "White paint",
+    paintred: "Red paint",
+    paintblue: "Blue paint",
+    paintgreen: "Green paint",
+    streetlight: "Street light",
+    railitem: "Rails",
+    railgate: "Rail gate",
+    watersponge: "Archimedean Screw",
+    artisttable: "Artist's Workbench",
+    rooftool: "Tiled roof",
+    rooftoolblue: "Blue tiled roof",
+    fence: "Fence",
 };
 
 const getUserFriendlyItemName = (name: string): string | null => {
@@ -287,6 +309,7 @@ const creatorNameMap: Readonly<Record<string, string>> = {
     barley: "Barley farmer",
     hemp: "Hemp farmer",
     wisteriaplant: "Wisteria flower farmer",
+    artist: "Artist",
 };
 
 const getUserFriendlyCreatorName = (creator: string): string | null => {


### PR DESCRIPTION
# What

Updated recipe converter to:
- Handle multiple `generateblocks*.json` files
- Handle new recipes added in 0.10.0

# Why

The `generateblocks.json` file has been split into multiple files with the same schema
- Updated to merge these into one
