### PR TITLE
fix: handle non-default max creator tools

### DIFF
--- a/api/src/json/items.json
+++ b/api/src/json/items.json
@@ -1294,7 +1294,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "copper"
         },
         "optionalOutputs": [
             { "name": "Empty pot", "likelihood": 0.95, "amount": 1 }
@@ -1312,7 +1312,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "copper"
         }
     },
     {
@@ -1324,7 +1324,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "stone"
         }
     },
     {
@@ -2477,7 +2477,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "copper"
         },
         "optionalOutputs": [
             { "name": "Empty pot", "likelihood": 0.95, "amount": 1 }
@@ -2496,7 +2496,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "copper"
         },
         "optionalOutputs": [
             { "name": "Empty pot", "likelihood": 0.95, "amount": 1 }
@@ -2514,7 +2514,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "copper"
         }
     },
     {
@@ -2529,7 +2529,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "copper"
         },
         "optionalOutputs": [
             { "name": "Empty pot", "likelihood": 0.95, "amount": 2 }
@@ -2548,7 +2548,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "copper"
         },
         "optionalOutputs": [
             { "name": "Empty pot", "likelihood": 0.95, "amount": 3 }
@@ -3007,7 +3007,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "stone"
         }
     },
     {
@@ -3019,7 +3019,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "stone"
         }
     },
     {
@@ -3031,7 +3031,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "stone"
         }
     },
     {
@@ -3043,7 +3043,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "stone"
         }
     },
     {
@@ -3055,7 +3055,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "stone"
         }
     },
     {
@@ -3070,7 +3070,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "stone"
         }
     },
     {
@@ -3082,7 +3082,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "stone"
         }
     },
     {
@@ -3094,7 +3094,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "stone"
         }
     },
     {
@@ -3106,7 +3106,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "stone"
         }
     },
     {
@@ -3118,7 +3118,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "stone"
         }
     },
     {
@@ -3133,7 +3133,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "stone"
         }
     },
     {
@@ -3148,7 +3148,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "stone"
         }
     },
     {
@@ -3160,7 +3160,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "stone"
         }
     },
     {
@@ -3172,7 +3172,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "stone"
         }
     },
     {
@@ -3184,7 +3184,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "stone"
         }
     },
     {
@@ -3199,7 +3199,7 @@
         "toolset": {
             "type": "default",
             "minimumTool": "none",
-            "maximumTool": "none"
+            "maximumTool": "stone"
         }
     },
     {

--- a/scripts/recipe-json-converter/domain/tool-utils.ts
+++ b/scripts/recipe-json-converter/domain/tool-utils.ts
@@ -67,7 +67,9 @@ const getMinMaxTools = (tools: PiplizTools[]): Item["toolset"] => {
         const value = ToolModifierValues[supportedTool];
         if (ToolModifierValues[minimumTool] > value) {
             minimumTool = supportedTool;
-        } else if (ToolModifierValues[maximumTool] < value) {
+        }
+
+        if (ToolModifierValues[maximumTool] < value) {
             maximumTool = supportedTool;
         }
     }
@@ -113,7 +115,13 @@ const getToolset = (
         };
     }
 
-    return getMinMaxTools(tools);
+    const test = getMinMaxTools(tools);
+    if (creator === "fisherman") {
+        console.dir(tools);
+        console.dir(test);
+    }
+
+    return test;
 };
 
 export { getToolset, SupportedPiplizTools, UNSUPPORTED_TOOL_ERROR };


### PR DESCRIPTION
# What

Updated recipe conversion script to correctly set max tool if creator uses non-default

# Why

The following creators were having their max tool set to none, when it should have been copper/stone etc:
- Fire pit cook
- Fisherman
- Potter
- Tinkerer

Raised by: [Wigwambam94 on Reddit](https://www.reddit.com/r/colonysurvival/comments/16orhlq/comment/k7um2xc/?utm_source=share&utm_medium=web2x&context=3)