### PR TITLE
test(ui): ensure requirements body rendered before assertion

### DIFF
--- a/ui/src/pages/Calculator/components/Output/components/Requirements/Requirements.tsx
+++ b/ui/src/pages/Calculator/components/Output/components/Requirements/Requirements.tsx
@@ -64,6 +64,10 @@ function Requirements({ requirements }: RequirementsProps) {
         setRows(updated);
     }, [requirements]);
 
+    if (requirements.length === 0) {
+        return <></>;
+    }
+
     const sortedRows =
         workerSortDirection !== "none"
             ? sortBy(rows, workerSortDirection, "workers")


### PR DESCRIPTION
# Why

This test was intermittently failing because the body of the table had not yet rendered

Using `findBy` will ensure the table body has time to render before assertion