### PR TITLE
feat(ui): add machine toolset checkbox

### DIFF
--- a/ui/src/common/components/Checkbox/Checkbox.tsx
+++ b/ui/src/common/components/Checkbox/Checkbox.tsx
@@ -1,0 +1,42 @@
+import React, { FormEvent, useId } from "react";
+import { Container, StyledCheckbox } from "./styles";
+import { ColorPalettes } from "../..";
+
+type CheckboxProps = {
+    label: string;
+    onChange?: (value: boolean) => void;
+    checked?: boolean;
+    palette?: ColorPalettes;
+    className?: string;
+};
+
+function Checkbox({
+    label,
+    onChange,
+    checked,
+    palette = "secondary",
+    className,
+}: CheckboxProps) {
+    const checkboxID = useId();
+
+    const handleCheckboxChange = (event: FormEvent<HTMLInputElement>) => {
+        if (onChange) {
+            onChange(event.currentTarget.checked);
+        }
+    };
+
+    return (
+        <Container className={className}>
+            <label htmlFor={checkboxID}>{label}</label>
+            <StyledCheckbox
+                id={checkboxID}
+                type="checkbox"
+                defaultChecked={checked}
+                onChange={handleCheckboxChange}
+                palette={palette}
+            />
+        </Container>
+    );
+}
+
+export { Checkbox };

--- a/ui/src/common/components/Checkbox/__tests__/Checkbox.test.tsx
+++ b/ui/src/common/components/Checkbox/__tests__/Checkbox.test.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { click, renderWithTestProviders as render } from "../../../../test";
+import { Checkbox } from "../Checkbox";
+
+const expectedLabelText = "Checkbox label:";
+const mockOnChangeHandler = vi.fn();
+
+beforeEach(() => {
+    mockOnChangeHandler.mockReset();
+});
+
+test("renders a checkbox with the provided label text", async () => {
+    render(<Checkbox label={expectedLabelText} />);
+
+    expect(
+        await screen.findByRole("checkbox", { name: expectedLabelText })
+    ).toBeVisible();
+});
+
+test("defaults to not checked if no default provided", async () => {
+    render(<Checkbox label={expectedLabelText} />);
+
+    expect(
+        await screen.findByRole("checkbox", { name: expectedLabelText })
+    ).not.toBeChecked();
+});
+
+test("defaults to checked if default of checked provided", async () => {
+    render(<Checkbox label={expectedLabelText} checked={true} />);
+
+    expect(
+        await screen.findByRole("checkbox", { name: expectedLabelText })
+    ).toBeChecked();
+});
+
+test("does not call on change handler when default assigned", async () => {
+    render(
+        <Checkbox
+            label={expectedLabelText}
+            checked={true}
+            onChange={mockOnChangeHandler}
+        />
+    );
+    await screen.findByRole("checkbox", { name: expectedLabelText });
+
+    expect(mockOnChangeHandler).not.toHaveBeenCalled();
+});
+
+test("changes checkbox to checked when clicked (default unchecked)", async () => {
+    render(
+        <Checkbox label={expectedLabelText} onChange={mockOnChangeHandler} />
+    );
+    await click({ label: expectedLabelText, role: "checkbox" });
+
+    expect(
+        screen.getByRole("checkbox", { name: expectedLabelText })
+    ).toBeChecked();
+    expect(mockOnChangeHandler).toHaveBeenCalledTimes(1);
+    expect(mockOnChangeHandler).toHaveBeenCalledWith(true);
+});
+
+test("changes checkbox to unchecked when clicked (default checked)", async () => {
+    render(
+        <Checkbox
+            label={expectedLabelText}
+            onChange={mockOnChangeHandler}
+            checked={true}
+        />
+    );
+    await click({ label: expectedLabelText, role: "checkbox" });
+
+    expect(
+        screen.getByRole("checkbox", { name: expectedLabelText })
+    ).not.toBeChecked();
+    expect(mockOnChangeHandler).toHaveBeenCalledTimes(1);
+    expect(mockOnChangeHandler).toHaveBeenCalledWith(false);
+});

--- a/ui/src/common/components/Checkbox/index.ts
+++ b/ui/src/common/components/Checkbox/index.ts
@@ -1,0 +1,3 @@
+import { Checkbox } from "./Checkbox";
+
+export default Checkbox;

