### PR TITLE
perf(ui): disable apollo development mode in production builds

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -3,9 +3,13 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-// https://vitejs.dev/config/
 export default defineConfig({
     plugins: [react()],
+    define: {
+        "globalThis.__DEV__": JSON.stringify(
+            process.env.NODE_ENV === "development"
+        ),
+    },
     test: {
         globals: true,
         environment: "jsdom",


### PR DESCRIPTION
# What

Disabled Apollo development mode in production builds, see [here](https://www.apollographql.com/docs/react/development-testing/reducing-bundle-size/)

# Why

Reduces bundle size
Removes log output from Apollo