### PR TITLE
feat(api): migrate away from serverless mongodb cluster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   node-version-file: ".nvmrc"
+            - uses: hashicorp/setup-terraform@v3
+              with:
+                  terraform_version: 1.3.7
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
               run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT

--- a/api/package.json
+++ b/api/package.json
@@ -41,7 +41,7 @@
     },
     "config": {
         "mongodbMemoryServer": {
-            "version": "6.0.4"
+            "version": "8.0.4"
         }
     }
 }

--- a/api/src/common/mongodb/__tests__/index.test.ts
+++ b/api/src/common/mongodb/__tests__/index.test.ts
@@ -8,7 +8,7 @@ let mongoDBMemoryServer: MongoMemoryServer;
 beforeAll(async () => {
     mongoDBMemoryServer = await MongoMemoryServer.create({
         binary: {
-            version: "6.0.4",
+            version: "8.0.4",
         },
         instance: {
             dbName: databaseName,

--- a/api/test/mongodb-utils.ts
+++ b/api/test/mongodb-utils.ts
@@ -3,7 +3,7 @@ import { MongoMemoryServer } from "mongodb-memory-server";
 async function createMemoryServer(databaseName: string) {
     return MongoMemoryServer.create({
         binary: {
-            version: "6.0.4",
+            version: "8.0.4",
         },
         instance: {
             dbName: databaseName,


### PR DESCRIPTION
Moving to M0 Cluster - Serverless cluster offering is no longer provided by Mongodb

Updated in memory mongodb server to match production version

Fixed issue with CI format checks not having terraform installed