### PR TITLE
feat: add machine tool recipes

### DIFF
--- a/api/src/json/items.json
+++ b/api/src/json/items.json
@@ -90,6 +90,25 @@
         ]
     },
     {
+        "name": "Nitro",
+        "creator": "Alchemist",
+        "createTime": 20,
+        "requires": [
+            { "name": "Cotton fibre", "amount": 5 },
+            { "name": "Vial of nitric acid", "amount": 1 },
+            { "name": "Vial of sulphuric acid", "amount": 1 }
+        ],
+        "output": 50,
+        "toolset": {
+            "type": "default",
+            "minimumTool": "iron",
+            "maximumTool": "steel"
+        },
+        "optionalOutputs": [
+            { "name": "Empty Vial", "likelihood": 0.95, "amount": 2 }
+        ]
+    },
+    {
         "name": "Door",
         "creator": "Artist",
         "createTime": 180,
@@ -310,6 +329,37 @@
     },
     {
         "name": "Iron bloom",
+        "creator": "Blast furnace operator",
+        "createTime": 15,
+        "requires": [
+            { "name": "Iron ore", "amount": 1 },
+            { "name": "Cokes", "amount": 1 }
+        ],
+        "output": 1,
+        "toolset": {
+            "type": "machine",
+            "minimumTool": "machine",
+            "maximumTool": "machine"
+        }
+    },
+    {
+        "name": "Steel ingot",
+        "creator": "Blast furnace operator",
+        "createTime": 15,
+        "requires": [
+            { "name": "Iron bloom", "amount": 1 },
+            { "name": "Silica sand", "amount": 1 },
+            { "name": "Cokes", "amount": 1 }
+        ],
+        "output": 1,
+        "toolset": {
+            "type": "machine",
+            "minimumTool": "machine",
+            "maximumTool": "machine"
+        }
+    },
+    {
+        "name": "Iron bloom",
         "creator": "Bloomery worker",
         "createTime": 120,
         "requires": [
@@ -378,6 +428,23 @@
             { "name": "Bronze ingot", "amount": 2 },
             { "name": "Iron wrought", "amount": 2 },
             { "name": "Chest", "amount": 1 }
+        ],
+        "output": 1,
+        "toolset": {
+            "type": "default",
+            "minimumTool": "none",
+            "maximumTool": "steel"
+        }
+    },
+    {
+        "name": "Luxury chest",
+        "creator": "Chest maker",
+        "createTime": 720,
+        "requires": [
+            { "name": "Luxury garments", "amount": 1 },
+            { "name": "Golden shield", "amount": 3 },
+            { "name": "Monocular", "amount": 3 },
+            { "name": "Earthenware", "amount": 10 }
         ],
         "output": 1,
         "toolset": {
@@ -749,6 +816,37 @@
             "type": "default",
             "minimumTool": "stone",
             "maximumTool": "steel"
+        }
+    },
+    {
+        "name": "Cotton fibre",
+        "creator": "Cotton engine operator",
+        "createTime": 120,
+        "requires": [{ "name": "Cotton", "amount": 30 }],
+        "output": 1,
+        "toolset": {
+            "type": "machine",
+            "minimumTool": "machine",
+            "maximumTool": "machine"
+        }
+    },
+    {
+        "name": "Luxury garments",
+        "creator": "Dyer",
+        "createTime": 300,
+        "requires": [
+            { "name": "Cotton fibre", "amount": 10 },
+            { "name": "Hemp fibre", "amount": 10 },
+            { "name": "Linen", "amount": 25 },
+            { "name": "Alkanet", "amount": 200 },
+            { "name": "Hollyhock", "amount": 200 },
+            { "name": "Wolfsbane", "amount": 200 }
+        ],
+        "output": 3,
+        "toolset": {
+            "type": "default",
+            "minimumTool": "none",
+            "maximumTool": "none"
         }
     },
     {
@@ -1169,7 +1267,7 @@
         }
     },
     {
-        "name": "Archimedean Screw",
+        "name": "Archimedean screw",
         "creator": "Engineer",
         "createTime": 480,
         "requires": [
@@ -1425,6 +1523,40 @@
         }
     },
     {
+        "name": "Gun trap",
+        "creator": "Gunsmith",
+        "createTime": 1000,
+        "requires": [
+            { "name": "Steel ingot", "amount": 10 },
+            { "name": "Steel parts", "amount": 25 },
+            { "name": "Brass parts", "amount": 25 },
+            { "name": "Vial of mineral oil", "amount": 5 },
+            { "name": "Nitro", "amount": 10 }
+        ],
+        "output": 1,
+        "toolset": {
+            "type": "default",
+            "minimumTool": "none",
+            "maximumTool": "steel"
+        }
+    },
+    {
+        "name": "Gun trap ammo",
+        "creator": "Gunsmith",
+        "createTime": 120,
+        "requires": [
+            { "name": "Brass parts", "amount": 3 },
+            { "name": "Lead ingot", "amount": 2 },
+            { "name": "Nitro", "amount": 15 }
+        ],
+        "output": 1,
+        "toolset": {
+            "type": "default",
+            "minimumTool": "none",
+            "maximumTool": "steel"
+        }
+    },
+    {
         "name": "Musket",
         "creator": "Gunsmith",
         "createTime": 720,
@@ -1466,6 +1598,23 @@
             { "name": "Vial of mineral oil", "amount": 1 }
         ],
         "output": 1,
