### PR TITLE
feat(ui): add total row for displaying total number of required workers

### DIFF
--- a/ui/src/pages/Calculator/__tests__/Calculator-creator-overrides.test.tsx
+++ b/ui/src/pages/Calculator/__tests__/Calculator-creator-overrides.test.tsx
@@ -98,11 +98,24 @@ const server = setupServer(
     }),
     createCalculatorOutputResponseHandler([
         createRequirement({
-            name: items[0].name,
+            name: expectedFirstItemName,
             amount: 1,
             creators: [
                 createRequirementCreator({
-                    recipeName: items[0].name,
+                    recipeName: expectedFirstItemName,
+                    workers: 1,
+                    amount: 1,
+                    creator: "Creator",
+                    demands: [],
+                }),
+            ],
+        }),
+        createRequirement({
+            name: expectedSecondItemName,
+            amount: 1,
+            creators: [
+                createRequirementCreator({
+                    recipeName: expectedSecondItemName,
                     workers: 1,
                     amount: 1,
                     creator: "Creator",

--- a/ui/src/pages/Calculator/components/Output/components/Requirements/Requirements.tsx
+++ b/ui/src/pages/Calculator/components/Output/components/Requirements/Requirements.tsx
@@ -13,6 +13,7 @@ import {
     Header,
     SortableHeader,
     TableContainer,
+    TotalRow,
 } from "./styles";
 import { RequirementRow } from "./RequirementRow";
 import {
@@ -64,7 +65,7 @@ function Requirements({ requirements }: RequirementsProps) {
         setRows(updated);
     }, [requirements]);
 
-    if (requirements.length === 0) {
+    if (rows.length === 0) {
         return <></>;
     }
 
@@ -72,6 +73,10 @@ function Requirements({ requirements }: RequirementsProps) {
         workerSortDirection !== "none"
             ? sortBy(rows, workerSortDirection, "workers")
             : sortBy(rows, amountSortDirection, "amount");
+
+    const totalWorkers = rows.reduce((acc, { workers }) => {
+        return acc + Math.ceil(workers);
+    }, 0);
 
     return (
         <>
@@ -126,6 +131,13 @@ function Requirements({ requirements }: RequirementsProps) {
                             />
                         ))}
                     </tbody>
+                    {rows.length > 1 && totalWorkers ? (
+                        <tfoot>
+                            <TotalRow
+                                row={{ name: "Total:", workers: totalWorkers }}
+                            />
+                        </tfoot>
+                    ) : null}
                 </RequirementsTable>
             </TableContainer>
         </>

--- a/ui/src/pages/Calculator/components/Output/components/Requirements/styles.ts
+++ b/ui/src/pages/Calculator/components/Output/components/Requirements/styles.ts
@@ -104,3 +104,8 @@ export const CreatorBreakdownRow = styled.tr`
 export const BreakdownRow = styled(Row)`
     background-color: ${(props) => props.theme.color.tertiary.on_main};
 `;
+
+export const TotalRow = styled(Row)`
+    font-weight: bold;
+    border-top: 1px solid ${(props) => props.theme.color.tertiary.on_container};
+`;


### PR DESCRIPTION
# What

Added table footer including total number of workers

# Why

Based on discord feedback

Enables users to quickly determine the total number of workers to produce the required item
- Useful for determining which foods are the best for example