--- a/ui/src/common/components/Checkbox/styles.ts
+++ b/ui/src/common/components/Checkbox/styles.ts
@@ -1,0 +1,50 @@
+import styled, { css } from "styled-components";
+import { ColorPalettes } from "../..";
+
+type PaletteProps = {
+    palette: ColorPalettes;
+};
+
+export const Container = styled.div`
+    display: flex;
+    align-items: center;
+`;
+
+export const StyledCheckbox = styled.input<PaletteProps>`
+    ${({ theme, palette }) => css`
+        border: 1px solid ${theme.color[palette].container};
+        background-color: ${theme.color[palette].container};
+
+        :hover {
+            border-color: ${theme.color[palette].on_container};
+        }
+
+        ::before {
+            content: "";
+            width: 60%;
+            height: 60%;
+        }
+
+        :checked::before {
+            background-color: ${theme.color[palette].on_container};
+            clip-path: polygon(
+                14% 44%,
+                0 65%,
+                50% 100%,
+                100% 16%,
+                80% 0%,
+                43% 62%
+            );
+        }
+    `}
+
+    appearance: none;
+    margin: 0 0 0 0.5rem;
+    width: 1.15rem;
+    height: 1.15rem;
+    border-radius: 0.25rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+`;

--- a/ui/src/common/components/Checkbox/styles.ts
+++ b/ui/src/common/components/Checkbox/styles.ts
@@ -47,4 +47,5 @@ export const StyledCheckbox = styled.input<PaletteProps>`
     display: flex;
     align-items: center;
     justify-content: center;
+    flex-shrink: 0;
 `;

--- a/ui/src/common/components/Input/Input.tsx
+++ b/ui/src/common/components/Input/Input.tsx
@@ -5,6 +5,7 @@ import {
     Container,
     IconContainer,
     InputContainer,
+    Label,
     Input as StyledInput,
 } from "./styles";
 import { ColorPalettes } from "../..";