+        "toolset": {
+            "type": "default",
+            "minimumTool": "none",
+            "maximumTool": "steel"
+        }
+    },
+    {
+        "name": "Grenade launcher ammo",
+        "creator": "Gunsmith",
+        "createTime": 120,
+        "requires": [
+            { "name": "Lead ingot", "amount": 2 },
+            { "name": "Steel parts", "amount": 2 },
+            { "name": "Brass parts", "amount": 1 },
+            { "name": "Nitro", "amount": 15 }
+        ],
+        "output": 30,
         "toolset": {
             "type": "default",
             "minimumTool": "none",
@@ -1667,7 +1816,7 @@
         }
     },
     {
-        "name": "Artist's Workbench",
+        "name": "Artist's workbench",
         "creator": "Job block crafter",
         "createTime": 240,
         "requires": [
@@ -2265,6 +2414,42 @@
         }
     },
     {
+        "name": "Metal gear",
+        "creator": "Metal lathe operator",
+        "createTime": 15,
+        "requires": [{ "name": "Iron wrought", "amount": 2 }],
+        "output": 1,
+        "toolset": {
+            "type": "machine",
+            "minimumTool": "machine",
+            "maximumTool": "machine"
+        }
+    },
+    {
+        "name": "Brass parts",
+        "creator": "Metal lathe operator",
+        "createTime": 25,
+        "requires": [{ "name": "Brass ingot", "amount": 2 }],
+        "output": 1,
+        "toolset": {
+            "type": "machine",
+            "minimumTool": "machine",
+            "maximumTool": "machine"
+        }
+    },
+    {
+        "name": "Steel parts",
+        "creator": "Metal lathe operator",
+        "createTime": 25,
+        "requires": [{ "name": "Steel ingot", "amount": 1 }],
+        "output": 1,
+        "toolset": {
+            "type": "machine",
+            "minimumTool": "machine",
+            "maximumTool": "machine"
+        }
+    },
+    {
         "name": "Paper",
         "creator": "Paper maker",
         "createTime": 318,
@@ -2368,6 +2553,18 @@
         "optionalOutputs": [
             { "name": "Empty pot", "likelihood": 0.95, "amount": 3 }
         ]
+    },
+    {
+        "name": "Movable type",
+        "creator": "Printing press operator",
+        "createTime": 45,
+        "requires": [{ "name": "Lead ingot", "amount": 1 }],
+        "output": 1,
+        "toolset": {
+            "type": "machine",
+            "minimumTool": "machine",
+            "maximumTool": "machine"
+        }
     },
     {
         "name": "Rope",
@@ -2699,6 +2896,18 @@
             "type": "default",
             "minimumTool": "none",
             "maximumTool": "steel"
+        }
+    },
+    {
+        "name": "Empty punch card",
+        "creator": "Tabulating machine operator",
+        "createTime": 45,
+        "requires": [{ "name": "Paper", "amount": 10 }],
+        "output": 1,
+        "toolset": {
+            "type": "machine",
+            "minimumTool": "machine",
+            "maximumTool": "machine"
         }
     },
     {

--- a/scripts/recipe-json-converter/domain/__tests__/craftable-recipe-converter.test.ts
+++ b/scripts/recipe-json-converter/domain/__tests__/craftable-recipe-converter.test.ts
@@ -1295,11 +1295,13 @@ describe("recipe to item mapping", () => {
             ["streetlight", "Street light"],
             ["railitem", "Rails"],
             ["railgate", "Rail gate"],
-            ["watersponge", "Archimedean Screw"],
-            ["artisttable", "Artist's Workbench"],
+            ["watersponge", "Archimedean screw"],
+            ["artisttable", "Artist's workbench"],
             ["rooftool", "Tiled roof"],
             ["rooftoolblue", "Blue tiled roof"],
             ["fence", "Fence"],
+            ["manuscript", "Manuscript"],
+            ["cardempty", "Empty punch card"],
         ])(
             "can handle recipes for item: %s",
             async (itemName: string, expectedConvertedItemName: string) => {
@@ -1386,6 +1388,10 @@ describe("recipe to item mapping", () => {
             ["woodcutter", "Woodcutter"],
             ["artist", "Artist"],
             ["metallathe", "Metal lathe operator"],
+            ["blastfurnace", "Blast furnace operator"],
+            ["cottonengine", "Cotton engine operator"],
+            ["printingpress", "Printing press operator"],
+            ["tabulator", "Tabulating machine operator"],
         ])(
             "can handle recipes from creator: %s",
             async (creator: string, expectedConvertedCreator: string) => {

--- a/scripts/recipe-json-converter/domain/__tests__/growable-converter.test.ts
+++ b/scripts/recipe-json-converter/domain/__tests__/growable-converter.test.ts
@@ -2,7 +2,7 @@ import path from "path";
 
 import { GrowableConverterInputs } from "../../interfaces/growable-converter";
 import { convertGrowables as baseConvertGrowables } from "../growable-converter";
-import { APITools, Growables, Item, Items } from "../../types";
+import { DefaultToolset, Growables, Item, Items } from "../../types";
 
 const mockFindFiles = jest.fn();
 const mockReadGrowablesFile = jest.fn();
@@ -34,8 +34,8 @@ const expectedStaticLogRecipe: Item = {
     optionalOutputs: [{ name: "Leaves", amount: 59.4, likelihood: 1 }],
     toolset: {
         type: "default",
-        minimumTool: APITools.none,
-        maximumTool: APITools.none,
+        minimumTool: DefaultToolset.none,
+        maximumTool: DefaultToolset.none,
     },
     creator: "Forester",
     size: {
@@ -53,8 +53,8 @@ const expectedStaticLeavesRecipe: Item = {
     optionalOutputs: [{ name: "Log", amount: 44, likelihood: 1 }],
     toolset: {
         type: "default",
-        minimumTool: APITools.none,
-        maximumTool: APITools.none,
+        minimumTool: DefaultToolset.none,
+        maximumTool: DefaultToolset.none,
     },
     creator: "Forester",
     size: {
@@ -161,8 +161,8 @@ test.each([
             requires: [],
             toolset: {
                 type: "default",
-                minimumTool: APITools.none,
-                maximumTool: APITools.none,
+                minimumTool: DefaultToolset.none,
+                maximumTool: DefaultToolset.none,
             },
             creator: expectedCreator,
             ...(expectedSize ? { size: expectedSize } : {}),
@@ -187,8 +187,8 @@ test("returns converted recipe given single growable with more than 2 stages", a
         requires: [],
         toolset: {
             type: "default",
-            minimumTool: APITools.none,
-            maximumTool: APITools.none,
+            minimumTool: DefaultToolset.none,
+            maximumTool: DefaultToolset.none,
         },
         creator: "Wheat farmer",
         size: {
@@ -269,8 +269,8 @@ test("converts multiple items given multiple growables found in file", async () 
             requires: [],
             toolset: {
                 type: "default",
-                minimumTool: APITools.none,
-                maximumTool: APITools.none,
+                minimumTool: DefaultToolset.none,
+                maximumTool: DefaultToolset.none,
             },
             creator: "Wheat farmer",
             size: {
@@ -285,8 +285,8 @@ test("converts multiple items given multiple growables found in file", async () 
             requires: [],
             toolset: {
                 type: "default",
-                minimumTool: APITools.none,
-                maximumTool: APITools.none,
+                minimumTool: DefaultToolset.none,
+                maximumTool: DefaultToolset.none,
             },
             creator: "Flax farmer",
             size: {

--- a/scripts/recipe-json-converter/domain/__tests__/mineable-item-converter.test.ts
+++ b/scripts/recipe-json-converter/domain/__tests__/mineable-item-converter.test.ts
@@ -2,7 +2,7 @@ import path from "path";
 
 import { MineableItemConverterInputs } from "../../interfaces/mineable-item-converter";
 import { convertMineableItems as baseConvertMineableItems } from "../mineable-item-converter";
-import { APITools, Item, Items, MineableItems } from "../../types";
+import { DefaultToolset, Item, Items, MineableItems } from "../../types";
 
 const mockFindFiles = jest.fn();
 const mockReadMineableItemsFile = jest.fn();
@@ -101,8 +101,8 @@ test.each([
             requires: [],
             toolset: {
                 type: "default",
-                minimumTool: APITools.none,
-                maximumTool: APITools.steel,
+                minimumTool: DefaultToolset.none,
+                maximumTool: DefaultToolset.steel,
             },
             creator: "Miner",
         };
@@ -132,8 +132,8 @@ test("ignores non-mineable items found in mineable items file", async () => {
         requires: [],
         toolset: {
             type: "default",
-            minimumTool: APITools.none,
-            maximumTool: APITools.steel,
+            minimumTool: DefaultToolset.none,
+            maximumTool: DefaultToolset.steel,
         },
         creator: "Miner",
     };
@@ -168,8 +168,8 @@ test("converts multiple items given multiple mineable items found in file", asyn
             requires: [],
             toolset: {
                 type: "default",
-                minimumTool: APITools.none,
-                maximumTool: APITools.steel,
+                minimumTool: DefaultToolset.none,
+                maximumTool: DefaultToolset.steel,
             },
             creator: "Miner",
         },
@@ -180,8 +180,8 @@ test("converts multiple items given multiple mineable items found in file", asyn
             requires: [],
             toolset: {
                 type: "default",
-                minimumTool: APITools.none,
-                maximumTool: APITools.steel,
+                minimumTool: DefaultToolset.none,
+                maximumTool: DefaultToolset.steel,
             },
             creator: "Miner",
         },

--- a/scripts/recipe-json-converter/domain/__tests__/recipe-converter.test.ts
+++ b/scripts/recipe-json-converter/domain/__tests__/recipe-converter.test.ts
@@ -2,7 +2,7 @@ import path from "path";
 
 import { RecipeConverterInputs } from "../../interfaces/recipe-converter";
 import { convertRecipes as baseConvertRecipes } from "../recipe-converter";
-import { APITools, Item, Items } from "../../types";
+import { DefaultToolset, Item, Items, MachineToolset } from "../../types";
 
 const mockConvertCrafteableRecipes = jest.fn();
 const mockConvertMineableItems = jest.fn();
@@ -31,8 +31,8 @@ const expectedCraftableRecipes: Items = [
         requires: [],
         toolset: {
             type: "default",
-            minimumTool: APITools.none,
-            maximumTool: APITools.none,
+            minimumTool: DefaultToolset.none,
+            maximumTool: DefaultToolset.none,
         },
         creator: "Alchemist",
     },
@@ -43,10 +43,22 @@ const expectedCraftableRecipes: Items = [
         requires: [],
         toolset: {
             type: "default",
-            minimumTool: APITools.none,
-            maximumTool: APITools.none,
+            minimumTool: DefaultToolset.none,
+            maximumTool: DefaultToolset.none,
         },
         creator: "Alchemist",
+    },
+    {
+        name: "Brass parts",
+        createTime: 20,
+        output: 2,
+        requires: [],
+        toolset: {
+            type: "machine",
+            minimumTool: MachineToolset.machine,
+            maximumTool: MachineToolset.machine,
+        },
+        creator: "Metal lathe operator",
     },
 ];
 
@@ -58,8 +70,8 @@ const expectedMineableItems: Items = [
         requires: [],
         toolset: {
             type: "default",
-            minimumTool: APITools.none,
-            maximumTool: APITools.steel,
+            minimumTool: DefaultToolset.none,
+            maximumTool: DefaultToolset.steel,
         },
         creator: "Miner",
     },
@@ -73,8 +85,8 @@ const expectedGrowables: Items = [
         requires: [],
         toolset: {
             type: "default",
-            minimumTool: APITools.none,
-            maximumTool: APITools.none,
+            minimumTool: DefaultToolset.none,
+            maximumTool: DefaultToolset.none,
         },
         creator: "Wheat farmer",
     },
@@ -181,8 +193,8 @@ describe("handles directly non-creatable items", () => {
         output: 1,
         toolset: {
             type: "default",
-            minimumTool: APITools.none,
-            maximumTool: APITools.steel,
+            minimumTool: DefaultToolset.none,
+            maximumTool: DefaultToolset.steel,
         },
         creator: "Test creator",
     };
@@ -220,8 +232,8 @@ describe("handles non-creatable items due to nested unknown item", () => {
         output: 1,
         toolset: {
             type: "default",
-            minimumTool: APITools.none,
-            maximumTool: APITools.steel,
+            minimumTool: DefaultToolset.none,
+            maximumTool: DefaultToolset.steel,
         },
         creator: "Test creator",
     };
@@ -232,8 +244,8 @@ describe("handles non-creatable items due to nested unknown item", () => {
         output: 1,
         toolset: {
             type: "default",
-            minimumTool: APITools.none,
-            maximumTool: APITools.steel,
+            minimumTool: DefaultToolset.none,
+            maximumTool: DefaultToolset.steel,
         },
         creator: "Test creator",
     };
@@ -279,8 +291,8 @@ test("filters out any item that depends on an item that cannot be created becaus
         output: 1,
         toolset: {
             type: "default",
-            minimumTool: APITools.none,
-            maximumTool: APITools.steel,
+            minimumTool: DefaultToolset.none,
+            maximumTool: DefaultToolset.steel,
         },
         creator: "Test creator",
     };
@@ -291,8 +303,8 @@ test("filters out any item that depends on an item that cannot be created becaus
         output: 1,
         toolset: {
             type: "default",
-            minimumTool: APITools.none,
-            maximumTool: APITools.steel,
+            minimumTool: DefaultToolset.none,
+            maximumTool: DefaultToolset.steel,
         },
         creator: "Test creator",
     };

--- a/scripts/recipe-json-converter/domain/craftable-recipe-converter.ts
+++ b/scripts/recipe-json-converter/domain/craftable-recipe-converter.ts
@@ -12,12 +12,9 @@ import {
     Items,
     OptionalOutput,
     Requirements,
+    Recipe,
 } from "../types";
-import {
-    UNSUPPORTED_TOOL_ERROR,
-    getDefaultMinMaxTools,
-    getMinMaxTools,
-} from "./tool-utils";
+import { UNSUPPORTED_TOOL_ERROR, getToolset } from "./tool-utils";
 import {
     getUserFriendlyCreatorName,
     getUserFriendlyItemName,
@@ -36,7 +33,6 @@ const RECIPE_PREFIX = "recipes_";
 const RECIPE_EXCLUSION_SET = new Set<string>(["recipes_merchant.json"]);
 
 type PiplizToolset = PiplizToolsets[number];
-type Recipe = Recipes[number];
 
 const getKnownToolsets = async (
     inputDirectoryPath: string,
@@ -211,14 +207,7 @@ const mapRecipeToItem = (
     npcToolsetMapping: Map<string, PiplizTools[]>
 ): Item => {
     const { itemName, creator } = splitPiplizName(recipe.name);
-    const tools = npcToolsetMapping.get(creator);
-    if (!tools) {
-        console.log(
-            `Defaulting to default toolset for recipe: ${itemName} from creator: ${creator}`
-        );
-    }
-
-    const toolset = getMinMaxTools(tools ?? getDefaultMinMaxTools(creator));
+    const toolset = getToolset(recipe, npcToolsetMapping);
     const { matching, nonMatching } = filterByCondition(
         recipe.results,
         (result) => result.type === itemName

--- a/scripts/recipe-json-converter/domain/growable-converter.ts
+++ b/scripts/recipe-json-converter/domain/growable-converter.ts
@@ -1,7 +1,7 @@
 import { FileFinder } from "../interfaces/file-finder";
 import { GrowableConverter } from "../interfaces/growable-converter";
 import { JSONFileReader } from "../interfaces/json-file-reader";
-import { APITools, Growables, Item, Items } from "../types";
+import { DefaultToolset, Growables, Item, Items } from "../types";
 import { JSON_FILE_EXTENSION } from "./constants";
 import {
     getUserFriendlyCreatorName,
@@ -21,8 +21,8 @@ const STATIC_RECIPES: Items = [
         optionalOutputs: [{ name: "Leaves", amount: 59.4, likelihood: 1 }],
         toolset: {
             type: "default",
-            minimumTool: APITools.none,
-            maximumTool: APITools.none,
+            minimumTool: DefaultToolset.none,
+            maximumTool: DefaultToolset.none,
         },
         creator: "Forester",
         size: {
@@ -38,8 +38,8 @@ const STATIC_RECIPES: Items = [
         optionalOutputs: [{ name: "Log", amount: 44, likelihood: 1 }],
         toolset: {
             type: "default",
-            minimumTool: APITools.none,
-            maximumTool: APITools.none,
+            minimumTool: DefaultToolset.none,
+            maximumTool: DefaultToolset.none,
         },
         creator: "Forester",
         size: {
@@ -147,8 +147,8 @@ const mapToItem = (growable: Growables[number]): Item => {
         requires: [],
         toolset: {
             type: "default",
-            minimumTool: APITools.none,
-            maximumTool: APITools.none,
+            minimumTool: DefaultToolset.none,
+            maximumTool: DefaultToolset.none,
         },
         creator,
         ...(size ? { size } : {}),

--- a/scripts/recipe-json-converter/domain/mineable-item-converter.ts
+++ b/scripts/recipe-json-converter/domain/mineable-item-converter.ts
@@ -1,7 +1,7 @@
 import { FileFinder } from "../interfaces/file-finder";
 import { JSONFileReader } from "../interfaces/json-file-reader";
 import { MineableItemConverter } from "../interfaces/mineable-item-converter";
-import { APITools, Items, MineableItems } from "../types";
+import { DefaultToolset, Items, MineableItems } from "../types";
 import { JSON_FILE_EXTENSION } from "./constants";
 import { getUserFriendlyItemName } from "./recipe-dictionary";
 import { checkDuplication } from "./utils";
@@ -54,8 +54,8 @@ const convertToItems = (mineable: MineableItems): Items => {
             requires: [],
             toolset: {
                 type: "default",
-                minimumTool: APITools.none,
-                maximumTool: APITools.steel,
+                minimumTool: DefaultToolset.none,
+                maximumTool: DefaultToolset.steel,
             },
             creator: "Miner",
         });

--- a/scripts/recipe-json-converter/domain/recipe-dictionary.ts
+++ b/scripts/recipe-json-converter/domain/recipe-dictionary.ts
@@ -254,11 +254,14 @@ const piplizItemNameMap: Readonly<Record<string, string>> = {
     streetlight: "Street light",
     railitem: "Rails",
     railgate: "Rail gate",
-    watersponge: "Archimedean Screw",
-    artisttable: "Artist's Workbench",
+    watersponge: "Archimedean screw",
+    artisttable: "Artist's workbench",
     rooftool: "Tiled roof",
     rooftoolblue: "Blue tiled roof",
     fence: "Fence",
+    movabletype: "Movable type",
+    manuscript: "Manuscript",
+    cardempty: "Empty punch card",
 };
 
 const getUserFriendlyItemName = (name: string): string | null => {
@@ -310,6 +313,11 @@ const creatorNameMap: Readonly<Record<string, string>> = {
     hemp: "Hemp farmer",
     wisteriaplant: "Wisteria flower farmer",
     artist: "Artist",
+    metallathe: "Metal lathe operator",
+    blastfurnace: "Blast furnace operator",
+    cottonengine: "Cotton engine operator",
+    printingpress: "Printing press operator",
+    tabulator: "Tabulating machine operator",
 };
 
 const getUserFriendlyCreatorName = (creator: string): string | null => {

--- a/scripts/recipe-json-converter/types/index.ts
+++ b/scripts/recipe-json-converter/types/index.ts
@@ -12,15 +12,19 @@ import {
     Requirement,
     Requirements,
     OptionalOutput,
-    DefaultToolset as APITools,
+    DefaultToolset,
+    MachineToolset,
 } from "./generated/items";
+
+type APITools = DefaultToolset | MachineToolset;
 
 type NPCToolsetMapping = {
     npcType: string;
     toolset: string;
 };
 
-type RecipeResult = Recipes[number]["results"][number];
+type Recipe = Recipes[number];
+type RecipeResult = Recipe["results"][number];
 
 export {
     NPCToolsetMapping,
@@ -32,6 +36,9 @@ export {
     PiplizTools,
     PiplizToolsets,
     APITools,
+    DefaultToolset,
+    MachineToolset,
     Recipes,
+    Recipe,
     RecipeResult,
 };

--- a/ui/src/pages/Calculator/components/CreatorOverrides/styles.ts
+++ b/ui/src/pages/Calculator/components/CreatorOverrides/styles.ts
@@ -2,7 +2,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import styled, { css } from "styled-components";
 
 export const OverrideListContainer = styled.div`
-    max-width: 45rem;
+    max-width: 50rem;
     width: 100%;
 
     display: flex;
@@ -68,6 +68,6 @@ export const OverrideContainer = styled.div`
     row-gap: 0.5rem;
 
     > div {
-        flex: 1 0 13rem;
+        flex: 1 0 16rem;
     }
 `;


### PR DESCRIPTION
# What

Updated recipe converter script to handle machine tool recipes
- Mapping all known recipes that require machine tools to common structure required by backend

Updated static item list in API with all recipes that required machine tools, or depended on an item that required machine tools

Update UI to fix minor width issue with long creator names in creator override selector

# Why

To allow the user to calculate the requirements for recipes that require machine tools

Calculator now supports all but 14 recipes (Eye glasses tool set)