### PR TITLE
docs(scripts): correct block behaviour file name

### DIFF
--- a/scripts/recipe-json-converter/README.md
+++ b/scripts/recipe-json-converter/README.md
@@ -5,7 +5,7 @@
 Requires the following Colony Survival files to be placed in a single folder for reading:
 
 -   `toolsets.json`
--   All `generateblocks_*.json`
+-   All `generateblocks*.json`
 -   All `recipes_*.json` files
 -   `types.json`
 -   `growables.json`


### PR DESCRIPTION
# What

Fixed typo with `generateblocks` prefix in script instructions