@@ -57,7 +58,7 @@ function Input<Type>({
 
     return (
         <Container className={className}>
-            <label htmlFor={inputID}>{label}</label>
+            <Label htmlFor={inputID}>{label}</Label>
             <InputContainer palette={palette}>
                 <StyledInput
                     id={inputID}

--- a/ui/src/common/components/Input/__tests__/Input.test.tsx
+++ b/ui/src/common/components/Input/__tests__/Input.test.tsx
@@ -3,7 +3,7 @@ import { screen, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
 
 import {
-    clickButton,
+    click,
     renderWithTestProviders as render,
     typeValue,
     clearInput,
@@ -248,7 +248,7 @@ test("clears the currently entered value if the clear input button is pressed", 
         />
     );
     await typeValue({ label: expectedLabelText, value: expectedRemovedValue });
-    await clickButton({ label: expectedClearLabel });
+    await click({ label: expectedClearLabel });
 
     await waitFor(() =>
         expect(
@@ -269,7 +269,7 @@ test("provides undefined to change handler if input is cleared", async () => {
         />
     );
     await typeValue({ label: expectedLabelText, value: "123" });
-    await clickButton({ label: expectedClearLabel });
+    await click({ label: expectedClearLabel });
 
     expect(mockOnChangeHandler).toHaveBeenLastCalledWith(undefined);
 });

--- a/ui/src/common/components/Input/styles.tsx
+++ b/ui/src/common/components/Input/styles.tsx
@@ -65,3 +65,7 @@ export const IconContainer = styled.span`
     right: 0.7rem;
     cursor: pointer;
 `;
+
+export const Label = styled.label`
+    margin-bottom: 0.2rem;
+`;

--- a/ui/src/common/components/Selector/AutoCompleteSelector.tsx
+++ b/ui/src/common/components/Selector/AutoCompleteSelector.tsx
@@ -13,6 +13,7 @@ import {
     Input,
     InputIconContainer,
     Item,
+    Label,
     Menu,
     SelectorInputContainer,
     ToggleIndicatorIcon,
@@ -87,7 +88,7 @@ function AutoCompleteSelector<Item>({
 
     return (
         <Container palette={palette} className={className}>
-            <label {...getLabelProps()}>{labelText}</label>
+            <Label {...getLabelProps()}>{labelText}</Label>
             <SelectorInputContainer palette={palette}>
                 <Input {...getInputProps()} placeholder={inputPlaceholder} />
                 <InputIconContainer>

--- a/ui/src/common/components/Selector/Selector.tsx
+++ b/ui/src/common/components/Selector/Selector.tsx
@@ -5,6 +5,7 @@ import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
 import {
     Container,
     Item,
+    Label,
     Menu,
     SelectorInputContainer,
     ToggleIndicatorIcon,
@@ -57,7 +58,7 @@ function Selector<Item>({
 
     return (
         <Container palette={palette} className={className}>
-            <label {...getLabelProps()}>{labelText}</label>
+            <Label {...getLabelProps()}>{labelText}</Label>
             <SelectorInputContainer
                 {...getToggleButtonProps()}
                 palette={palette}

--- a/ui/src/common/components/Selector/__tests__/AutoCompleteSelector.test.tsx
+++ b/ui/src/common/components/Selector/__tests__/AutoCompleteSelector.test.tsx
@@ -4,7 +4,7 @@ import { screen, waitFor } from "@testing-library/react";
 import { Item, createItem, itemToKey, itemToDisplayText } from "./utils";
 import { AutoCompleteSelector } from "../AutoCompleteSelector";
 import {
-    clickButton,
+    click,
     renderWithTestProviders as render,
     typeValue,
     wrapWithTestProviders,
@@ -161,7 +161,7 @@ test.each([
                 itemToDisplayText={itemToDisplayText}
             />
         );
-        await clickButton({ label: expectedToggleLabelText });
+        await click({ label: expectedToggleLabelText });
 
         expect(await screen.findAllByRole("option")).toHaveLength(items.length);
         for (const item of items) {
@@ -464,7 +464,7 @@ test("clears the currently entered value if the clear input button is pressed", 
         />
     );
     await typeValue({ label: expectedLabelText, value: expectedRemovedValue });
-    await clickButton({ label: expectedClearLabelText });
+    await click({ label: expectedClearLabelText });
 
     await waitFor(() =>
         expect(

--- a/ui/src/common/components/Selector/styles.tsx
+++ b/ui/src/common/components/Selector/styles.tsx
@@ -117,3 +117,7 @@ export const ClearInputIcon = styled(FontAwesomeIcon)`
     margin-right: 0.5rem;
     cursor: pointer;
 `;
+
+export const Label = styled.label`
+    margin-bottom: 0.2rem;
+`;

--- a/ui/src/pages/Calculator/Calculator.tsx
+++ b/ui/src/pages/Calculator/Calculator.tsx
@@ -143,6 +143,7 @@ function CalculatorTab({
                             workers={workers}
                             outputUnit={selectedOutputUnit}
                             maxAvailableTool={selectedTool}
+                            hasMachineTools={hasMachineTools}
                             creatorOverrides={selectedCreatorOverrides}
                         />
                     ) : null}

--- a/ui/src/pages/Calculator/Calculator.tsx
+++ b/ui/src/pages/Calculator/Calculator.tsx
@@ -16,6 +16,7 @@ import { gql } from "../../graphql/__generated__";
 import ToolSelector from "./components/ToolSelector";
 import CreatorOverrides from "./components/CreatorOverrides";
 import Output from "./components/Output";
+import Checkbox from "../../common/components/Checkbox";
 
 const GET_ITEM_NAMES_QUERY = gql(`
     query GetItemNames {
@@ -40,6 +41,7 @@ type CalculatorTabProps = {
     itemState: StateProp<string | undefined>;
     workersState: StateProp<number | undefined>;
     toolState: StateProp<AvailableTools>;
+    machineToolState: StateProp<boolean>;
     outputUnitState: StateProp<OutputUnit>;
     selectedCreatorOverrides: CreatorOverride[];
 };
@@ -47,6 +49,7 @@ type CalculatorTabProps = {
 function getItemDetailsFilters(
     item?: string,
     tool?: AvailableTools,
+    hasMachineTools?: boolean,
     overrides?: CreatorOverride[]
 ): ItemsFilters {
     const creator = overrides
@@ -54,13 +57,14 @@ function getItemDetailsFilters(
         : undefined;
     return creator
         ? { name: item, creator }
-        : { name: item, optimal: { maxAvailableTool: tool } };
+        : { name: item, optimal: { maxAvailableTool: tool, hasMachineTools } };
 }
 
 function CalculatorTab({
     itemState: [selectedItem, setSelectedItem],
     workersState: [workers, setWorkers],
     toolState: [selectedTool, setSelectedTool],
+    machineToolState: [hasMachineTools, setHasMachineTools],
     outputUnitState: [selectedOutputUnit, setSelectedOutputUnit],
     selectedCreatorOverrides,
 }: CalculatorTabProps) {
@@ -76,6 +80,7 @@ function CalculatorTab({
                 filters: getItemDetailsFilters(
                     selectedItem,
                     selectedTool,
+                    hasMachineTools,
                     selectedCreatorOverrides
                 ),
             },
@@ -115,6 +120,11 @@ function CalculatorTab({
                     <OutputUnitSelector
                         onUnitChange={setSelectedOutputUnit}
                         defaultUnit={selectedOutputUnit}
+                    />
+                    <Checkbox
+                        onChange={setHasMachineTools}
+                        label="Machine tools available?"
+                        checked={hasMachineTools}
                     />
                 </>
             ) : null}
@@ -186,6 +196,7 @@ function Calculator() {
     const selectedItemState = useState<string>();
     const workersState = useState<number>();
     const selectedToolState = useState<AvailableTools>(AvailableTools.None);
+    const hasMachineToolState = useState<boolean>(false);
     const selectedOutputUnitState = useState<OutputUnit>(OutputUnit.Minutes);
     const selectedCreatorOverrides = useState<CreatorOverride[]>([]);
 
@@ -215,6 +226,7 @@ function Calculator() {
                         itemState={selectedItemState}
                         workersState={workersState}
                         toolState={selectedToolState}
+                        machineToolState={hasMachineToolState}
                         outputUnitState={selectedOutputUnitState}
                         selectedCreatorOverrides={selectedCreatorOverrides[0]}
                     />

--- a/ui/src/pages/Calculator/Calculator.tsx
+++ b/ui/src/pages/Calculator/Calculator.tsx
@@ -5,7 +5,14 @@ import ItemSelector from "./components/ItemSelector";
 import WorkerInput from "./components/WorkerInput";
 import OutputUnitSelector from "./components/OutputUnitSelector";
 import ErrorBoundary from "./components/ErrorBoundary";
-import { PageContainer, TabContainer, TabHeader, Tabs } from "./styles";
+import {
+    DefaultToolSelector,
+    MachineToolCheckbox,
+    PageContainer,
+    TabContainer,
+    TabHeader,
+    Tabs,
+} from "./styles";
 import {
     AvailableTools,
     CreatorOverride,
@@ -13,10 +20,8 @@ import {
     OutputUnit,
 } from "../../graphql/__generated__/graphql";
 import { gql } from "../../graphql/__generated__";
-import ToolSelector from "./components/ToolSelector";
 import CreatorOverrides from "./components/CreatorOverrides";
 import Output from "./components/Output";
-import Checkbox from "../../common/components/Checkbox";
 
 const GET_ITEM_NAMES_QUERY = gql(`
     query GetItemNames {
@@ -113,18 +118,18 @@ function CalculatorTab({
                         onWorkerChange={setWorkers}
                         defaultWorkers={workers}
                     />
-                    <ToolSelector
+                    <DefaultToolSelector
                         onToolChange={setSelectedTool}
                         defaultTool={selectedTool}
+                    />
+                    <MachineToolCheckbox
+                        onChange={setHasMachineTools}
+                        label="Machine tools available?"
+                        checked={hasMachineTools}
                     />
                     <OutputUnitSelector
                         onUnitChange={setSelectedOutputUnit}
                         defaultUnit={selectedOutputUnit}
-                    />
-                    <Checkbox
-                        onChange={setHasMachineTools}
-                        label="Machine tools available?"
-                        checked={hasMachineTools}
                     />
                 </>
             ) : null}

--- a/ui/src/pages/Calculator/__tests__/Calculator-creator-overrides.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-creator-overrides.test.tsx
@@ -817,7 +817,10 @@ describe("given items w/ multiple creators returned", () => {
                 {
                     filters: {
                         name: expectedItem,
-                        optimal: { maxAvailableTool: expectedTool },
+                        optimal: {
+                            maxAvailableTool: expectedTool,
+                            hasMachineTools: false,
+                        },
                     },
                 }
             );
@@ -896,6 +899,7 @@ describe("given items w/ multiple creators returned", () => {
                 workers: expectedWorkers,
                 unit: OutputUnit.Minutes,
                 maxAvailableTool: expectedTool,
+                hasMachineTools: false,
                 outputCreator: expectedCreator,
                 creatorOverrides: expectedOverrides,
             });
@@ -915,6 +919,7 @@ describe("given items w/ multiple creators returned", () => {
                     workers: expectedWorkers,
                     unit: OutputUnit.Minutes,
                     maxAvailableTool: expectedTool,
+                    hasMachineTools: false,
                 }
             );
 
@@ -976,6 +981,7 @@ describe("given items w/ multiple creators returned", () => {
                 workers: expectedWorkers,
                 unit: expectedOutputUnit,
                 maxAvailableTool: expectedTool,
+                hasMachineTools: false,
                 outputCreator: expectedCreator,
                 creatorOverrides: expectedOverrides,
             });

--- a/ui/src/pages/Calculator/__tests__/Calculator-item-selection.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-item-selection.test.tsx
@@ -310,7 +310,7 @@ test("requests item details for newly selected item if selection is changed", as
         {
             filters: {
                 name: expectedItemName,
-                optimal: { maxAvailableTool: "NONE" },
+                optimal: { maxAvailableTool: "NONE", hasMachineTools: false },
             },
         }
     );
@@ -320,14 +320,8 @@ test("requests item details for newly selected item if selection is changed", as
         label: expectedItemSelectLabel,
         optionName: expectedItemName,
     });
-    const { matchedRequestDetails } = await expectedRequest;
 
-    expect(matchedRequestDetails.variables).toEqual({
-        filters: {
-            name: expectedItemName,
-            optimal: { maxAvailableTool: "NONE" },
-        },
-    });
+    await expect(expectedRequest).resolves.not.toThrow();
 });
 
 test("does not reset the currently selected item after changing tabs", async () => {

--- a/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-output.test.tsx
@@ -5,6 +5,7 @@ import { act, screen, render as rtlRender } from "@testing-library/react";
 import { vi } from "vitest";
 
 import {
+    click,
     openSelectMenu,
     renderWithTestProviders as render,
     wrapWithTestProviders,
@@ -26,6 +27,7 @@ import {
     expectedCalculatorOutputQueryName,
     expectedLoadingOutputMessage,
     expectedRequirementsHeading,
+    expectedMachineToolCheckboxLabel,
 } from "./utils";
 import { OutputUnit } from "../../../graphql/__generated__/graphql";
 
@@ -153,6 +155,7 @@ test("queries calculator output if item and workers inputted with default unit s
         workers: expectedWorkers,
         unit: OutputUnit.Minutes,
         maxAvailableTool: "NONE",
+        hasMachineTools: false,
     });
 });
 
@@ -178,6 +181,7 @@ test("queries calculator output if item and workers inputted with non-default un
         workers: expectedWorkers,
         unit: OutputUnit.GameDays,
         maxAvailableTool: "NONE",
+        hasMachineTools: false,
     });
 });
 
@@ -406,6 +410,35 @@ describe.each([
         });
     }
 );
+
+test("queries optimal output and requirements with machine tool availability once checked", async () => {
+    const expectedWorkers = 5;
+    const expectedRequest = waitForRequest(
+        server,
+        "POST",
+        expectedGraphQLAPIURL,
+        expectedCalculatorOutputQueryName,
+        {
+            name: item.name,
+            workers: expectedWorkers,
+            unit: OutputUnit.Minutes,
+            maxAvailableTool: "NONE",
+            hasMachineTools: true,
+        }
+    );
+
+    render(<Calculator />, expectedGraphQLAPIURL);
+    await selectItemAndWorkers({
+        itemName: item.name,
+        workers: expectedWorkers,
+    });
+    await click({
+        label: expectedMachineToolCheckboxLabel,
+        role: "checkbox",
+    });
+
+    await expect(expectedRequest).resolves.not.toThrow();
+});
 
 describe("debounces output requests", () => {
     beforeAll(() => {

--- a/ui/src/pages/Calculator/__tests__/Calculator-requirements.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-requirements.test.tsx
@@ -4,7 +4,7 @@ import { setupServer } from "msw/node";
 import { screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { clickButton, renderWithTestProviders as render } from "../../../test";
+import { click, renderWithTestProviders as render } from "../../../test";
 import { Requirement } from "../../../graphql/__generated__/graphql";
 import Calculator from "../Calculator";
 import {
@@ -677,7 +677,7 @@ describe("requirements rendering given requirements", () => {
                 const itemCell = await screen.findByRole("cell", {
                     name: requirementWithSingleCreatorAndDemands.name,
                 });
-                await clickButton({
+                await click({
                     label: expectedExpandDemandBreakdownLabel,
                     inside: itemCell,
                 });
@@ -698,11 +698,11 @@ describe("requirements rendering given requirements", () => {
                 const itemCell = await screen.findByRole("cell", {
                     name: requirementWithSingleCreatorAndDemands.name,
                 });
-                await clickButton({
+                await click({
                     label: expectedExpandDemandBreakdownLabel,
                     inside: itemCell,
                 });
-                await clickButton({
+                await click({
                     label: expectedCollapseDemandBreakdownLabel,
                     inside: itemCell,
                 });
@@ -732,7 +732,7 @@ describe("requirements rendering given requirements", () => {
                     name: requirementWithSingleCreatorAndDemands.name,
                 });
 
-                await clickButton({
+                await click({
                     label: expectedExpandDemandBreakdownLabel,
                     inside: itemCell,
                 });
@@ -742,7 +742,7 @@ describe("requirements rendering given requirements", () => {
                         name: expectedCollapseDemandBreakdownLabel,
                     })
                 ).toBeVisible();
-                await clickButton({
+                await click({
                     label: expectedCollapseDemandBreakdownLabel,
                     inside: itemCell,
                 });
@@ -793,7 +793,7 @@ describe("requirements rendering given requirements", () => {
                 const itemCell = await screen.findByRole("cell", {
                     name: requirementWithSingleCreatorAndDemands.name,
                 });
-                await clickButton({
+                await click({
                     label: expectedExpandDemandBreakdownLabel,
                     inside: itemCell,
                 });
@@ -913,7 +913,7 @@ describe("requirements rendering given requirements", () => {
             const itemCell = await screen.findByRole("cell", {
                 name: requirementWithMultipleCreators.name,
             });
-            await clickButton({ label: expectedExpandCreatorBreakdownLabel });
+            await click({ label: expectedExpandCreatorBreakdownLabel });
 
             expect(
                 await within(itemCell).findByRole("button", {
@@ -931,8 +931,8 @@ describe("requirements rendering given requirements", () => {
             const itemCell = await screen.findByRole("cell", {
                 name: requirementWithMultipleCreators.name,
             });
-            await clickButton({ label: expectedExpandCreatorBreakdownLabel });
-            await clickButton({ label: expectedCollapseCreatorBreakdownLabel });
+            await click({ label: expectedExpandCreatorBreakdownLabel });
+            await click({ label: expectedCollapseCreatorBreakdownLabel });
 
             expect(
                 await within(itemCell).findByRole("button", {
@@ -958,7 +958,7 @@ describe("requirements rendering given requirements", () => {
             const itemCell = await screen.findByRole("cell", {
                 name: requirementWithMultipleCreators.name,
             });
-            await clickButton({
+            await click({
                 label: expectedExpandCreatorBreakdownLabel,
                 inside: itemCell,
             });
@@ -968,7 +968,7 @@ describe("requirements rendering given requirements", () => {
                     name: expectedCollapseCreatorBreakdownLabel,
                 })
             ).toBeVisible();
-            await clickButton({
+            await click({
                 label: expectedCollapseCreatorBreakdownLabel,
                 inside: itemCell,
             });
@@ -1017,7 +1017,7 @@ describe("requirements rendering given requirements", () => {
                 workers: 5,
             });
             const requirementsTable = await screen.findByRole("table");
-            await clickButton({ label: expectedExpandCreatorBreakdownLabel });
+            await click({ label: expectedExpandCreatorBreakdownLabel });
             const rows = within(requirementsTable).getAllByRole("row");
 
             expect(rows).toHaveLength(
@@ -1068,7 +1068,7 @@ describe("requirements rendering given requirements", () => {
                 const itemCell = await screen.findByRole("cell", {
                     name: requirementWithMultipleCreatorsAndDemands.name,
                 });
-                await clickButton({
+                await click({
                     label: expectedExpandCreatorBreakdownLabel,
                     inside: itemCell,
                 });
@@ -1092,14 +1092,14 @@ describe("requirements rendering given requirements", () => {
                 const itemCell = await screen.findByRole("cell", {
                     name: requirementWithMultipleCreatorsAndDemands.name,
                 });
-                await clickButton({
+                await click({
                     label: expectedExpandCreatorBreakdownLabel,
                     inside: itemCell,
                 });
                 const creatorCell = await screen.findByRole("cell", {
                     name: expectedCreatorWithDemands,
                 });
-                await clickButton({
+                await click({
                     label: expectedExpandDemandBreakdownLabel,
                     inside: creatorCell,
                 });
@@ -1120,18 +1120,18 @@ describe("requirements rendering given requirements", () => {
                 const itemCell = await screen.findByRole("cell", {
                     name: requirementWithMultipleCreatorsAndDemands.name,
                 });
-                await clickButton({
+                await click({
                     label: expectedExpandCreatorBreakdownLabel,
                     inside: itemCell,
                 });
                 const creatorCell = await screen.findByRole("cell", {
                     name: expectedCreatorWithDemands,
                 });
-                await clickButton({
+                await click({
                     label: expectedExpandDemandBreakdownLabel,
                     inside: creatorCell,
                 });
-                await clickButton({
+                await click({
                     label: expectedCollapseDemandBreakdownLabel,
                     inside: creatorCell,
                 });
@@ -1160,18 +1160,18 @@ describe("requirements rendering given requirements", () => {
                 const itemCell = await screen.findByRole("cell", {
                     name: requirementWithMultipleCreatorsAndDemands.name,
                 });
-                await clickButton({
+                await click({
                     label: expectedExpandCreatorBreakdownLabel,
                     inside: itemCell,
                 });
                 const creatorCell = await screen.findByRole("cell", {
                     name: expectedCreatorWithDemands,
                 });
-                await clickButton({
+                await click({
                     label: expectedExpandDemandBreakdownLabel,
                     inside: creatorCell,
                 });
-                await clickButton({
+                await click({
                     label: expectedCollapseDemandBreakdownLabel,
                     inside: creatorCell,
                 });
@@ -1230,14 +1230,14 @@ describe("requirements rendering given requirements", () => {
                 const itemCell = await screen.findByRole("cell", {
                     name: requirementWithMultipleCreatorsAndDemands.name,
                 });
-                await clickButton({
+                await click({
                     label: expectedExpandCreatorBreakdownLabel,
                     inside: itemCell,
                 });
                 const creatorCell = await screen.findByRole("cell", {
                     name: expectedCreatorWithDemands,
                 });
-                await clickButton({
+                await click({
                     label: expectedExpandDemandBreakdownLabel,
                     inside: creatorCell,
                 });
@@ -1710,10 +1710,10 @@ describe("requirements rendering given requirements", () => {
                         name: expectedWorkerColumnName,
                     }
                 );
-                await clickButton({
+                await click({
                     label: expectedExpandDemandBreakdownLabel,
                 });
-                await clickButton({
+                await click({
                     label: expectedExpandCreatorBreakdownLabel,
                 });
                 for (let i = 0; i < numberOfClicks; i++) {
@@ -2097,10 +2097,10 @@ describe("requirements rendering given requirements", () => {
                         name: expectedAmountColumnName,
                     }
                 );
-                await clickButton({
+                await click({
                     label: expectedExpandDemandBreakdownLabel,
                 });
-                await clickButton({
+                await click({
                     label: expectedExpandCreatorBreakdownLabel,
                 });
                 for (let i = 0; i < numberOfClicks; i++) {

--- a/ui/src/pages/Calculator/__tests__/Calculator-tool-selection.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-tool-selection.test.tsx
@@ -133,6 +133,7 @@ test("queries calculator with provided tool if non default selected", async () =
         workers: expectedWorkers,
         unit: OutputUnit.Minutes,
         maxAvailableTool: expectedTool,
+        hasMachineTools: false,
     });
 });
 
@@ -149,6 +150,7 @@ test("queries optimal output again if tool is changed after first query", async 
             workers: expectedWorkers,
             unit: OutputUnit.Minutes,
             maxAvailableTool: expectedTool,
+            hasMachineTools: false,
         }
     );
 
@@ -185,6 +187,7 @@ test("queries requirements with provided tool if non default selected", async ()
         name: item.name,
         workers: expectedWorkers,
         maxAvailableTool: expectedTool,
+        hasMachineTools: false,
         unit: OutputUnit.Minutes,
     });
 });
@@ -202,6 +205,7 @@ test("queries requirements again if tool is changed after first query", async ()
             workers: expectedWorkers,
             unit: OutputUnit.Minutes,
             maxAvailableTool: expectedTool,
+            hasMachineTools: false,
         }
     );
 

--- a/ui/src/pages/Calculator/__tests__/utils/constants.ts
+++ b/ui/src/pages/Calculator/__tests__/utils/constants.ts
@@ -8,6 +8,7 @@ export const expectedItemSelectLabel = "Item:";
 export const expectedWorkerInputLabel = "Workers:";
 export const expectedOutputUnitLabel = "Desired output units:";
 export const expectedToolSelectLabel = "Tools:";
+export const expectedMachineToolCheckboxLabel = "Machine tools available?";
 export const expectedOutputPrefix = "Optimal output:";
 export const expectedFarmSizeNotePrefix = "Calculations use optimal farm size:";
 export const expectedLoadingOutputMessage = "Calculating output...";

--- a/ui/src/pages/Calculator/components/Output/Output.tsx
+++ b/ui/src/pages/Calculator/components/Output/Output.tsx
@@ -17,6 +17,7 @@ type OptimalProps = {
     workers: number;
     outputUnit: OutputUnit;
     maxAvailableTool?: AvailableTools;
+    hasMachineTools?: boolean;
     creatorOverrides?: CreatorOverride[];
 };
 
@@ -25,8 +26,8 @@ type ErrorMessageProps = {
 };
 
 const GET_CALCULATOR_OUTPUT = gql(`
-    query GetCalculatorOutput($name: ID!, $workers: Int!, $unit: OutputUnit!, $maxAvailableTool: AvailableTools, $outputCreator: String, $creatorOverrides: [CreatorOverride!]) {
-        output(name: $name, workers: $workers, unit: $unit, maxAvailableTool: $maxAvailableTool, creator: $outputCreator) {
+    query GetCalculatorOutput($name: ID!, $workers: Int!, $unit: OutputUnit!, $maxAvailableTool: AvailableTools, $hasMachineTools: Boolean, $outputCreator: String, $creatorOverrides: [CreatorOverride!]) {
+        output(name: $name, workers: $workers, unit: $unit, maxAvailableTool: $maxAvailableTool, hasMachineTools: $hasMachineTools, creator: $outputCreator) {
             ... on OptimalOutput {
                 amount
             }
@@ -34,7 +35,7 @@ const GET_CALCULATOR_OUTPUT = gql(`
                 message
             }
         }
-        requirement(name: $name, workers: $workers, maxAvailableTool: $maxAvailableTool, creatorOverrides: $creatorOverrides, unit: $unit) {
+        requirement(name: $name, workers: $workers, maxAvailableTool: $maxAvailableTool, hasMachineTools: $hasMachineTools, creatorOverrides: $creatorOverrides, unit: $unit) {
             ... on Requirements {
                 requirements {
                     name
@@ -67,6 +68,7 @@ function Output({
     workers,
     outputUnit,
     maxAvailableTool,
+    hasMachineTools,
     creatorOverrides,
 }: OptimalProps) {
     const [getCalculatorOutput, { loading, data, error }] = useLazyQuery(
@@ -90,6 +92,7 @@ function Output({
                 workers: debouncedWorkers,
                 unit: outputUnit,
                 maxAvailableTool,
+                hasMachineTools,
                 outputCreator: creator,
                 creatorOverrides: creatorOverridesFilter,
             },
@@ -99,6 +102,7 @@ function Output({
         debouncedWorkers,
         outputUnit,
         maxAvailableTool,
+        hasMachineTools,
         creatorOverrides,
     ]);
 

--- a/ui/src/pages/Calculator/components/ToolSelector/ToolSelector.tsx
+++ b/ui/src/pages/Calculator/components/ToolSelector/ToolSelector.tsx
@@ -7,11 +7,16 @@ import { Selector } from "../../../../common/components";
 type ToolSelectorProps = {
     onToolChange: (unit: AvailableTools) => void;
     defaultTool?: AvailableTools;
+    className?: string;
 };
 
 const tools = Object.values(AvailableTools);
 
-function ToolSelector({ onToolChange, defaultTool }: ToolSelectorProps) {
+function ToolSelector({
+    onToolChange,
+    defaultTool,
+    className,
+}: ToolSelectorProps) {
     const handleToolChange = (selectedTool?: AvailableTools) => {
         if (selectedTool) onToolChange(selectedTool);
     };
@@ -25,6 +30,7 @@ function ToolSelector({ onToolChange, defaultTool }: ToolSelectorProps) {
             defaultSelectedItem={defaultTool ?? tools[3]}
             onSelectedItemChange={handleToolChange}
             palette="secondary"
+            className={className}
         />
     );
 }

--- a/ui/src/pages/Calculator/styles.tsx
+++ b/ui/src/pages/Calculator/styles.tsx
@@ -1,4 +1,6 @@
 import styled, { css } from "styled-components";
+import ToolSelector from "./components/ToolSelector";
+import Checkbox from "../../common/components/Checkbox";
 
 export const PageContainer = styled.div``;
 
@@ -48,3 +50,7 @@ export const TabHeader = styled.h2`
     margin-top: 0rem;
     margin-bottom: 0rem;
 `;
+
+export const DefaultToolSelector = styled(ToolSelector)``;
+
+export const MachineToolCheckbox = styled(Checkbox)``;

--- a/ui/src/test/utils.tsx
+++ b/ui/src/test/utils.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react";
-import { render, within } from "@testing-library/react";
+import { ByRoleMatcher, render, within } from "@testing-library/react";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "styled-components";
@@ -66,16 +66,18 @@ function renderWithTestProviders(
     };
 }
 
-async function clickButton({
+async function click({
     label,
+    role = "button",
     inside,
 }: {
     label: string;
+    role?: ByRoleMatcher;
     inside?: HTMLElement;
 }): Promise<void> {
     const user = userEvent.setup();
     const container = inside ? within(inside) : screen;
-    const button = await container.findByRole("button", { name: label });
+    const button = await container.findByRole(role, { name: label });
 
     await user.click(button);
 }
@@ -131,7 +133,7 @@ export {
     wrapWithTestProviders,
     renderWithRouterProvider,
     renderWithTestProviders,
-    clickButton,
+    click,
     typeValue,
     clearInput,
     openSelectMenu,


### PR DESCRIPTION
# What

Added common styled checkbox component
Added machine tool availability checkbox to main calculator page
Updated item detail, output, and requirement queries to send machine tool availability based on checkbox value

# Why

To inform the API of whether the user has machine tools available, allowing the calculator to display results for recipes that have machine tool requirements