### PR TITLE
feat(api): support desired output

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -38,5 +38,10 @@
         "mongodb-memory-server": "^9.1.1",
         "ts-jest": "^29.1.0",
         "typescript": "^5.0.3"
+    },
+    "config": {
+        "mongodbMemoryServer": {
+            "version": "6.0.4"
+        }
     }
 }

--- a/api/src/functions/query-requirements/__tests__/handler.test.ts
+++ b/api/src/functions/query-requirements/__tests__/handler.test.ts
@@ -309,6 +309,10 @@ test.each([
         "Invalid workers",
         "Invalid number of workers provided, must be a positive number",
     ],
+    [
+        "Invalid target amount",
+        "Invalid target output provided, must be a positive number",
+    ],
     ["Unknown item", "Unknown item provided"],
     [
         "Minimum tool",

--- a/api/src/functions/query-requirements/domain/__tests__/query-requirements.test.ts
+++ b/api/src/functions/query-requirements/domain/__tests__/query-requirements.test.ts
@@ -2129,6 +2129,7 @@ describe("handles machine tools", () => {
 });
 
 describe("handles calculating requirements for target output", () => {
+    const targetAmount = 7.5;
     const requiredItem3 = createItem({
         name: "required item 3",
         createTime: 4,
@@ -2166,73 +2167,6 @@ describe("handles calculating requirements for target output", () => {
         ]);
     });
 
-    test("returns expected requirements", async () => {
-        const targetAmount = 7.5;
-
-        const actual = await queryRequirements({
-            name: validItemName,
-            amount: targetAmount,
-        });
-
-        expect(actual).toEqual([
-            {
-                name: item.name,
-                amount: targetAmount,
-                creators: [
-                    {
-                        name: item.name,
-                        creator: item.creator,
-                        amount: targetAmount,
-                        workers: 5,
-                        demands: [{ name: requiredItem1.name, amount: 10 }],
-                    },
-                ],
-            },
-            {
-                name: requiredItem1.name,
-                amount: 10,
-                creators: [
-                    {
-                        name: requiredItem1.name,
-                        creator: requiredItem1.creator,
-                        amount: 10,
-                        workers: 7.5,
-                        demands: [
-                            { name: requiredItem2.name, amount: 15 },
-                            { name: requiredItem3.name, amount: 10 },
-                        ],
-                    },
-                ],
-            },
-            {
-                name: requiredItem2.name,
-                amount: 15,
-                creators: [
-                    {
-                        name: requiredItem2.name,
-                        creator: requiredItem2.creator,
-                        amount: 15,
-                        workers: 30,
-                        demands: [],
-                    },
-                ],
-            },
-            {
-                name: requiredItem3.name,
-                amount: 10,
-                creators: [
-                    {
-                        name: requiredItem3.name,
-                        creator: requiredItem3.creator,
-                        amount: 10,
-                        workers: 20,
-                        demands: [],
-                    },
-                ],
-            },
-        ]);
-    });
-
     test.each([
         ["equal to zero", 0],
         ["less than zero", -1],
@@ -2247,6 +2181,200 @@ describe("handles calculating requirements for target output", () => {
             await expect(
                 queryRequirements({ name: validItemName, amount })
             ).rejects.toThrow(expectedError);
+        }
+    );
+
+    test.each([
+        [
+            OutputUnit.SECONDS,
+            [
+                {
+                    name: item.name,
+                    amount: targetAmount,
+                    creators: [
+                        {
+                            name: item.name,
+                            creator: item.creator,
+                            amount: targetAmount,
+                            workers: 5,
+                            demands: [{ name: requiredItem1.name, amount: 10 }],
+                        },
+                    ],
+                },
+                {
+                    name: requiredItem1.name,
+                    amount: 10,
+                    creators: [
+                        {
+                            name: requiredItem1.name,
+                            creator: requiredItem1.creator,
+                            amount: 10,
+                            workers: 7.5,
+                            demands: [
+                                { name: requiredItem2.name, amount: 15 },
+                                { name: requiredItem3.name, amount: 10 },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    name: requiredItem2.name,
+                    amount: 15,
+                    creators: [
+                        {
+                            name: requiredItem2.name,
+                            creator: requiredItem2.creator,
+                            amount: 15,
+                            workers: 30,
+                            demands: [],
+                        },
+                    ],
+                },
+                {
+                    name: requiredItem3.name,
+                    amount: 10,
+                    creators: [
+                        {
+                            name: requiredItem3.name,
+                            creator: requiredItem3.creator,
+                            amount: 10,
+                            workers: 20,
+                            demands: [],
+                        },
+                    ],
+                },
+            ],
+        ],
+        [
+            OutputUnit.MINUTES,
+            [
+                {
+                    name: item.name,
+                    amount: targetAmount,
+                    creators: [
+                        {
+                            name: item.name,
+                            creator: item.creator,
+                            amount: targetAmount,
+                            workers: 0.08333333,
+                            demands: [{ name: requiredItem1.name, amount: 10 }],
+                        },
+                    ],
+                },
+                {
+                    name: requiredItem1.name,
+                    amount: 10,
+                    creators: [
+                        {
+                            name: requiredItem1.name,
+                            creator: requiredItem1.creator,
+                            amount: 10,
+                            workers: 0.125,
+                            demands: [
+                                { name: requiredItem2.name, amount: 15 },
+                                { name: requiredItem3.name, amount: 10 },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    name: requiredItem2.name,
+                    amount: 15,
+                    creators: [
+                        {
+                            name: requiredItem2.name,
+                            creator: requiredItem2.creator,
+                            amount: 15,
+                            workers: 0.5,
+                            demands: [],
+                        },
+                    ],
+                },
+                {
+                    name: requiredItem3.name,
+                    amount: 10,
+                    creators: [
+                        {
+                            name: requiredItem3.name,
+                            creator: requiredItem3.creator,
+                            amount: 10,
+                            workers: 0.33333333,
+                            demands: [],
+                        },
+                    ],
+                },
+            ],
+        ],
+        [
+            OutputUnit.GAME_DAYS,
+            [
+                {
+                    name: item.name,
+                    amount: targetAmount,
+                    creators: [
+                        {
+                            name: item.name,
+                            creator: item.creator,
+                            amount: targetAmount,
+                            workers: 0.01149425,
+                            demands: [{ name: requiredItem1.name, amount: 10 }],
+                        },
+                    ],
+                },
+                {
+                    name: requiredItem1.name,
+                    amount: 10,
+                    creators: [
+                        {
+                            name: requiredItem1.name,
+                            creator: requiredItem1.creator,
+                            amount: 10,
+                            workers: 0.01724138,
+                            demands: [
+                                { name: requiredItem2.name, amount: 15 },
+                                { name: requiredItem3.name, amount: 10 },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    name: requiredItem2.name,
+                    amount: 15,
+                    creators: [
+                        {
+                            name: requiredItem2.name,
+                            creator: requiredItem2.creator,
+                            amount: 15,
+                            workers: 0.06896552,
+                            demands: [],
+                        },
+                    ],
+                },
+                {
+                    name: requiredItem3.name,
+                    amount: 10,
+                    creators: [
+                        {
+                            name: requiredItem3.name,
+                            creator: requiredItem3.creator,
+                            amount: 10,
+                            workers: 0.04597701,
+                            demands: [],
+                        },
+                    ],
+                },
+            ],
+        ],
+    ])(
+        "factors output unit into target amount when given non default %s",
+        async (unit: OutputUnit, expected: Requirement[]) => {
+            const actual = await queryRequirements({
+                name: validItemName,
+                amount: targetAmount,
+                unit,
+            });
+
+            expect(actual).toEqual(expected);
         }
     );
 });

--- a/api/src/functions/query-requirements/domain/__tests__/query-requirements.test.ts
+++ b/api/src/functions/query-requirements/domain/__tests__/query-requirements.test.ts
@@ -41,14 +41,14 @@ test.each([
     ["less than zero", -1],
 ])(
     "throws an error given number of workers that is %s",
-    async (_: string, amount: number) => {
+    async (_: string, workers: number) => {
         const expectedError = new Error(
             "Invalid number of workers provided, must be a positive number"
         );
 
         expect.assertions(1);
         await expect(
-            queryRequirements({ name: validItemName, workers: amount })
+            queryRequirements({ name: validItemName, workers })
         ).rejects.toThrow(expectedError);
     }
 );
@@ -2126,4 +2126,127 @@ describe("handles machine tools", () => {
             },
         ]);
     });
+});
+
+describe("handles calculating requirements for target output", () => {
+    const requiredItem3 = createItem({
+        name: "required item 3",
+        createTime: 4,
+        output: 2,
+        requirements: [],
+    });
+    const requiredItem2 = createItem({
+        name: "required item 2",
+        createTime: 4,
+        output: 2,
+        requirements: [],
+    });
+    const requiredItem1 = createItem({
+        name: "required item 1",
+        createTime: 3,
+        output: 4,
+        requirements: [
+            { name: requiredItem2.name, amount: 6 },
+            { name: requiredItem3.name, amount: 4 },
+        ],
+    });
+    const item = createItem({
+        name: validItemName,
+        createTime: 2,
+        output: 3,
+        requirements: [{ name: requiredItem1.name, amount: 4 }],
+    });
+
+    beforeEach(() => {
+        mockMongoDBQueryRequirements.mockResolvedValue([
+            item,
+            requiredItem1,
+            requiredItem2,
+            requiredItem3,
+        ]);
+    });
+
+    test("returns expected requirements", async () => {
+        const targetAmount = 7.5;
+
+        const actual = await queryRequirements({
+            name: validItemName,
+            amount: targetAmount,
+        });
+
+        expect(actual).toEqual([
+            {
+                name: item.name,
+                amount: targetAmount,
+                creators: [
+                    {
+                        name: item.name,
+                        creator: item.creator,
+                        amount: targetAmount,
+                        workers: 5,
+                        demands: [{ name: requiredItem1.name, amount: 10 }],
+                    },
+                ],
+            },
+            {
+                name: requiredItem1.name,
+                amount: 10,
+                creators: [
+                    {
+                        name: requiredItem1.name,
+                        creator: requiredItem1.creator,
+                        amount: 10,
+                        workers: 7.5,
+                        demands: [
+                            { name: requiredItem2.name, amount: 15 },
+                            { name: requiredItem3.name, amount: 10 },
+                        ],
+                    },
+                ],
+            },
+            {
+                name: requiredItem2.name,
+                amount: 15,
+                creators: [
+                    {
+                        name: requiredItem2.name,
+                        creator: requiredItem2.creator,
+                        amount: 15,
+                        workers: 30,
+                        demands: [],
+                    },
+                ],
+            },
+            {
+                name: requiredItem3.name,
+                amount: 10,
+                creators: [
+                    {
+                        name: requiredItem3.name,
+                        creator: requiredItem3.creator,
+                        amount: 10,
+                        workers: 20,
+                        demands: [],
+                    },
+                ],
+            },
+        ]);
+    });
+
+    test.each([
+        ["equal to zero", 0],
+        ["less than zero", -1],
+    ])(
+        "throws an error given target amount that is %s",
+        async (_: string, amount: number) => {
+            const expectedError = new Error(
+                "Invalid target output provided, must be a positive number"
+            );
+
+            expect.assertions(1);
+            await expect(
+                queryRequirements({ name: validItemName, amount })
+            ).rejects.toThrow(expectedError);
+        }
+    );
 });

--- a/api/src/functions/query-requirements/domain/errors.ts
+++ b/api/src/functions/query-requirements/domain/errors.ts
@@ -2,6 +2,8 @@ const INVALID_ITEM_NAME_ERROR =
     "Invalid item name provided, must be a non-empty string";
 const INVALID_WORKERS_ERROR =
     "Invalid number of workers provided, must be a positive number";
+const INVALID_TARGET_ERROR =
+    "Invalid target output provided, must be a positive number";
 const UNKNOWN_ITEM_ERROR = "Unknown item provided";
 const TOOL_LEVEL_ERROR_PREFIX = "Unable to create item with available tools,";
 const MULTIPLE_OVERRIDE_ERROR_PREFIX =
@@ -13,6 +15,7 @@ const INTERNAL_SERVER_ERROR = "Internal server error";
 export {
     INVALID_ITEM_NAME_ERROR,
     INVALID_WORKERS_ERROR,
+    INVALID_TARGET_ERROR,
     UNKNOWN_ITEM_ERROR,
     TOOL_LEVEL_ERROR_PREFIX,
     MULTIPLE_OVERRIDE_ERROR_PREFIX,

--- a/api/src/functions/query-requirements/handler.ts
+++ b/api/src/functions/query-requirements/handler.ts
@@ -44,7 +44,7 @@ const handler: GraphQLEventHandler<
 > = async (event) => {
     const {
         name,
-        workers,
+        target,
         unit,
         maxAvailableTool,
         creatorOverrides,
@@ -63,7 +63,9 @@ const handler: GraphQLEventHandler<
     try {
         const requirements = await queryRequirements({
             name,
-            workers,
+            ...("amount" in target
+                ? { amount: target.amount }
+                : { workers: target.workers }),
             ...(unit ? { unit: OutputUnit[unit] } : {}),
             ...(maxAvailableTool
                 ? {

--- a/api/src/functions/query-requirements/handler.ts
+++ b/api/src/functions/query-requirements/handler.ts
@@ -15,8 +15,10 @@ import {
 } from "./domain/errors";
 import { queryRequirements } from "./domain/query-requirements";
 
-const INVALID_ARGUMENT_ERROR =
+const INVALID_OUTPUT_UNIT_ARGUMENT_ERROR =
     "Invalid arguments: Must provide output unit when querying amounts";
+const INVALID_TARGET_ARGUMENT_ERROR =
+    "Invalid arguments: Must provide either amount or workers when querying requirements (not both)";
 
 const amountFields = new Set([
     "amount",
@@ -40,17 +42,44 @@ const isUserError = ({ message }: Error): boolean => {
     );
 };
 
+const isDefined = <T>(input: T | undefined | null): input is T => {
+    return input !== undefined && input !== null;
+};
+
+const validateTargetInput = ({
+    workers,
+    amount,
+}: Pick<QueryRequirementArgs, "workers" | "amount">):
+    | { amount: number }
+    | { workers: number } => {
+    const isTargetWorkersDefined = isDefined(workers);
+    const isTargetAmountDefined = isDefined(amount);
+    if (isTargetWorkersDefined && isTargetAmountDefined) {
+        throw new Error(INVALID_TARGET_ARGUMENT_ERROR);
+    }
+
+    if (isTargetWorkersDefined) {
+        return { workers };
+    }
+
+    if (isTargetAmountDefined) {
+        return { amount };
+    }
+
+    throw new Error(INVALID_TARGET_ARGUMENT_ERROR);
+};
+
 const handler: GraphQLEventHandler<
     QueryRequirementArgs,
     RequirementResult
 > = async (event) => {
     const {
         name,
-        target,
         unit,
         maxAvailableTool,
         creatorOverrides,
         hasMachineTools,
+        ...targetInputs
     } = event.arguments;
     const { selectionSetList } = event.info;
 
@@ -59,15 +88,15 @@ const handler: GraphQLEventHandler<
     );
 
     if (selectedAmountFields.length > 0 && !unit) {
-        throw new Error(INVALID_ARGUMENT_ERROR);
+        throw new Error(INVALID_OUTPUT_UNIT_ARGUMENT_ERROR);
     }
+
+    const validatedTarget = validateTargetInput(targetInputs);
 
     try {
         const requirements = await queryRequirements({
             name,
-            ...("amount" in target
-                ? { amount: target.amount }
-                : { workers: target.workers }),
+            ...validatedTarget,
             ...(unit ? { unit: OutputUnit[unit] } : {}),
             ...(maxAvailableTool
                 ? {

--- a/api/src/functions/query-requirements/handler.ts
+++ b/api/src/functions/query-requirements/handler.ts
@@ -11,6 +11,7 @@ import {
     TOOL_LEVEL_ERROR_PREFIX,
     MULTIPLE_OVERRIDE_ERROR_PREFIX,
     INVALID_OVERRIDE_ITEM_NOT_CREATABLE_ERROR,
+    INVALID_TARGET_ERROR,
 } from "./domain/errors";
 import { queryRequirements } from "./domain/query-requirements";
 
@@ -26,6 +27,7 @@ const amountFields = new Set([
 const exactUserErrors = new Set([
     INVALID_ITEM_NAME_ERROR,
     INVALID_WORKERS_ERROR,
+    INVALID_TARGET_ERROR,
     UNKNOWN_ITEM_ERROR,
     INVALID_OVERRIDE_ITEM_NOT_CREATABLE_ERROR,
 ]);

--- a/api/src/functions/query-requirements/interfaces/query-requirements-primary-port.ts
+++ b/api/src/functions/query-requirements/interfaces/query-requirements-primary-port.ts
@@ -25,15 +25,28 @@ type Requirement = {
     creators: RequirementRecipe[];
 };
 
+type QueryRequirementsBaseParams = {
+    name: string;
+    unit?: OutputUnit;
+    maxAvailableTool?: DefaultToolset;
+    hasMachineTools?: boolean;
+    creatorOverrides?: CreatorOverride[];
+};
+
+type QueryRequirementsTargetWorkers = QueryRequirementsBaseParams & {
+    workers: number;
+};
+
+type QueryRequirementsTargetAmount = QueryRequirementsBaseParams & {
+    amount: number;
+};
+
+type QueryRequirementsParams =
+    | QueryRequirementsTargetWorkers
+    | QueryRequirementsTargetAmount;
+
 interface QueryRequirementsPrimaryPort {
-    (input: {
-        name: string;
-        workers: number;
-        unit?: OutputUnit;
-        maxAvailableTool?: DefaultToolset;
-        hasMachineTools?: boolean;
-        creatorOverrides?: CreatorOverride[];
-    }): Promise<Requirement[]>;
+    (input: QueryRequirementsParams): Promise<Requirement[]>;
 }
 
 export type {
@@ -42,4 +55,7 @@ export type {
     RequirementRecipe,
     Demand,
     QueryRequirementsPrimaryPort,
+    QueryRequirementsTargetWorkers,
+    QueryRequirementsTargetAmount,
+    QueryRequirementsParams,
 };

--- a/api/src/graphql/schema.graphql
+++ b/api/src/graphql/schema.graphql
@@ -61,16 +61,6 @@ type Requirements {
 
 union RequirementResult = Requirements | UserError
 
-type RequirementTargetWorkers {
-    workers: Int!
-}
-
-type RequirementTargetAmount {
-    amount: Float!
-}
-
-union RequirementTarget = RequirementTargetWorkers | RequirementTargetAmount
-
 type OptimalOutput {
     amount: Float!
 }
@@ -109,11 +99,12 @@ type Query {
     item(filters: ItemsFilters): [Item!]!
     requirement(
         name: ID!
-        target: RequirementTarget!
         maxAvailableTool: AvailableTools
         hasMachineTools: Boolean
         creatorOverrides: [CreatorOverride!]
         unit: OutputUnit
+        workers: Int
+        amount: Float
     ): RequirementResult!
     output(
         name: ID!

--- a/api/src/graphql/schema.graphql
+++ b/api/src/graphql/schema.graphql
@@ -61,6 +61,16 @@ type Requirements {
 
 union RequirementResult = Requirements | UserError
 
+type RequirementTargetWorkers {
+    workers: Int!
+}
+
+type RequirementTargetAmount {
+    amount: Float!
+}
+
+union RequirementTarget = RequirementTargetWorkers | RequirementTargetAmount
+
 type OptimalOutput {
     amount: Float!
 }
@@ -99,7 +109,7 @@ type Query {
     item(filters: ItemsFilters): [Item!]!
     requirement(
         name: ID!
-        workers: Int!
+        target: RequirementTarget!
         maxAvailableTool: AvailableTools
         hasMachineTools: Boolean
         creatorOverrides: [CreatorOverride!]


### PR DESCRIPTION
# What

Updated requirements query to accept target output item amount as well as workers
- If target amount is provided, the required amount of workers + requirements will be calculated to achieve the target output amount
- Cannot provide both workers and amount at once

# Why

Enables future updates to UI to allow the user to select whether to calculate requirements based on:
- Worker count if they want to figure out what the optimal output is for a given set of target workers
- Target amount if they want to figure out how many workers + requirements they need to achieve a given amount of output per second etc.